### PR TITLE
Service instance creation errors

### DIFF
--- a/static/app/controllers.js
+++ b/static/app/controllers.js
@@ -316,7 +316,7 @@
         // Checks if the service was created and display message
         var checkIfCreated = function(response) {
             $scope.disableSubmit = false;
-            if (response.status == 400) {
+            if (response.status >= 300) {
                 $scope.message = {
                     type: 'error',
                     message: response.data.description


### PR DESCRIPTION
Allowing any error message generated by creating a service instance to be displayed
<img width="791" alt="screen shot 2015-10-26 at 11 02 10 am" src="https://cloud.githubusercontent.com/assets/4596845/10732565/095652b0-7bd1-11e5-8770-c2a8d2fd98a5.png">
. 