### PR TITLE
Fix root url in frontend router

### DIFF
--- a/static_src/main.js
+++ b/static_src/main.js
@@ -76,7 +76,6 @@ function notFound() {
 }
 
 let routes = {
-  '': dashboard,
   '/': dashboard,
   '/dashboard': dashboard,
   '/login': login,
@@ -106,5 +105,5 @@ router.configure({
   before: checkAuth,
   notfound: notFound
 });
-router.init();
+router.init('/');
 


### PR DESCRIPTION
This allows the normal `/` url to work rather then just `/#/`. Before
the `/` url would cause a blank page.