### PR TITLE
538 css build

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "babel-loader": "^5.1.4",
     "babel-runtime": "^5.5.4",
     "codecov.io": "^0.1.5",
-    "css-loader": "^0.14.4",
+    "css-loader": "^0.23.0",
     "cssnext-loader": "^1.0.1",
     "eslint": "^1.6.0",
     "eslint-plugin-react": "^3.5.1",
@@ -43,13 +43,15 @@
     "karma-sinon": "^1.0.4",
     "karma-sourcemap-loader": "^0.3.5",
     "karma-webpack": "^1.7.0",
+    "less-loader": "^2.2.2",
     "node-libs-browser": "^0.5.2",
+    "postcss-loader": "^0.8.0",
     "promises-done-polyfill": "^1.0.0",
     "react-hot-loader": "^1.2.7",
     "react-jasmine-matchers": "^2.0.0",
-    "style-loader": "^0.12.3",
+    "style-loader": "^0.13.0",
     "watch": "^0.16.0",
-    "webpack": "^1.9.10"
+    "webpack": "^1.12.9"
   },
   "dependencies": {
     "axios": "^0.5.4",

--- a/static_src/app.jsx
+++ b/static_src/app.jsx
@@ -1,5 +1,8 @@
 
+import classNames from 'classnames';
 import React from 'react';
+
+import styles from './css/main.css';
 
 import loginActions from './actions/login_actions.js';
 import Login from './components/login.jsx';
@@ -36,6 +39,9 @@ export default class App extends React.Component {
       content = <Login />;
     }
 
+    let sidebarClasses = classNames('col-sm-3', 'col-md-2', styles.sidebar);
+    let mainClasses = classNames('col-sm-9', 'col-sm-offset-3', 'col-md-10',
+                                 'col-md-offset-2', styles.main);
     return (
     <div>
       { /* TODO use a separate navbar component for this. */ }
@@ -50,10 +56,10 @@ export default class App extends React.Component {
       </nav>
       <div className="container-fluid">
         <div className="row">
-          <nav className="col-sm-3 col-md-2 sidebar">
+          <nav className={ sidebarClasses }>
             { sidebar }
           </nav>
-          <main className="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main">
+          <main className={ mainClasses }>
             { content }
           </main>
         </div>

--- a/static_src/components/dropdown.jsx
+++ b/static_src/components/dropdown.jsx
@@ -1,6 +1,8 @@
 
 import React from 'react';
 
+import styles from '../css/main.css';
+
 import classNames from 'classnames';
 
 export default class Dropdown extends React.Component {
@@ -16,13 +18,13 @@ export default class Dropdown extends React.Component {
 
   render() {
     var id = 'dropdown-' + this.props.title,
-        classes = classNames('dropdown', this.props.classes, {
+        classes = classNames(styles.dropdown, this.props.classes, {
           'open': !!this.state.open
         });
 
     return (
       <div className={ classes }>
-      <a id="dropdown-{ this.props.title }" 
+      <a id= { 'dropdown-' + this.props.title }
             className="dropdown-toggle" role="button"
             aria-haspopup="true" aria-expanded={ id }
             onClick={ this.handleTitleClick }>

--- a/static_src/components/navbar.jsx
+++ b/static_src/components/navbar.jsx
@@ -36,8 +36,6 @@ export default class Navbar extends React.Component {
     var orgEls = [],
         navigation;
 
-    console.log('styles', styles);
-    
     let classes = classNames('nav', styles.sidebar);
 
     orgEls = this.state.orgs.map((org) => {

--- a/static_src/components/navbar.jsx
+++ b/static_src/components/navbar.jsx
@@ -1,5 +1,8 @@
 
+import classNames from 'classnames';
 import React from 'react';
+
+import styles from '../css/main.css';
 
 import Dropdown from '../components/dropdown.jsx';
 import orgActions from '../actions/org_actions.js';
@@ -32,6 +35,8 @@ export default class Navbar extends React.Component {
   render = () => {
     var orgEls = [],
         navigation;
+    
+    let classes = classNames('nav', styles['nav-sidebar']);
 
     orgEls = this.state.orgs.map((org) => {
       return {
@@ -45,8 +50,8 @@ export default class Navbar extends React.Component {
     }
 
     return (
-      <ul className="nav nav-sidebar">
-        <li>
+      <ul className={ classes }>
+        <li className="">
           <Dropdown title='Change Organization' classes={ ['test-nav-orgs'] }
             items={ orgEls } />
         </li>

--- a/static_src/components/navbar.jsx
+++ b/static_src/components/navbar.jsx
@@ -2,7 +2,7 @@
 import classNames from 'classnames';
 import React from 'react';
 
-import styles from '../css/main.css';
+import styles from '../css/components/navbar.css';
 
 import Dropdown from '../components/dropdown.jsx';
 import orgActions from '../actions/org_actions.js';
@@ -35,8 +35,10 @@ export default class Navbar extends React.Component {
   render = () => {
     var orgEls = [],
         navigation;
+
+    console.log('styles', styles);
     
-    let classes = classNames('nav', styles['nav-sidebar']);
+    let classes = classNames('nav', styles.sidebar);
 
     orgEls = this.state.orgs.map((org) => {
       return {

--- a/static_src/css/components/navbar.css
+++ b/static_src/css/components/navbar.css
@@ -1,0 +1,4 @@
+
+.athing {
+  background: blue;
+}

--- a/static_src/css/components/navbar.css
+++ b/static_src/css/components/navbar.css
@@ -1,4 +1,15 @@
 
-.athing {
-  background: blue;
+.sidebar {
+  margin-right: -21px; /* 20px padding + 1px border */
+  margin-bottom: 20px;
+  margin-left: -20px;
+  padding-left: 20px;
+  padding-right: 20px;
+}
+
+.sidebar > .active > a,
+.sidebar > .active > a:hover,
+.sidebar > .active > a:focus {
+  color: #fff;
+  background-color: #428bca;
 }

--- a/static_src/css/main.css
+++ b/static_src/css/main.css
@@ -23,23 +23,9 @@ body {
     border-right: 1px solid #eee;
   }
 }
-/* Sidebar navigation */
-.nav-sidebar {
-  margin-right: -21px; /* 20px padding + 1px border */
-  margin-bottom: 20px;
-  margin-left: -20px;
-  padding-left: 20px;
-  padding-right: 20px;
-}
 .dropdown {
   padding-bottom: 10px;
   padding-top: 10px;
-}
-.nav-sidebar > .active > a,
-.nav-sidebar > .active > a:hover,
-.nav-sidebar > .active > a:focus {
-  color: #fff;
-  background-color: #428bca;
 }
 
 /*

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -1,5 +1,5 @@
 
-import '../node_modules/bootstrap/dist/css/bootstrap.css';
+import 'bootstrap.css';
 
 import './css/main.css';
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,16 @@ module.exports = {
       { test: /\.jsx?$/,
         loader: 'babel?optional[]=runtime&stage=0',
         exclude: /node_modules/ },
+      { test: /\.css$/, 
+        include: path.resolve(__dirname, 'static_src/css'),
+        loader: ExtractTextPlugin.extract('style-loader',
+          'css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!postcss-loader') 
+      },
+      { test: /\.less$/,
+        loader: ExtractTextPlugin.extract('style-loader', 'css-loader!less-loader')
+      },
       { test: /\.css$/,
+        include: path.resolve(__dirname, 'node_modules'),
         loader: ExtractTextPlugin.extract('style-loader', 'css-loader')
       },
       { test: /\.(woff|woff2)$/,  loader: 'url-loader?limit=10000&mimetype=application/font-woff' },
@@ -30,6 +39,10 @@ module.exports = {
   },
 
   resolve: {
+    alias: {
+      'bootstrap.css':  __dirname + '/node_modules/bootstrap/dist/css/bootstrap.css',
+      'bootstrap.less': __dirname + '/node_modules/bootstrap/less/bootstrap.less'
+    },
     modulesDirectories: ['node_modules', 'components']
   },
 


### PR DESCRIPTION
The purpose of this is to set up a CSS folder structure, import structure and build so fe devs that come onto this project are ready to write CSS.

This uses webpack to require CSS into the JS files where it's needed. It uses the CSS modules spec to make component CSS imported into react components "local". More can be read here:
http://glenmaddern.com/articles/css-modules

I set up this build so that any CSS that isn't ours, like Bootstrap, won't be imported as a CSS module, meaning it's normal global JS. This is for convenience as we'll likely get rid of bootstrap code at some point anyway. In the future, all CSS code could potentially be treated as local.

This will be more complete once we get rid of bootstrap but get's things going.