### PR TITLE
Pins node buildpack to certain version

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,2 @@
-https://github.com/cloudfoundry/nodejs-buildpack
+https://github.com/cloudfoundry/nodejs-buildpack.git#v.1.5.3
 https://github.com/cloudfoundry/go-buildpack.git

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tests",
   "version": "1.0.0",
   "engines": {
-    "node": "4.2.2",
+    "node": "4.2.x",
     "npm": "2.14.x"
   },
   "description": "test suite",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tests",
   "version": "1.0.0",
   "engines": {
-    "node": "4.2.x",
+    "node": "4.2.2",
     "npm": "2.14.x"
   },
   "description": "test suite",


### PR DESCRIPTION
This ensure's it will always work with a certain node version.

I still changed the node engine pin to 4.2.x because I think this is
better anyway. This app should work on any version of node 4.2.