### PR TITLE
Bug: deploy failing from wrong node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "tests",
   "version": "1.0.0",
+  "engines": {
+    "node": "4.2.2",
+    "npm": "2.14.x"
+  },
   "description": "test suite",
   "main": "null",
   "scripts": {


### PR DESCRIPTION
If you don't specify the current node version in package.json, the
CF node buildback assume the most recent version of node, which isn't
available right now.

Using 4.2.2 because it's the newest version of node that's available on
CF buildpack. Want the newest version to ease and potential development
in node and ensure we're using the latest features.