### PR TITLE
Header: better display when givenName is empty

### DIFF
--- a/static/app/views/partials/header.html
+++ b/static/app/views/partials/header.html
@@ -44,7 +44,7 @@
                             </ul>
                         </li>
                         <li>
-                            <a href="/v2/profile">{{ givenName }}'s Profile</a>
+                            <a href="/v2/profile">{{ givenName.length ? givenName + "'s " : "" }}Profile</a>
                         </li>
 
                         <li>


### PR DESCRIPTION
This avoids the odd looking “'s Profile” when logged in using an account
which has no value for givenName