### PR TITLE
425 user permission roles

### DIFF
--- a/static_src/actions/user_actions.js
+++ b/static_src/actions/user_actions.js
@@ -15,6 +15,13 @@ export default {
     });
   },
 
+  fetchOrgUserRoles(orgGuid) {
+    AppDispatcher.handleViewAction({
+      type: userActionTypes.ORG_USER_ROLES_FETCH,
+      orgGuid: orgGuid
+    });
+  },
+
   fetchSpaceUsers(spaceGuid) {
     AppDispatcher.handleViewAction({
       type: userActionTypes.SPACE_USERS_FETCH,
@@ -26,6 +33,14 @@ export default {
     AppDispatcher.handleServerAction({
       type: userActionTypes.ORG_USERS_RECEIVED,
       users: users,
+      orgGuid: orgGuid
+    });
+  },
+
+  receivedOrgUserRoles(roles, orgGuid) {
+    AppDispatcher.handleServerAction({
+      type: userActionTypes.ORG_USER_ROLES_RECEIVED,
+      orgUserRoles: roles,
       orgGuid: orgGuid
     });
   },

--- a/static_src/actions/user_actions.js
+++ b/static_src/actions/user_actions.js
@@ -79,6 +79,15 @@ export default {
     });
   },
 
+  addedUserRoles(roles, userGuid, resourceType) {
+    AppDispatcher.handleServerAction({
+      type: userActionTypes.USER_ROLES_ADDED,
+      roles: roles,
+      userGuid: userGuid,
+      resourceType: resourceType
+    });
+  },
+
   deleteUserRoles(roles, userGuid, resourceGuid, resourceType) {
     AppDispatcher.handleViewAction({
       type: userActionTypes.USER_ROLES_DELETE,
@@ -87,7 +96,15 @@ export default {
       resourceGuid: resourceGuid,
       resourceType: resourceType
     });
+  },
 
+  deletedUserRoles(roles, userGuid, resourceType) {
+    AppDispatcher.handleServerAction({
+      type: userActionTypes.USER_ROLES_DELETED,
+      roles: roles,
+      userGuid: userGuid,
+      resourceType: resourceType
+    });
   },
 
   errorRemoveUser(userGuid, error) {

--- a/static_src/actions/user_actions.js
+++ b/static_src/actions/user_actions.js
@@ -69,6 +69,27 @@ export default {
     });
   },
 
+  addUserRoles(roles, userGuid, resourceGuid, resourceType) {
+    AppDispatcher.handleViewAction({
+      type: userActionTypes.USER_ROLES_ADD,
+      roles: roles,
+      userGuid: userGuid,
+      resourceGuid: resourceGuid,
+      resourceType: resourceType
+    });
+  },
+
+  deleteUserRoles(roles, userGuid, resourceGuid, resourceType) {
+    AppDispatcher.handleViewAction({
+      type: userActionTypes.USER_ROLES_DELETE,
+      roles: roles,
+      userGuid: userGuid,
+      resourceGuid: resourceGuid,
+      resourceType: resourceType
+    });
+
+  },
+
   errorRemoveUser(userGuid, error) {
     AppDispatcher.handleServerAction({
       type: userActionTypes.ERROR_REMOVE_USER,

--- a/static_src/components/user_list.jsx
+++ b/static_src/components/user_list.jsx
@@ -4,15 +4,10 @@
  */
 
 import React from 'react';
-import Reactable from 'reactable';
 
 import Button from './button.jsx';
+import UserRoleListControl from './user_role_list_control.jsx';
 
-var Table = Reactable.Table,
-    Thead = Reactable.Thead,
-    Th = Reactable.Th,
-    Tr = Reactable.Tr,
-    Td = Reactable.Td;
 
 export default class UserList extends React.Component {
   constructor(props) {
@@ -48,38 +43,45 @@ export default class UserList extends React.Component {
     var content = <h4 className="test-none_message">No users</h4>;
     if (this.state.users.length) {
       content = (
-      <Table sortable={ true } className="table">
-        <Thead>
+      <table sortable={ true } className="table">
+        <thead>
           { this.columns.map((column) => {
             return (
-              <Th column={ column.label } className={ column.key }
+              <th column={ column.label } className={ column.key }
                   key={ column.key }>
-                { column.label }</Th>
+                { column.label }</th>
             )
           })}
-        </Thead>
+        </thead>
+        <tbody>
         { this.state.users.map((user) => {
           var actions;
           if (this.props.onRemove) {
             actions = (
-              <Td column="Actions">
+              <td column="Actions">
                 <Button 
                 onClickHandler={ this._handleDelete.bind(this, user.guid) } 
                 label="delete">
                   <span>Remove User From Org</span>
                 </Button>
-              </Td>
+                </td>
             );
           } 
-          return (
-            <Tr key={ user.guid }>
-              <Td column="Name"><span>{ user.username }</span></Td>
-              <Td column="Date Created">{ user.created_at }</Td>
+          return ([
+            <tr key={ user.guid }>
+              <td column="Name"><span>{ user.username }</span></td>
+              <td column="Date Created">{ user.created_at }</td>
               { actions }
-            </Tr>
-          )
+            </tr>,
+            <tr key={ user.guid + '-role' }>
+              <td colSpan="2">
+                <UserRoleListControl user={ user } />
+              </td>
+            </tr>
+          ])
         })}
-      </Table>
+        </tbody>
+      </table>
       );
     }
 

--- a/static_src/components/user_list.jsx
+++ b/static_src/components/user_list.jsx
@@ -75,7 +75,11 @@ export default class UserList extends React.Component {
             </tr>,
             <tr key={ user.guid + '-role' }>
               <td colSpan="2">
-                <UserRoleListControl user={ user } />
+                <UserRoleListControl 
+                  onAddPermissions={ this.props.onAddPermissions }
+                  onRemovePermissions={ this.props.onRemovePermissions }
+                  user={ user } 
+                />
               </td>
             </tr>
           ])
@@ -97,7 +101,9 @@ export default class UserList extends React.Component {
 UserList.propTypes = {
   initialUsers: React.PropTypes.array,
   // Set to a function when there should be a remove button.
-  onRemove: React.PropTypes.func
+  onRemove: React.PropTypes.func,
+  onRemovePermissions: React.PropTypes.func,
+  onAddPermissions: React.PropTypes.func
 };
 
 UserList.defaultProps = {

--- a/static_src/components/user_role_control.jsx
+++ b/static_src/components/user_role_control.jsx
@@ -11,7 +11,7 @@ export default class UserRoleControl extends React.Component {
   }
 
   _handleChange = (ev) => {
-    this.onChange(ev.target.checked);
+    this.props.onChange(ev.target.checked);
     this.setState({ checked: ev.target.checked });
   }
 

--- a/static_src/components/user_role_control.jsx
+++ b/static_src/components/user_role_control.jsx
@@ -1,0 +1,40 @@
+
+import React from 'react';
+
+export default class UserRoleControl extends React.Component {
+  constructor(props) {
+    super(props);
+    this.props = props;
+    this.state = {
+      checked: props.initialValue
+    };
+  }
+
+  _handleChange = (ev) => {
+    this.onChange(ev.target.checked);
+    this.setState({ checked: ev.target.checked });
+  }
+
+  render() {
+    return (
+      <span>
+        <input type="checkbox" 
+          onClick={ this._handleChange }
+          name={ this.props.roleKey }
+          checked={ this.state.checked }
+        />
+        { this.props.roleName }
+      </span>
+    );
+  }
+}
+UserRoleControl.propTypes = {
+  roleName: React.PropTypes.string.isRequired,
+  roleKey: React.PropTypes.string.isRequired,
+  initialValue: React.PropTypes.bool,
+  onChange: React.PropTypes.func
+};
+UserRoleControl.defaultProps = {
+  initialValue: false,
+  onChange: function() { }
+}

--- a/static_src/components/user_role_control.jsx
+++ b/static_src/components/user_role_control.jsx
@@ -10,16 +10,19 @@ export default class UserRoleControl extends React.Component {
     };
   }
 
+  componentWillReceiveProps(nextProps) {
+    this.setState({checked: nextProps.initialValue});
+  }
+
   _handleChange = (ev) => {
     this.props.onChange(ev.target.checked);
-    this.setState({ checked: ev.target.checked });
   }
 
   render() {
     return (
       <span>
         <input type="checkbox" 
-          onClick={ this._handleChange }
+          onChange={ this._handleChange }
           name={ this.props.roleKey }
           checked={ this.state.checked }
         />

--- a/static_src/components/user_role_list_control.jsx
+++ b/static_src/components/user_role_list_control.jsx
@@ -12,6 +12,12 @@ const roles = [
   { key: 'org_auditor', label: 'Org Auditor' }
 ];
 
+const roleToResource = {
+  'org_manager': 'managers',
+  'billing_manager': 'billing_managers',
+  'org_auditor': 'auditors'
+}
+
 export default class UserRoleListControl extends React.Component {
   constructor(props) {
     super(props);
@@ -27,10 +33,11 @@ export default class UserRoleListControl extends React.Component {
   }
 
   _onChange = (roleKey, checked) => {
-    var handler = (checked) ? this.props.onRemovePermissions : 
+    var handler = (!checked) ? this.props.onRemovePermissions : 
       this.props.onAddPermissions;
+    var resource = roleToResource[roleKey];
 
-    handler(roleKey, this.props.user.guid);
+    handler(resource, this.props.user.guid);
   }
 
   get roles() {

--- a/static_src/components/user_role_list_control.jsx
+++ b/static_src/components/user_role_list_control.jsx
@@ -27,7 +27,10 @@ export default class UserRoleListControl extends React.Component {
   }
 
   _onChange = (roleKey, checked) => {
+    var handler = (checked) ? this.props.onRemovePermissions : 
+      this.props.onAddPermissions;
 
+    handler(roleKey, this.props.user.guid);
   }
 
   get roles() {
@@ -55,5 +58,11 @@ export default class UserRoleListControl extends React.Component {
   }
 }
 UserRoleListControl.propTypes = {
-  user: React.PropTypes.object.isRequired
+  user: React.PropTypes.object.isRequired,
+  onRemovePermissions: React.PropTypes.func,
+  onAddPermissions: React.PropTypes.func
 };
+UserRoleListControl.defaultProps = {
+  onRemovePermissions: function() { },
+  onAddPermissions: function() { }
+}

--- a/static_src/components/user_role_list_control.jsx
+++ b/static_src/components/user_role_list_control.jsx
@@ -1,0 +1,59 @@
+/*
+ * Renders a users roles with controls to edit them
+ */
+
+import React from 'react';
+
+import UserRoleControl from './user_role_control.jsx';
+
+const roles = [
+  { key: 'org_manager', label: 'Org Manager' },
+  { key: 'billing_manager', label: 'Billing Manager' },
+  { key: 'org_auditor', label: 'Org Auditor' }
+];
+
+export default class UserRoleListControl extends React.Component {
+  constructor(props) {
+    super(props);
+    this.props = props;
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({user: nextProps.users});
+  }
+
+  checkRole = (roleKey) => {
+    return (this.roles.indexOf(roleKey) > -1);
+  }
+
+  _onChange = (roleKey, checked) => {
+
+  }
+
+  get roles() {
+    return this.props.user.organization_roles || [];
+  }
+
+
+  render() {
+    return (
+      <div>
+      { roles.map((role) => {
+        return (
+          <span key={ role.key }>
+            <UserRoleControl 
+              roleName={ role.label }
+              roleKey={ role.key }
+              initialValue={ this.checkRole(role.key) }
+              onChange={ this._onChange.bind(this, role.key) }
+            />
+          </span>
+        );
+      })}
+      </div>
+    );
+  }
+}
+UserRoleListControl.propTypes = {
+  user: React.PropTypes.object.isRequired
+};

--- a/static_src/components/users.jsx
+++ b/static_src/components/users.jsx
@@ -71,11 +71,17 @@ export default class Users extends React.Component {
   }
 
   handleAddPermissions = (roleKey, userGuid) => {
-
+    userActions.addUserRoles(roleKey, 
+                                userGuid, 
+                                this.state.currentOrgGuid,
+                                'organization');
   }
 
   handleRemovePermissions = (roleKey, userGuid) => {
-
+    userActions.deleteUserRoles(roleKey, 
+                                userGuid, 
+                                this.state.currentOrgGuid,
+                                'organization');
   }
 
   get subNav() {
@@ -126,6 +132,8 @@ export default class Users extends React.Component {
             <UserList 
                 initialUsers={ this.state.users } 
                 onRemove={ removeHandler } 
+                onAddPermissions={ this.handleAddPermissions }
+                onRemovePermissions={ this.handleRemovePermissions }
             />
           </div>
         </div>

--- a/static_src/components/users.jsx
+++ b/static_src/components/users.jsx
@@ -73,15 +73,27 @@ export default class Users extends React.Component {
   handleAddPermissions = (roleKey, userGuid) => {
     userActions.addUserRoles(roleKey, 
                                 userGuid, 
-                                this.state.currentOrgGuid,
-                                'organization');
+                                this.resourceGuid,
+                                this.resourceType);
   }
 
   handleRemovePermissions = (roleKey, userGuid) => {
     userActions.deleteUserRoles(roleKey, 
                                 userGuid, 
-                                this.state.currentOrgGuid,
-                                'organization');
+                                this.resourceGuid,
+                                this.resourceType);
+  }
+
+  get resourceType() {
+    var resourceType = this.state.currentTab === TAB_ORG_NAME ? 'organization' :
+      'space';
+    return resourceType;
+  }
+
+  get resourceGuid() {
+    var resourceGuid = this.state.currentTab === TAB_ORG_NAME ? 
+      this.state.currentOrgGuid : this.state.currentSpaceGuid;
+    return resourceGuid;
   }
 
   get subNav() {

--- a/static_src/components/users.jsx
+++ b/static_src/components/users.jsx
@@ -70,6 +70,14 @@ export default class Users extends React.Component {
     userActions.deleteUser(userGuid, this.state.currentOrgGuid);
   }
 
+  handleAddPermissions = (roleKey, userGuid) => {
+
+  }
+
+  handleRemovePermissions = (roleKey, userGuid) => {
+
+  }
+
   get subNav() {
     var tabs = [
       { name: 'space_users' },
@@ -115,8 +123,10 @@ export default class Users extends React.Component {
         { errorMessage }
         <div className="tab-content">
           <div role="tabpanel" className="tab-pane active">
-            <UserList onRemove={ removeHandler } 
-                initialUsers={ this.state.users } />
+            <UserList 
+                initialUsers={ this.state.users } 
+                onRemove={ removeHandler } 
+            />
           </div>
         </div>
       </div>

--- a/static_src/constants.js
+++ b/static_src/constants.js
@@ -82,6 +82,10 @@ var userActionTypes = keymirror({
   ORG_USER_ROLES_RECEIVED: null,
   // Action when all space users were received from the server.
   SPACE_USERS_RECEIVED: null,
+  // Action to add permissions to a user for a space or org on the server.
+  USER_ROLES_ADD: null,
+  // Action to delete persmissions to a user for a space or org on the server.
+  USER_ROLES_DELETE: null,
   // Action to delete a user from an org.
   USER_DELETE: null,
   // Action when a user was deleted from an org on the server.

--- a/static_src/constants.js
+++ b/static_src/constants.js
@@ -72,10 +72,14 @@ var appActionTypes = keymirror({
 var userActionTypes = keymirror({
   // Action to fetch users belonging to a organization from the server.
   ORG_USERS_FETCH: null,
+  // Action to fetch the user roles for an org from the server.
+  ORG_USER_ROLES_FETCH: null,
   // Action to fetch users belonging to a space from the server.
   SPACE_USERS_FETCH: null,
   // Action when all organization users were received from the server.
   ORG_USERS_RECEIVED: null,
+  // Action when all org user roles were received from the server.
+  ORG_USER_ROLES_RECEIVED: null,
   // Action when all space users were received from the server.
   SPACE_USERS_RECEIVED: null,
   // Action to delete a user from an org.

--- a/static_src/constants.js
+++ b/static_src/constants.js
@@ -84,8 +84,12 @@ var userActionTypes = keymirror({
   SPACE_USERS_RECEIVED: null,
   // Action to add permissions to a user for a space or org on the server.
   USER_ROLES_ADD: null,
+  // Action when user roles are added on the server.
+  USER_ROLES_ADDED: null,
   // Action to delete persmissions to a user for a space or org on the server.
   USER_ROLES_DELETE: null,
+  // Action when user roles are deleted on the server.
+  USER_ROLES_DELETED: null,
   // Action to delete a user from an org.
   USER_DELETE: null,
   // Action when a user was deleted from an org on the server.

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -40,6 +40,10 @@ function space(orgGuid, spaceGuid, potentialPage) {
   // TODO what happens if the space arrives before the changelistener is added?
   cfApi.fetchOrg(orgGuid);
   cfApi.fetchSpace(spaceGuid);
+  // TODO use constant
+  if (potentialPage === 'users') {
+    cfApi.fetchOrgUserRoles(orgGuid);
+  }
   React.render(
     <App>
       <Space

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -23,8 +23,20 @@ class UserStore extends BaseStore {
         cfApi.fetchOrgUsers(action.orgGuid);
         break;
 
+      case userActionTypes.ORG_USER_ROLES_FETCH:
+        cfApi.fetchOrgUserRoles(action.orgGuid);
+        break;
+
       case userActionTypes.SPACE_USERS_FETCH:
         cfApi.fetchSpaceUsers(action.spaceGuid);
+        break;
+
+      case userActionTypes.ORG_USER_ROLES_RECEIVED:
+        var updates = this.formatSplitResponse(action.orgUserRoles);
+        if (updates.length) {
+          this._data = this._merge(this._data, updates);
+          this.emitChange();
+        }
         break;
 
       case userActionTypes.SPACE_USERS_RECEIVED:

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -7,7 +7,14 @@
 import AppDispatcher from '../dispatcher';
 import BaseStore from './base_store.js';
 import cfApi from '../util/cf_api.js';
+import userActions from '../actions/user_actions.js';
 import { userActionTypes } from '../constants.js';
+
+const resourceToRole = {
+  'managers': 'org_manager',
+  'billing_managers': 'billing_manager',
+  'auditors': 'org_auditor'
+};
 
 class UserStore extends BaseStore {
   constructor() {
@@ -49,15 +56,21 @@ class UserStore extends BaseStore {
           action.userGuid,
           action.resourceGuid,
           action.roles
-        );
+        ).done((res) => {
+          userActions.addedUserRoles(
+            action.roles,
+            action.userGuid,
+            action.resouceType);
+        });
         break;
 
       case userActionTypes.USER_ROLES_ADDED:
         var user = this.get(action.userGuid);
         if (user) {
+          let role = resourceToRole[action.roles] || action.roles;
           if (user.organization_roles && 
-              user.organization_roles.indexOf(action.roles) === -1) {
-            user.organization_roles.push(action.roles);
+              user.organization_roles.indexOf(role) === -1) {
+            user.organization_roles.push(role);
             this.emitChange();
           } 
         }
@@ -73,14 +86,20 @@ class UserStore extends BaseStore {
           action.userGuid,
           action.resourceGuid,
           action.roles
-        );
+        ).done((res) => {
+          userActions.deletedUserRoles(
+            action.roles,
+            action.userGuid,
+            action.resouceType);
+        });
         break;
 
       case userActionTypes.USER_ROLES_DELETED:
         var user = this.get(action.userGuid);
         if (user) {
+          let role = resourceToRole[action.roles] || action.roles;
           let idx =  user.organization_roles && 
-            user.organization_roles.indexOf(action.roles);
+            user.organization_roles.indexOf(role);
           if (idx > -1) {
             user.organization_roles.splice(idx, 1);
             this.emitChange();

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -39,6 +39,32 @@ class UserStore extends BaseStore {
         }
         break;
 
+      case userActionTypes.USER_ROLES_ADD:
+        var apiMethodMap = {
+          'organization': cfApi.putOrgUserPermissions,
+          'space': cfApi.putSpaceUserPermissions
+        }
+        var api = apiMethodMap[action.resourceType];
+        api(
+          action.userGuid,
+          action.resourceGuid,
+          action.roles
+        );
+        break;
+
+      case userActionTypes.USER_ROLES_DELETE:
+        var apiMethodMap = {
+          'organization': cfApi.deleteOrgUserPermissions,
+          'space': cfApi.deleteSpaceUserPermissions
+        }
+        var api = apiMethodMap[action.resourceType];
+        api(
+          action.userGuid,
+          action.resourceGuid,
+          action.roles
+        );
+        break;
+
       case userActionTypes.SPACE_USERS_RECEIVED:
       case userActionTypes.ORG_USERS_RECEIVED:
         var updates = this.formatSplitResponse(action.users);

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -90,7 +90,7 @@ class UserStore extends BaseStore {
           userActions.deletedUserRoles(
             action.roles,
             action.userGuid,
-            action.resouceType);
+            action.resourceType);
         });
         break;
 

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -52,6 +52,17 @@ class UserStore extends BaseStore {
         );
         break;
 
+      case userActionTypes.USER_ROLES_ADDED:
+        var user = this.get(action.userGuid);
+        if (user) {
+          if (user.organization_roles && 
+              user.organization_roles.indexOf(action.roles) === -1) {
+            user.organization_roles.push(action.roles);
+            this.emitChange();
+          } 
+        }
+        break;
+
       case userActionTypes.USER_ROLES_DELETE:
         var apiMethodMap = {
           'organization': cfApi.deleteOrgUserPermissions,
@@ -63,6 +74,18 @@ class UserStore extends BaseStore {
           action.resourceGuid,
           action.roles
         );
+        break;
+
+      case userActionTypes.USER_ROLES_DELETED:
+        var user = this.get(action.userGuid);
+        if (user) {
+          let idx =  user.organization_roles && 
+            user.organization_roles.indexOf(action.roles);
+          if (idx > -1) {
+            user.organization_roles.splice(idx, 1);
+            this.emitChange();
+          } 
+        }
         break;
 
       case userActionTypes.SPACE_USERS_RECEIVED:

--- a/static_src/test/unit/actions/user_actions.spec.js
+++ b/static_src/test/unit/actions/user_actions.spec.js
@@ -164,4 +164,58 @@ describe('userActions', function() {
       assertAction(spy, userActionTypes.ERROR_REMOVE_USER, expectedParams);
     });
   });
+
+  describe('addUserRoles()', function() {
+    it(`should call a view action to add user roles with current roles 
+        user guid and guid and type`, function() {
+      var expectedRole = 'org_manager',
+          expectedUserGuid = 'akdfjadzxcvzxcvzxvzx',
+          expectedGuid = '2eve2v2vadsfa',
+          expectedType = 'org';
+
+      let expectedParams = {
+        roles: expectedRole,
+        userGuid: expectedUserGuid,
+        resourceGuid: expectedGuid,
+        resourceType: expectedType
+      };
+          
+      let spy = setupViewSpy(sandbox)
+
+      userActions.addUserRoles(
+        expectedRole,
+        expectedUserGuid,
+        expectedGuid,
+        expectedType);
+
+      assertAction(spy, userActionTypes.USER_ROLES_ADD, expectedParams);
+    });
+  });
+
+  describe('deleteUserRoles()', function() {
+    it(`should call a view action to remove user roles with current roles 
+        user guid and org guid and type`, function() {
+      var expectedRole = 'org_manager',
+          expectedUserGuid = 'akdfjasdfjasdfadzxcvzxcvzxvzx',
+          expectedGuid = '2eve2dsfa',
+          expectedType = 'space';
+
+      let expectedParams = {
+        roles: expectedRole,
+        userGuid: expectedUserGuid,
+        resourceGuid: expectedGuid,
+        resourceType: expectedType
+      };
+          
+      let spy = setupViewSpy(sandbox)
+
+      userActions.deleteUserRoles(
+        expectedRole,
+        expectedUserGuid,
+        expectedGuid,
+        expectedType);
+
+      assertAction(spy, userActionTypes.USER_ROLES_DELETE, expectedParams);
+    });
+  });
 });

--- a/static_src/test/unit/actions/user_actions.spec.js
+++ b/static_src/test/unit/actions/user_actions.spec.js
@@ -82,7 +82,7 @@ describe('userActions', function() {
   describe('receivedOrgUserRoles()', function() {
     it('should dispatch a view event of type org user roles fetch', function() {
       var expectedOrgGuid = 'zknxvzmnxjkafakdlsxcv',
-          expectedOrgRoles = [{ guid: 'zxcvz' }],
+          expectedOrgRoles = [{ metadata: {guid: 'zxcvz'}, entity: { }}],
           expectedParams = {
             orgUserRoles: expectedOrgRoles,
             orgGuid: expectedOrgGuid

--- a/static_src/test/unit/actions/user_actions.spec.js
+++ b/static_src/test/unit/actions/user_actions.spec.js
@@ -192,6 +192,30 @@ describe('userActions', function() {
     });
   });
 
+  describe('addedUserRoles()', function() {
+    it(`should call a server action to add user roles with roles user guid and
+        resource type`, function() {
+      var expectedRole = 'org_manager',
+          expectedUserGuid = 'azxcvoiuzxcvzxcvzxvzx',
+          expectedType = 'organization';
+
+      let expectedParams = {
+        roles: expectedRole,
+        userGuid: expectedUserGuid,
+        resourceType: expectedType
+      };
+          
+      let spy = setupServerSpy(sandbox)
+
+      userActions.addedUserRoles(
+        expectedRole,
+        expectedUserGuid,
+        expectedType);
+
+      assertAction(spy, userActionTypes.USER_ROLES_ADDED, expectedParams);
+    });
+  });
+
   describe('deleteUserRoles()', function() {
     it(`should call a view action to remove user roles with current roles 
         user guid and org guid and type`, function() {
@@ -216,6 +240,30 @@ describe('userActions', function() {
         expectedType);
 
       assertAction(spy, userActionTypes.USER_ROLES_DELETE, expectedParams);
+    });
+  });
+
+  describe('deletedUserRoles()', function() {
+    it(`should call a server action to add user roles with roles user guid and
+        resource type`, function() {
+      var expectedRole = 'org_manager',
+          expectedUserGuid = 'azxcvoiuzxcvzxcvzxvzx',
+          expectedType = 'organization';
+
+      let expectedParams = {
+        roles: expectedRole,
+        userGuid: expectedUserGuid,
+        resourceType: expectedType
+      };
+          
+      let spy = setupServerSpy(sandbox)
+
+      userActions.deletedUserRoles(
+        expectedRole,
+        expectedUserGuid,
+        expectedType);
+
+      assertAction(spy, userActionTypes.USER_ROLES_DELETED, expectedParams);
     });
   });
 });

--- a/static_src/test/unit/actions/user_actions.spec.js
+++ b/static_src/test/unit/actions/user_actions.spec.js
@@ -33,6 +33,21 @@ describe('userActions', function() {
     });
   });
 
+  describe('fetchOrgUserRoles()', function() {
+    it('should dispatch a view event of type org user roles fetch', function() {
+      var expectedOrgGuid = 'zknxvzmnxjkafakdlsxcv',
+          expectedParams = {
+            orgGuid: expectedOrgGuid
+          };
+
+      let spy = setupViewSpy(sandbox);
+
+      userActions.fetchOrgUserRoles(expectedOrgGuid);
+
+      assertAction(spy, userActionTypes.ORG_USER_ROLES_FETCH, expectedParams);
+    });
+  });
+
   describe('fetchSpaceUsers()', function() {
     it('should dispatch a view event of type space users fetch', function() {
       var expectedSpaceGuid = 'asdflkjz',
@@ -61,6 +76,23 @@ describe('userActions', function() {
       userActions.receivedOrgUsers(expected);
 
       assertAction(spy, userActionTypes.ORG_USERS_RECEIVED, expectedParams);
+    });
+  });
+
+  describe('receivedOrgUserRoles()', function() {
+    it('should dispatch a view event of type org user roles fetch', function() {
+      var expectedOrgGuid = 'zknxvzmnxjkafakdlsxcv',
+          expectedOrgRoles = [{ guid: 'zxcvz' }],
+          expectedParams = {
+            orgUserRoles: expectedOrgRoles,
+            orgGuid: expectedOrgGuid
+          };
+
+      let spy = setupServerSpy(sandbox);
+
+      userActions.receivedOrgUserRoles(expectedOrgRoles, expectedOrgGuid);
+
+      assertAction(spy, userActionTypes.ORG_USER_ROLES_RECEIVED, expectedParams);
     });
   });
 

--- a/static_src/test/unit/helpers.js
+++ b/static_src/test/unit/helpers.js
@@ -28,10 +28,10 @@ export function assertAction(spy, type, params) {
 }
 
 export function setupViewSpy(sandbox) {
-  return sandbox.spy(AppDispatcher, 'handleViewAction');
+  return sandbox.stub(AppDispatcher, 'handleViewAction');
 }
 
 export function setupServerSpy(sandbox) {
-  return sandbox.spy(AppDispatcher, 'handleServerAction');
+  return sandbox.stub(AppDispatcher, 'handleServerAction');
 }
 

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -60,6 +60,22 @@ describe('UserStore', function() {
     });
   });
 
+  describe('on org user roles fetch', function() {
+    it('should fetch org user roles through api', function() {
+      var spy = sandbox.spy(cfApi, 'fetchOrgUserRoles'),
+          expectedGuid = 'axckzvjxcov';
+
+      AppDispatcher.handleViewAction({
+        type: userActionTypes.ORG_USER_ROLES_FETCH,
+        orgGuid: expectedGuid
+      });
+
+      expect(spy).toHaveBeenCalledOnce();
+      let arg = spy.getCall(0).args[0];
+      expect(arg).toEqual(expectedGuid);
+    });
+  });
+
   describe('on space or org users received', function() {
     it('should emit a change event if data was updated', function() {
       var spy = sandbox.spy(UserStore, 'emitChange');
@@ -120,6 +136,40 @@ describe('UserStore', function() {
       let actual = UserStore.get(user.guid);
 
       expect(actual.orgGuid).toEqual(expectedGuid);
+    });
+  });
+
+  describe('on org user roles received', function() {
+    it('should emit a change event if data changed', function() {
+      var spy = sandbox.spy(UserStore, 'emitChange');
+
+      AppDispatcher.handleViewAction({
+        type: userActionTypes.ORG_USER_ROLES_RECEIVED,
+        orgUserRoles: wrapInRes([{ guid: 'adsfa' }])
+      });
+
+      expect(spy).toHaveBeenCalledOnce();
+    });
+    it('should merge and update new users with existing users in data',
+        function() {
+      var sharedGuid = 'wpqoifesadkzcvn';
+
+      let existingUser = { guid: sharedGuid, name: 'Michael' };
+      let newUser = { guid: sharedGuid, organization_roles: ['role'] };
+
+      UserStore._data.push(existingUser);
+      expect(UserStore.get(sharedGuid)).toEqual(existingUser);
+
+      AppDispatcher.handleViewAction({
+        type: userActionTypes.ORG_USER_ROLES_RECEIVED,
+        orgUserRoles: wrapInRes([newUser])
+      });
+      let actual = UserStore.get(sharedGuid);
+      expect(actual).toEqual({
+        guid: sharedGuid,
+        name: 'Michael',
+        organization_roles: ['role']
+      });
     });
   });
 

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -173,6 +173,51 @@ describe('UserStore', function() {
     });
   });
 
+  describe('on user roles add', function() {
+    it('should call the api for org delete if type org to update the role',
+        function() {
+      var spy = sandbox.stub(cfApi, 'putOrgUserPermissions'),
+          expectedRoles = 'org_manager',
+          expectedUserGuid = 'zjkxcvadfzxcvz',
+          expectedOrgGuid = 'zxcvzcxvzxroiter';
+
+      userActions.addUserRoles(
+        expectedRoles,
+        expectedUserGuid,
+        expectedOrgGuid,
+        'organization'
+      );
+      
+      expect(spy).toHaveBeenCalledOnce(); 
+      let args = spy.getCall(0).args;
+      expect(args[0]).toEqual(expectedUserGuid);
+      expect(args[1]).toEqual(expectedOrgGuid);
+      expect(args[2]).toEqual(expectedRoles);
+    });
+  });
+
+  describe('on user roles delete', function() {
+    it('should call the api to delete the role', function() {
+      var spy = sandbox.stub(cfApi, 'deleteOrgUserPermissions'),
+          expectedRoles = 'org_manager',
+          expectedUserGuid = 'zjkxcvz234asdf',
+          expectedOrgGuid = 'zxcvzcxvzxroiter';
+
+      userActions.deleteUserRoles(
+        expectedRoles,
+        expectedUserGuid,
+        expectedOrgGuid,
+        'organization'
+      );
+      
+      expect(spy).toHaveBeenCalledOnce(); 
+      let args = spy.getCall(0).args;
+      expect(args[0]).toEqual(expectedUserGuid);
+      expect(args[1]).toEqual(expectedOrgGuid);
+      expect(args[2]).toEqual(expectedRoles);
+    });
+  });
+
   describe('on user delete', function() {
     it('should remove user permissions from org', function() {
       var spy = sandbox.spy(cfApi, 'deleteOrgUserPermissions'),

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -196,6 +196,37 @@ describe('UserStore', function() {
     });
   });
 
+  describe('on user roles added', function() {
+    it('should update the resource type roles array if it exists with new roles',
+        function() {
+      var testGuid = 'zxcvzxc',
+          expectedRole = 'org_dark_lord';
+
+      var existingUser = {
+        guid: testGuid,
+        organization_roles: ['org_manager']
+      };
+
+      UserStore._data.push(existingUser);
+
+      userActions.addedUserRoles(expectedRole, testGuid, 'organization');
+
+      let actual = UserStore.get(testGuid);
+      expect(actual).toBeTruthy();
+      expect(actual.organization_roles).toContain(expectedRole);
+    });
+
+    it('should emit a change event if it finds the user', function() {
+      var spy = sandbox.spy(UserStore, 'emitChange'),
+          testUserGuid = '234xcvbqwn';
+
+      UserStore._data.push({guid: testUserGuid, organization_roles: []});
+      userActions.addedUserRoles('testrole', testUserGuid, 'organization');
+
+      expect(spy).toHaveBeenCalledOnce();
+    });
+  });
+
   describe('on user roles delete', function() {
     it('should call the api to delete the role', function() {
       var spy = sandbox.stub(cfApi, 'deleteOrgUserPermissions'),
@@ -215,6 +246,39 @@ describe('UserStore', function() {
       expect(args[0]).toEqual(expectedUserGuid);
       expect(args[1]).toEqual(expectedOrgGuid);
       expect(args[2]).toEqual(expectedRoles);
+    });
+  });
+
+  describe('on user roles deleted', function() {
+    it('should update the resource type roles array if it exists with new roles',
+        function() {
+      var testGuid = 'zxcvzxc',
+          expectedRole = 'org_dark_lord';
+
+      var existingUser = {
+        guid: testGuid,
+        organization_roles: ['org_manager', expectedRole]
+      };
+
+      UserStore._data.push(existingUser);
+
+      userActions.deletedUserRoles(expectedRole, testGuid, 'organization');
+
+      let actual = UserStore.get(testGuid);
+      expect(actual).toBeTruthy();
+      expect(actual.organization_roles).not.toContain(expectedRole);
+    });
+
+    it('should emit a change event if it finds the user and no role', function() {
+      var spy = sandbox.spy(UserStore, 'emitChange'),
+          expectedRole = 'org_dark_lord',
+          testUserGuid = '234xcvbqwn';
+
+      UserStore._data.push({guid: testUserGuid,
+        organization_roles: [expectedRole]});
+      userActions.deletedUserRoles(expectedRole, testUserGuid, 'organization');
+
+      expect(spy).toHaveBeenCalledOnce();
     });
   });
 

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -150,6 +150,7 @@ describe('UserStore', function() {
 
       expect(spy).toHaveBeenCalledOnce();
     });
+
     it('should merge and update new users with existing users in data',
         function() {
       var sharedGuid = 'wpqoifesadkzcvn';
@@ -174,12 +175,17 @@ describe('UserStore', function() {
   });
 
   describe('on user roles add', function() {
-    it('should call the api for org delete if type org to update the role',
+    it('should call the api for org add if type org to update the role',
         function() {
       var spy = sandbox.stub(cfApi, 'putOrgUserPermissions'),
           expectedRoles = 'org_manager',
           expectedUserGuid = 'zjkxcvadfzxcvz',
           expectedOrgGuid = 'zxcvzcxvzxroiter';
+
+      let testPromise = {
+        done: function() { }
+      };
+      spy.returns(testPromise);
 
       userActions.addUserRoles(
         expectedRoles,
@@ -193,6 +199,11 @@ describe('UserStore', function() {
       expect(args[0]).toEqual(expectedUserGuid);
       expect(args[1]).toEqual(expectedOrgGuid);
       expect(args[2]).toEqual(expectedRoles);
+    });
+
+    it('should call the added user role action with role, user guid and type',
+        function() {
+
     });
   });
 
@@ -225,6 +236,11 @@ describe('UserStore', function() {
 
       expect(spy).toHaveBeenCalledOnce();
     });
+
+    it(`should map certain resource names to a role name when adding to user`,
+        function() {
+
+    });
   });
 
   describe('on user roles delete', function() {
@@ -233,6 +249,11 @@ describe('UserStore', function() {
           expectedRoles = 'org_manager',
           expectedUserGuid = 'zjkxcvz234asdf',
           expectedOrgGuid = 'zxcvzcxvzxroiter';
+
+      let testPromise = {
+        done: function() { }
+      };
+      spy.returns(testPromise);
 
       userActions.deleteUserRoles(
         expectedRoles,
@@ -246,6 +267,11 @@ describe('UserStore', function() {
       expect(args[0]).toEqual(expectedUserGuid);
       expect(args[1]).toEqual(expectedOrgGuid);
       expect(args[2]).toEqual(expectedRoles);
+    });
+
+    it('should call the deleted user role action with role, user guid and type',
+        function() {
+
     });
   });
 
@@ -279,6 +305,11 @@ describe('UserStore', function() {
       userActions.deletedUserRoles(expectedRole, testUserGuid, 'organization');
 
       expect(spy).toHaveBeenCalledOnce();
+    });
+
+    it(`should map certain resource names to a role name when deleting from user`,
+        function() {
+
     });
   });
 

--- a/static_src/test/unit/util/cf_api.spec.js
+++ b/static_src/test/unit/util/cf_api.spec.js
@@ -456,8 +456,27 @@ describe('cfApi', function() {
       expect(actual).toMatch(new RegExp(expected));
       expect(actual).toMatch(new RegExp('organizations'));
       expect(actual).toMatch(new RegExp('users'));
-      actual = spy.getCall(0).args[1];
+      actual = spy.getCall(0).args[1]
       expect(actual).toEqual(userActions.receivedOrgUsers);
+    });
+  });
+
+  describe('fetchOrgUserRoles()', function() {
+    it(`should call fetch org user roles with org guid and received org user 
+        roles action and org guid`, function() {
+      var expectedOrgGuid = 'zkjvczcvzwexdvzdfa',
+          spy = sandbox.stub(cfApi, 'fetchMany');
+          
+      cfApi.fetchOrgUserRoles(expectedOrgGuid);
+      expect(spy).toHaveBeenCalledOnce();
+      let actual = spy.getCall(0).args[0];
+      expect(actual).toMatch(new RegExp(expectedOrgGuid));
+      expect(actual).toMatch(new RegExp('organizations'));
+      expect(actual).toMatch(new RegExp('roles'));
+      actual = spy.getCall(0).args[1];
+      expect(actual).toEqual(userActions.receivedOrgUserRoles);
+      actual = spy.getCall(0).args[2];
+      expect(actual).toEqual(expectedOrgGuid);
     });
   });
 

--- a/static_src/test/unit/util/cf_api.spec.js
+++ b/static_src/test/unit/util/cf_api.spec.js
@@ -473,7 +473,7 @@ describe('cfApi', function() {
       expect(actual).toMatch(new RegExp(expected));
       expect(actual).toMatch(new RegExp('organizations'));
       expect(actual).toMatch(new RegExp('users'));
-      actual = spy.getCall(0).args[1]
+      actual = spy.getCall(0).args[1];
       expect(actual).toEqual(userActions.receivedOrgUsers);
       actual = spy.getCall(0).args[2];
       expect(actual).toEqual(expected);

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -162,7 +162,9 @@ export default {
   },
 
   fetchOrgUserRoles(orgGuid) {
-
+    return this.fetchMany(`/organizations/${ orgGuid }/user_roles`,
+                          userActions.receivedOrgUserRoles,
+                          orgGuid);
   },
 
   deleteUser(userGuid, orgGuid) {

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -200,6 +200,27 @@ export default {
     });
   },
 
+  // TODO refactor with org user permissions
+  putSpaceUserPermissions(userGuid, spaceGuid, role) {
+    return http.put(APIV + `/spaces/${ spaceGuid }/${ role }/${ userGuid }`).then(
+      (res) => {
+        return res.response;
+      }, (err) => {
+        // TODO figure out error action
+        console.error(err);
+      });
+  },
+
+  // TODO refactor with org user permissions
+  deleteSpaceUserPermissions(userGuid, spaceGuid, role) {
+    return http.delete(APIV + `/spaces/${ spaceGuid }/${ role }/${ userGuid }`).then(
+      (res) => {
+        return res.response;
+      }, (err) => {
+        userActions.errorRemoveUser(userGuid, err.data);
+      });
+  },
+
   fetchAllServices(orgGuid) {
     return this.fetchMany('/organizations/' + orgGuid + '/services',
                           serviceActions.receivedServices);

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -161,6 +161,10 @@ export default {
                           orgGuid);
   },
 
+  fetchOrgUserRoles(orgGuid) {
+
+  },
+
   deleteUser(userGuid, orgGuid) {
     return http.delete(APIV + '/organizations/' + orgGuid + '/users/' + userGuid)
         .done((res) => {


### PR DESCRIPTION
Adds ability to modify (remove and add) user roles from a user. The UI to do this is a simple list of checkboxes below each user in the user list. This is changed from the current app as to not make more UI that may be unnecessary.

More info in commit messages.