### PR TITLE
Use webpack to load css modules from cg-style

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ If you are testing locally, export these variables. If you are deploying to clou
 - `CONSOLE_API_URL`: The URL of the API service. i.e. `http://api.domain.com`
 - `CONSOLE_LOG_URL`: The URL of the loggregator service. i.e. `http://loggregator.domain.com`
 - `PPROF_ENABLED`: An optional variable. If set to `true` or `1`, will turn on `/debug/pprof` endpoints as seen [here](https://golang.org/pkg/net/http/pprof/)
+- `CG_STYLE_PATH`: The absolute path to your `cg-style` repo. Used for webpack in development
 
 ## Front end
 Install front end dependencies, including the `cloudgov-style` library

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -1,6 +1,5 @@
 
-import 'cloudgov-style/base.scss';
-
+import 'cloudgov-style/base.css';
 import './css/main.css';
 
 import { Router } from 'director';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,13 +3,15 @@ const path = require('path');
 
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
+const CG_STYLE_PATH = process.env.CG_STYLE_PATH;
+
 const srcDir = './static_src';
 const compiledDir = './static/assets';
 
 module.exports = {
   entry: [
     'babel-polyfill',
-    srcDir + '/main.js'
+    `${srcDir}/main.js`
   ],
 
   output: {
@@ -30,20 +32,15 @@ module.exports = {
           plugins: ['transform-runtime']
         }
       },
-      { test: /\.css$/,
-        include: path.resolve(__dirname, 'static_src/css'),
+      {
+        test: /\.css$/,
+        include: [
+          path.resolve(__dirname, 'static_src/css'),
+          path.resolve(__dirname, 'node_modules/cloudgov-style'),
+          CG_STYLE_PATH
+        ],
         loader: ExtractTextPlugin.extract('style-loader',
-          'css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!postcss-loader')
-      },
-      { test: /\.less$/,
-        loader: ExtractTextPlugin.extract('style-loader', 'css-loader!less-loader')
-      },
-      { test: /\.scss$/,
-        loader: ExtractTextPlugin.extract('style-loader', 'css-loader!sass?sourceMap')
-      },
-      { test: /\.css$/,
-        include: path.resolve(__dirname, 'node_modules'),
-        loader: ExtractTextPlugin.extract('style-loader', 'css-loader')
+          'css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]')
       },
       {
         test: /\.(svg|png|jpe?g)$/,
@@ -55,19 +52,12 @@ module.exports = {
     ]
   },
 
-  sassLoader: {
-    data: '$static-font-path: \'../../font\'; $static-img-path: \'../../img\';'
-  },
-
   resolve: {
     alias: {
-      'cloudgov-style': path.resolve(__dirname, 'node_modules/cloudgov-style/src/css')
+      'cloudgov-style': 'cloudgov-style/css'
     },
 
-    modulesDirectories: [
-      'node_modules',
-      'components'
-    ]
+    modulesDirectories: ['node_modules']
   },
 
   resolveLoader: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,7 +37,7 @@ module.exports = {
         include: [
           path.resolve(__dirname, 'static_src/css'),
           path.resolve(__dirname, 'node_modules/cloudgov-style'),
-          CG_STYLE_PATH
+          CG_STYLE_PATH || ''
         ],
         loader: ExtractTextPlugin.extract('style-loader',
           'css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]')


### PR DESCRIPTION
To load CSS modules from webpack, it needs to be configured with the proper loaders and the proper paths. Because cg-style is still under active development, we don’t install it from the npm registry.

`npm link` (by itself) isn’t sufficient as its just a symlink. When webpack goes to try and resolve things, it will use the absolute path so we need to include that in the loader.

That path has been abstracted away into an environment variable called `CG_STYLE_PATH`, which should be an absolute path to the location of the cg-style repo.

The README has been updated to also reflect the new environment variable.

Refs #173 