### PR TITLE
Refactor stores shared functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,11 @@ script:
 - npm test
 - "./codecheck.sh -u"
 - go test ./...
-- cd acceptance && go test -tags acceptance && cd ..
 branches:
   only:
   - master
   - production
   - staging-alpha
-matrix:
-  allow_failures:
-    - script: cd acceptance && go test -tags acceptance && cd ..
 before_deploy:
 - export BUILD_INFO=build-$TRAVIS_BRANCH-$(date -u "+%Y-%m-%d-%H-%M-%S")-$TRAVIS_BUILD_NUMBER
 # Extract any encrypted env vars and put them into the manifests/manifest-master.yml

--- a/static_src/stores/app_store.js
+++ b/static_src/stores/app_store.js
@@ -33,18 +33,6 @@ class AppStore extends BaseStore {
         break;
     }
   }
-
-  get(guid) {
-    if (guid) {
-      return this._data.find((app) => {
-        return app.guid === guid;
-      });
-    }
-  }
-
-  getAll() {
-    return this._data;
-  }
 }
 
 let _AppStore = new AppStore();

--- a/static_src/stores/base_store.js
+++ b/static_src/stores/base_store.js
@@ -10,6 +10,7 @@ export default class BaseStore extends EventEmitter {
 
   constructor() {
     super();
+    this._data = [];
   }
 
   subscribe(actionSubscribe) {
@@ -30,6 +31,16 @@ export default class BaseStore extends EventEmitter {
 
   removeChangeListener(cb) {
     this.removeListener('CHANGE', cb);
+  }
+
+  get(guid) {
+    return this._data.find((space) => {
+      return space.guid === guid;
+    });
+  }
+
+  getAll() {
+    return this._data;
   }
 
   _formatSplitRes(resources) {

--- a/static_src/stores/base_store.js
+++ b/static_src/stores/base_store.js
@@ -34,9 +34,11 @@ export default class BaseStore extends EventEmitter {
   }
 
   get(guid) {
-    return this._data.find((space) => {
-      return space.guid === guid;
-    });
+    if (guid) {
+      return this._data.find((space) => {
+        return space.guid === guid;
+      });
+    }
   }
 
   getAll() {

--- a/static_src/stores/base_store.js
+++ b/static_src/stores/base_store.js
@@ -45,7 +45,7 @@ export default class BaseStore extends EventEmitter {
     return this._data;
   }
 
-  _formatSplitRes(resources) {
+  formatSplitResponse(resources) {
     return resources.map((resource) => {
       return Object.assign(resource.entity, resource.metadata);
     });

--- a/static_src/stores/org_store.js
+++ b/static_src/stores/org_store.js
@@ -48,7 +48,7 @@ class OrgStore extends BaseStore {
         break;
 
       case orgActionTypes.ORGS_RECEIVED:
-        var updates = this._formatSplitRes(action.orgs);
+        var updates = this.formatSplitResponse(action.orgs);
         this._data = this._merge(this._data, updates);
         this.emitChange();
         break;

--- a/static_src/stores/org_store.js
+++ b/static_src/stores/org_store.js
@@ -66,18 +66,6 @@ class OrgStore extends BaseStore {
     }
   }
 
-  get(guid) {
-    if (guid) {
-      return this._data.find((org) => {
-        return org.guid === guid;
-      });
-    }
-  }
-
-  getAll() {
-    return this._data;
-  }
-
   get currentOrgGuid() {
     return this._currentOrgGuid;
   }

--- a/static_src/stores/service_store.js
+++ b/static_src/stores/service_store.js
@@ -15,19 +15,6 @@ class ServiceStore extends BaseStore {
     this.subscribe(() => this._registerToActions.bind(this));
     this._data = [];
   }
-
-  get(serviceGuid) {
-    if (serviceGuid) {
-      return this._data.find((service) => {
-        return service.guid === serviceGuid;
-      });
-    }
-  }
-
-  getAll() {
-    return this._data;
-  }
-
   _registerToActions(action) {
     switch (action.type) {
       case serviceActionTypes.SERVICE_INSTANCES_FETCH:

--- a/static_src/stores/service_store.js
+++ b/static_src/stores/service_store.js
@@ -22,7 +22,7 @@ class ServiceStore extends BaseStore {
         break;
 
       case serviceActionTypes.SERVICE_INSTANCES_RECEIVED:
-        var updates = this._formatSplitRes(action.serviceInstances);
+        var updates = this.formatSplitResponse(action.serviceInstances);
         this._data = updates;
         this.emitChange();
         break;

--- a/static_src/stores/space_store.js
+++ b/static_src/stores/space_store.js
@@ -16,12 +16,6 @@ class SpaceStore extends BaseStore {
     this._data = [];
   }
 
-  get(guid) {
-    return this._data.find((space) => {
-      return space.guid === guid;
-    });
-  }
-
   _registerToActions(action) {
     switch (action.type) {
       case spaceActionTypes.SPACE_RECEIVED:

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -29,7 +29,7 @@ class UserStore extends BaseStore {
 
       case userActionTypes.SPACE_USERS_RECEIVED:
       case userActionTypes.ORG_USERS_RECEIVED:
-        var updates = this._formatSplitRes(action.users);
+        var updates = this.formatSplitResponse(action.users);
         updates = updates.map((update) => {
           if (action.orgGuid) {
             update.orgGuid = action.orgGuid;

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -78,19 +78,6 @@ class UserStore extends BaseStore {
     }
   }
 
-  // TODO move all of this to base store, I've found they're all the same.
-  get(guid) {
-    if (guid) {
-      return this._data.find((user) => {
-        return user.guid === guid;
-      });
-    }
-  }
-
-  getAll() {
-    return this._data;
-  }
-
   /**
    * Get all users in a certain space
    */

--- a/static_src/test/unit/stores/app_store.spec.js
+++ b/static_src/test/unit/stores/app_store.spec.js
@@ -25,38 +25,6 @@ describe('AppStore', function() {
     });
   });
 
-  describe('getAll()', function() {
-    it('should return all the data', function() {
-      var expected = [{guid: 'adfxzcv'}];
-
-      AppStore._data = expected;
-
-      expect(AppStore.getAll()).toEqual(expected);
-    });
-  });
-
-  describe('get()', function() {
-    it('should return a service if it can find one based on guid', function() {
-      var expectedGuid = '8sfjlkasjdf',
-          expected = { guid: expectedGuid };
-
-      AppStore._data.push(expected);
-
-      let actual = AppStore.get(expectedGuid);
-
-      expect(actual).toEqual(expected);
-    });
-
-    it('should return undefined if not found by guid', function() {
-      var expectedGuid = '8sfjlkasjdf',
-          expected = { guid: expectedGuid };
-
-      let actual = AppStore.get(expectedGuid);
-
-      expect(actual).toBeFalsy();
-    });
-  });
-
   describe('on app fetch', function() {
     it('should fetch app with guid from api', function() {
       var spy = sandbox.spy(cfApi, 'fetchApp'),

--- a/static_src/test/unit/stores/base_store.spec.js
+++ b/static_src/test/unit/stores/base_store.spec.js
@@ -1,0 +1,116 @@
+
+import '../../global_setup.js';
+
+import BaseStore from '../../../stores/base_store.js';
+
+describe('BaseStore', () => {
+  var sandbox,
+      store;
+
+  beforeEach(() => {
+    store = new BaseStore();
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('subscribe()', function() {
+    it('it should set the dispatch token to an app dispatcher register',
+        function() {
+
+    });
+  });
+
+  describe('get dispatchToken()', function() {
+    it('should return the hidden dispatch token', function() {
+      var expected = {};
+
+      store._dispatchToken = expected;
+
+      expect(store.dispatchToken).toEqual(expected);
+    });
+  });
+
+  describe('emitChange()', function() {
+    it('should emit an event with string CHANGE', function() {
+      var spy = sandbox.spy();
+
+      store.on('CHANGE', spy);
+
+      store.emitChange();
+
+      expect(spy).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('addChangeListener()', function() {
+    it('should add a listener on CHANGE with the callback passed', function() {
+      var spy = sandbox.spy();
+
+      store.addChangeListener(spy);
+
+      store.emit('CHANGE');
+
+      expect(spy).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('removeChangeListener()', function() {
+    it('should remove a listener of type CHANGE with callback passed',
+        function() {
+      var spy = sandbox.spy();
+
+      store.addChangeListener(spy);
+      store.removeChangeListener(spy);
+
+      store.emit('CHANGE');
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('get()', function() {
+    it('should get an entity by guid if it exists', function() {
+      var expectedGuid = 'adkfjlzcxv',
+          expected = { guid: expectedGuid };
+
+      store._data.push(expected);
+
+      let actual = store.get(expectedGuid);
+
+      expect(actual).toEqual(expected);
+    });
+    
+    it('should returned undefined if entity with guid it doesn\'t exist',
+        function() {
+      store._data = [];
+      let actual = store.get('adjlfk');
+
+      expect(actual).toBe(undefined);
+    });
+  });
+
+  describe('getAll()', function() {
+    it('should get all entities if there are some', function() {
+      var expected = [{ guid: 'adf' }, { guid: 'adsfjk' }];
+
+      store._data = expected;
+
+      let actual = store.getAll();
+
+      expect(actual).toBeTruthy();
+      expect(actual.length).toEqual(2);
+      expect(actual).toEqual(expected);
+    });
+
+    it('should return an empty array if there are no entities', function() {
+      store._data = [];
+
+      let actual = store.getAll();
+
+      expect(actual).toBeEmptyArray();
+    });
+  });
+});

--- a/static_src/test/unit/stores/base_store.spec.js
+++ b/static_src/test/unit/stores/base_store.spec.js
@@ -90,6 +90,14 @@ describe('BaseStore', () => {
 
       expect(actual).toBe(undefined);
     });
+
+    it('should return undefined if not guid is passed in', function() {
+      store._data = [{ guid: 'adsf' }]; 
+
+      let actual = store.get();
+
+      expect(actual).toBe(undefined);
+    });
   });
 
   describe('getAll()', function() {

--- a/static_src/test/unit/stores/base_store.spec.js
+++ b/static_src/test/unit/stores/base_store.spec.js
@@ -146,4 +146,59 @@ describe('BaseStore', () => {
       expect(clone).toEqual(testRezs);
     });
   });
+
+  describe('merge()', function() {
+    var existingEntityA = {
+      guid: 'zznbmbz',
+      name: 'ea',
+      cpu: 34
+    }; 
+    var existingEntityB = {
+      guid: 'zzlkcxv',
+      name: 'eb'
+    }; 
+    var existingEntities = [existingEntityA, existingEntityB];
+
+    it('should update existing entities with updated with same guid ', 
+        function() {
+      var updateA = {
+        guid: existingEntityA.guid,
+        name: 'zzz',
+        memory: 1024
+      };
+
+      let actual = store._merge(existingEntities, [updateA]);
+
+      expect(actual[0]).toEqual({
+        guid: updateA.guid,
+        name: updateA.name,
+        memory: updateA.memory,
+        cpu: existingEntityA.cpu
+      });
+      expect(actual[1]).toEqual(existingEntityB);
+    });
+
+    it('should not modify the source data', function() {
+      var clone = existingEntities.slice(0);
+      var updateA = {
+        guid: existingEntityA.guid,
+        memory: 1024
+      };
+
+      store._merge(existingEntities, [updateA]);
+
+      expect(existingEntities).toEqual(clone);
+    });
+
+    it('should return the updates if there\'s no current data', function() {
+      var updates = [
+        { guid: 'zxb', name: 'a1' },
+        { guid: 'kjl', name: 'a2' }
+      ];
+
+      let actual = store._merge([], updates);
+
+      expect(actual).toEqual(updates);
+    });
+  });
 });

--- a/static_src/test/unit/stores/base_store.spec.js
+++ b/static_src/test/unit/stores/base_store.spec.js
@@ -121,4 +121,29 @@ describe('BaseStore', () => {
       expect(actual).toBeEmptyArray();
     });
   });
+
+  describe('formatSplitResponse()', function() {
+    var testRezs;
+
+    beforeEach(function() {
+      testRezs = [
+        { entity: { name: 'e1' }, metadata: { guid: 'mmmmmn' }},
+        { entity: { name: 'e2' }, metadata: { guid: 'mmmmmo' }}
+      ];
+    });
+
+    it('should merge entity with metadata for each resource', function() {
+      var actual = store.formatSplitResponse(testRezs);
+
+      expect(actual[0]).toEqual({ name: 'e1', guid: 'mmmmmn'});
+    });
+
+    it('should not modify the original data', function() {
+      var clone = testRezs.slice(0);
+
+      store.formatSplitResponse(testRezs);
+
+      expect(clone).toEqual(testRezs);
+    });
+  });
 });

--- a/static_src/test/unit/stores/org_store.spec.js
+++ b/static_src/test/unit/stores/org_store.spec.js
@@ -26,27 +26,6 @@ describe('OrgStore', () => {
     });
   });
 
-  describe('getAll()', () => {
-    it('should return object when no state', () => {
-      expect(OrgStore.getAll()).toBeArray();
-    });
-  });
-
-  describe('get()', () => {
-    it('should return the correct org based on guid', () => {
-      var testOrgs = [
-        { guid: '1xxa', name: 'testOrgA' },
-        { guid: '1xxb', name: 'testOrgB' }
-      ];
-
-      OrgStore._data = testOrgs;
-
-      let actual = OrgStore.get(testOrgs[0].guid);
-
-      expect(actual).toEqual(testOrgs[0]);
-    });
-  });
-
   describe('get currentOrgGuid', function() {
     it('should start with null, none selected', function() {
       expect(OrgStore.currentOrgGuid).toBe(null);

--- a/static_src/test/unit/stores/service_store.spec.js
+++ b/static_src/test/unit/stores/service_store.spec.js
@@ -25,36 +25,6 @@ describe('ServiceStore', function() {
     });
   });
 
-  describe('get()', function() {
-    it('should return a service if it can find it in data based on guid',
-        function() {
-      var expectedGuid = '8sfjlkasjdf',
-          expected = { guid: expectedGuid };
-
-      ServiceStore._data.push(expected);
-
-      let actual = ServiceStore.get(expectedGuid);
-
-      expect(actual).toEqual(expected);
-    });
-
-    it('should returned undefined if not found', function() {
-      var testService = { guid: 'aaa' };
-
-      ServiceStore._data.push(testService);
-
-      let actual = ServiceStore.get('mkmkmkmkm');
-      
-      expect(actual).toBeFalsy();
-    });
-  });
-
-  describe('getAll()', function() {
-    it('should return a list of services', () => {
-      expect(ServiceStore.getAll()).toBeArray();
-    });
-  });
-
   describe('on service instances fetch', function() {
     it('should fetch service instances from api with space guid', function() {
       var spy = sandbox.spy(cfApi, 'fetchServiceInstances'),

--- a/static_src/test/unit/stores/space_store.spec.js
+++ b/static_src/test/unit/stores/space_store.spec.js
@@ -22,19 +22,4 @@ describe('SpaceStore', () => {
       expect(SpaceStore._data).toBeEmptyArray();
     });
   });
-
-  describe('get()', () => {
-    it('should return the correct space based on guid', () => {
-      var testSpaces = [
-        { guid: 'sp1xxa', name: 'testSpaceA', apps: [] },
-        { guid: 'sp1xxb', name: 'testSpaceB', apps: [] }
-      ];
-
-      SpaceStore._data = testSpaces;
-
-      let actual = SpaceStore.get(testSpaces[0].guid);
-
-      expect(actual).toEqual(testSpaces[0]);
-    });
-  });
 });


### PR DESCRIPTION
Moves all `get()` and `getAll()` functionality to the base store and moves tests there. Also tests the rest of the functionality of the base store.

This was done to reduce repetition and increase unit test coverage for important and highly used code.