### PR TITLE
Change promise code to remove non-standard `done`

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -15,6 +15,5 @@ static_src/stores/org_store.js
 static_src/stores/base_store.js
 static_src/stores/login_store.js
 static_src/stores/service_instance_store.js
-static_src/stores/user_store.js
 static_src/tests.bundle.js
 static_src/constants.js

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "node-libs-browser": "^0.5.2",
     "node-sass": "^3.4.2",
     "postcss-loader": "^0.8.0",
-    "promises-done-polyfill": "^1.0.0",
     "react-hot-loader": "^1.2.7",
     "react-jasmine-matchers": "^2.0.0",
     "sass-loader": "^3.2.0",

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -4,16 +4,15 @@
  * server.
  */
 
-import AppDispatcher from '../dispatcher';
 import BaseStore from './base_store.js';
 import cfApi from '../util/cf_api.js';
 import userActions from '../actions/user_actions.js';
 import { userActionTypes } from '../constants.js';
 
 const resourceToRole = {
-  'managers': 'org_manager',
-  'billing_managers': 'billing_manager',
-  'auditors': 'org_auditor'
+  managers: 'org_manager',
+  billing_managers: 'billing_manager',
+  auditors: 'org_auditor'
 };
 
 class UserStore extends BaseStore {
@@ -25,99 +24,114 @@ class UserStore extends BaseStore {
   }
 
   _registerToActions(action) {
-    switch(action.type) {
-      case userActionTypes.ORG_USERS_FETCH:
+    switch (action.type) {
+      case userActionTypes.ORG_USERS_FETCH: {
         cfApi.fetchOrgUsers(action.orgGuid);
         break;
+      }
 
-      case userActionTypes.ORG_USER_ROLES_FETCH:
+      case userActionTypes.ORG_USER_ROLES_FETCH: {
         cfApi.fetchOrgUserRoles(action.orgGuid);
         break;
+      }
 
-      case userActionTypes.SPACE_USERS_FETCH:
+      case userActionTypes.SPACE_USERS_FETCH: {
         cfApi.fetchSpaceUsers(action.spaceGuid);
         break;
+      }
 
-      case userActionTypes.ORG_USER_ROLES_RECEIVED:
-        var updates = this.formatSplitResponse(action.orgUserRoles);
+      case userActionTypes.ORG_USER_ROLES_RECEIVED: {
+        const updates = this.formatSplitResponse(action.orgUserRoles);
         if (updates.length) {
           this._data = this._merge(this._data, updates);
           this.emitChange();
         }
         break;
+      }
 
-      case userActionTypes.USER_ROLES_ADD:
-        var apiMethodMap = {
-          'organization': cfApi.putOrgUserPermissions,
-          'space': cfApi.putSpaceUserPermissions
-        }
-        var api = apiMethodMap[action.resourceType];
+      case userActionTypes.USER_ROLES_ADD: {
+        const apiMethodMap = {
+          organization: cfApi.putOrgUserPermissions,
+          space: cfApi.putSpaceUserPermissions
+        };
+        const api = apiMethodMap[action.resourceType];
+
         api(
           action.userGuid,
           action.resourceGuid,
           action.roles
-        ).done((res) => {
+        ).then(() => {
           userActions.addedUserRoles(
             action.roles,
             action.userGuid,
             action.resouceType);
+        }).catch((err) => {
+          window.console.error(err);
         });
         break;
+      }
 
-      case userActionTypes.USER_ROLES_ADDED:
-        var user = this.get(action.userGuid);
+      case userActionTypes.USER_ROLES_ADDED: {
+        const user = this.get(action.userGuid);
         if (user) {
-          let role = resourceToRole[action.roles] || action.roles;
-          if (user.organization_roles && 
+          const role = resourceToRole[action.roles] || action.roles;
+          if (user.organization_roles &&
               user.organization_roles.indexOf(role) === -1) {
             user.organization_roles.push(role);
             this.emitChange();
-          } 
+          }
         }
         break;
+      }
 
-      case userActionTypes.USER_ROLES_DELETE:
-        var apiMethodMap = {
-          'organization': cfApi.deleteOrgUserPermissions,
-          'space': cfApi.deleteSpaceUserPermissions
-        }
-        var api = apiMethodMap[action.resourceType];
+      case userActionTypes.USER_ROLES_DELETE: {
+        const apiMethodMap = {
+          organization: cfApi.deleteOrgUserPermissions,
+          space: cfApi.deleteSpaceUserPermissions
+        };
+        const api = apiMethodMap[action.resourceType];
+
         api(
           action.userGuid,
           action.resourceGuid,
           action.roles
-        ).done((res) => {
+        ).then(() => {
           userActions.deletedUserRoles(
             action.roles,
             action.userGuid,
             action.resourceType);
+        }).catch((err) => {
+          window.console.error(err);
         });
         break;
+      }
 
-      case userActionTypes.USER_ROLES_DELETED:
-        var user = this.get(action.userGuid);
+      case userActionTypes.USER_ROLES_DELETED: {
+        const user = this.get(action.userGuid);
         if (user) {
-          let role = resourceToRole[action.roles] || action.roles;
-          let idx =  user.organization_roles && 
+          const role = resourceToRole[action.roles] || action.roles;
+          const idx = user.organization_roles &&
             user.organization_roles.indexOf(role);
           if (idx > -1) {
             user.organization_roles.splice(idx, 1);
             this.emitChange();
-          } 
+          }
         }
         break;
+      }
 
       case userActionTypes.SPACE_USERS_RECEIVED:
-      case userActionTypes.ORG_USERS_RECEIVED:
-        var updates = this.formatSplitResponse(action.users);
+      case userActionTypes.ORG_USERS_RECEIVED: {
+        let updates = this.formatSplitResponse(action.users);
         updates = updates.map((update) => {
+          const updateCopy = Object.assign({}, update);
           if (action.orgGuid) {
-            update.orgGuid = action.orgGuid;
+            updateCopy.orgGuid = action.orgGuid;
           }
           if (action.spaceGuid) {
-            update.spaceGuid = action.spaceGuid;
+            updateCopy.spaceGuid = action.spaceGuid;
           }
-          return update;
+          return updateCopy;
         });
         if (updates.length) {
           this._data = this._merge(this._data, updates);
@@ -125,33 +139,37 @@ class UserStore extends BaseStore {
           this.emitChange();
         }
         break;
+      }
 
-      case userActionTypes.USER_DELETE:
-        var orgPermissionsReq = cfApi.deleteOrgUserPermissions(
+      case userActionTypes.USER_DELETE: {
+        const orgPermissionsReq = cfApi.deleteOrgUserPermissions(
           action.userGuid,
           action.orgGuid,
           'users');
 
-        orgPermissionsReq.then((res) => {
+        orgPermissionsReq.then(() => {
           cfApi.deleteUser(action.userGuid, action.orgGuid);
         });
 
         break;
+      }
 
-      case userActionTypes.USER_DELETED:
-        var deleted = this.get(action.userGuid);
+      case userActionTypes.USER_DELETED: {
+        const deleted = this.get(action.userGuid);
         if (deleted) {
-          var index = this._data.indexOf(deleted);
+          const index = this._data.indexOf(deleted);
           this._data.splice(index, 1);
           this._error = null;
           this.emitChange();
         }
         break;
+      }
 
-      case userActionTypes.ERROR_REMOVE_USER:
+      case userActionTypes.ERROR_REMOVE_USER: {
         this._error = action.error;
         this.emitChange();
         break;
+      }
 
       default:
         break;
@@ -162,23 +180,19 @@ class UserStore extends BaseStore {
    * Get all users in a certain space
    */
   getAllInSpace(spaceGuid) {
-    return this._data.filter((user) => {
-      return user.spaceGuid === spaceGuid;
-    });
+    return this._data.filter((user) => user.spaceGuid === spaceGuid);
   }
 
   getAllInOrg(orgGuid) {
-    return this._data.filter((user) => {
-      return user.orgGuid === orgGuid;
-    });
+    return this._data.filter((user) => user.orgGuid === orgGuid);
   }
 
   getError() {
     return this._error;
   }
 
-};
+}
 
-let _UserStore = new UserStore();
+const _UserStore = new UserStore();
 
 export default _UserStore;

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -182,9 +182,7 @@ describe('UserStore', function() {
           expectedUserGuid = 'zjkxcvadfzxcvz',
           expectedOrgGuid = 'zxcvzcxvzxroiter';
 
-      let testPromise = {
-        then: function() { }
-      };
+      let testPromise = Promise.resolve()
       spy.returns(testPromise);
 
       userActions.addUserRoles(
@@ -250,10 +248,7 @@ describe('UserStore', function() {
           expectedUserGuid = 'zjkxcvz234asdf',
           expectedOrgGuid = 'zxcvzcxvzxroiter';
 
-      let testPromise = {
-        then: function() { },
-        catch: function() { }
-      };
+      let testPromise = Promise.resolve()
       spy.returns(testPromise);
 
       userActions.deleteUserRoles(

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -98,7 +98,7 @@ describe('UserStore', function() {
 
       expect(spy).not.toHaveBeenCalled();
     });
-    
+
     it('should merge and update new users with existing users in data',
         function() {
       var sharedGuid = 'wpqoifesadkzcvn';
@@ -183,7 +183,7 @@ describe('UserStore', function() {
           expectedOrgGuid = 'zxcvzcxvzxroiter';
 
       let testPromise = {
-        done: function() { }
+        then: function() { }
       };
       spy.returns(testPromise);
 
@@ -193,8 +193,8 @@ describe('UserStore', function() {
         expectedOrgGuid,
         'organization'
       );
-      
-      expect(spy).toHaveBeenCalledOnce(); 
+
+      expect(spy).toHaveBeenCalledOnce();
       let args = spy.getCall(0).args;
       expect(args[0]).toEqual(expectedUserGuid);
       expect(args[1]).toEqual(expectedOrgGuid);
@@ -251,7 +251,8 @@ describe('UserStore', function() {
           expectedOrgGuid = 'zxcvzcxvzxroiter';
 
       let testPromise = {
-        done: function() { }
+        then: function() { },
+        catch: function() { }
       };
       spy.returns(testPromise);
 
@@ -261,8 +262,8 @@ describe('UserStore', function() {
         expectedOrgGuid,
         'organization'
       );
-      
-      expect(spy).toHaveBeenCalledOnce(); 
+
+      expect(spy).toHaveBeenCalledOnce();
       let args = spy.getCall(0).args;
       expect(args[0]).toEqual(expectedUserGuid);
       expect(args[1]).toEqual(expectedOrgGuid);
@@ -328,7 +329,7 @@ describe('UserStore', function() {
       expect(args[1]).toEqual(expectedOrgGuid);
       expect(args[2]).toEqual(expectedCategory);
     });
-    
+
     it('should delete the user on the server', function() {
       var spy = sandbox.spy(cfApi, 'deleteUser'),
           stub = sandbox.stub(cfApi, 'deleteOrgUserPermissions'),

--- a/static_src/test/unit/util/cf_api.spec.js
+++ b/static_src/test/unit/util/cf_api.spec.js
@@ -17,16 +17,10 @@ import { wrapInRes, unwrapOfRes } from '../helpers.js';
 
 function createPromise(res, err) {
   // TODO figure out how to do this with actual Promise object.
-  var fakePromise = function(cb, errCb) {
-    if (!err) {
-      cb(res);
-    } else {
-      errCb(err);
-    }
-  };
-  return {
-    then: fakePromise,
-    done: fakePromise
+  if (!err) {
+    return Promise.resolve(res);
+  } else {
+    return Promise.reject(err);
   }
 };
 
@@ -50,7 +44,7 @@ describe('cfApi', function() {
 
     let testPromise = createPromise(true, expected);
     stub.returns(testPromise);
-    
+
     return spy;
   };
 
@@ -190,7 +184,7 @@ describe('cfApi', function() {
       let thing = cfApi.fetchOrg(testRes.guid);
       thing.then(function() {
         expect(spy).toHaveBeenCalledOnce();
-        done(); 
+        done();
       });
     });
   });
@@ -264,8 +258,8 @@ describe('cfApi', function() {
     it('calls http get request for orgs memory usage', function() {
       var spy = sandbox.spy(http, 'get'),
           expectedGuid = 'asdfad',
-          expectedOrg = {guid: expectedGuid, 
-              quota_definition_url: 'http://api.gov/quota_definitions/' + 
+          expectedOrg = {guid: expectedGuid,
+              quota_definition_url: 'http://api.gov/quota_definitions/' +
                 expectedGuid};
 
       cfApi.fetchOrgMemoryLimit(expectedOrg);
@@ -348,7 +342,7 @@ describe('cfApi', function() {
           expectedName,
           expectedSpaceGuid,
           expectedServicePlanGuid);
-      
+
       expect(spy).toHaveBeenCalledOnce();
       let actual = spy.getCall(0).args[0];
       expect(actual).toMatch(new RegExp('accepts_incomplete'));
@@ -481,11 +475,11 @@ describe('cfApi', function() {
   });
 
   describe('fetchOrgUserRoles()', function() {
-    it(`should call fetch org user roles with org guid and received org user 
+    it(`should call fetch org user roles with org guid and received org user
         roles action and org guid`, function() {
       var expectedOrgGuid = 'zkjvczcvzwexdvzdfa',
           spy = sandbox.stub(cfApi, 'fetchMany');
-          
+
       cfApi.fetchOrgUserRoles(expectedOrgGuid);
       expect(spy).toHaveBeenCalledOnce();
       let actual = spy.getCall(0).args[0];

--- a/static_src/test/unit/util/cf_api.spec.js
+++ b/static_src/test/unit/util/cf_api.spec.js
@@ -68,7 +68,8 @@ describe('cfApi', function() {
       expect(actual).toEqual(cfApi.version + expectedUrl);
     });
 
-    it('should call the action with the response data on success', function() {
+    it('should call the action with the response data on success',
+        function(done) {
       var expected = { data: { guid: 'q39g08hgdih' }},
           stub = sandbox.stub(http, 'get'),
           spy = sandbox.spy();
@@ -76,21 +77,24 @@ describe('cfApi', function() {
       let testPromise = createPromise(expected);
       stub.returns(testPromise);
 
-      cfApi.fetchOne('/thing/adjfk', spy);
-      expect(spy).toHaveBeenCalledOnce();
-      let actual = spy.getCall(0).args[0];
-      expect(actual).toEqual(expected.data);
+      cfApi.fetchOne('/thing/adjfk', spy).then(() => {
+        expect(spy).toHaveBeenCalledOnce();
+        let actual = spy.getCall(0).args[0];
+        expect(actual).toEqual(expected.data);
+        done();
+      });;
     });
 
-    it('should call the fetch error action on failure', function() {
+    it('should call the fetch error action on failure', function(done) {
       var spy = fetchErrorSetup();
 
-      cfApi.fetchOne();
-
-      assertFetchError(spy);
+      cfApi.fetchOne().then(() => {
+        assertFetchError(spy);
+        done();
+      });
     });
 
-    it('should pass any additional arguments to the action', function() {
+    it('should pass any additional arguments to the action', function(done) {
       var spy = sandbox.spy(),
           stub = sandbox.stub(http, 'get'),
           expectedArgA = 'arga',
@@ -98,26 +102,29 @@ describe('cfApi', function() {
 
       let testPromise = createPromise('asdf');
       stub.returns(testPromise);
-      cfApi.fetchOne('/thing/asdfz', spy, expectedArgA, expectedArgB);
-      let actual = spy.getCall(0).args[1];
-      expect(actual).toEqual(expectedArgA);
-      actual = spy.getCall(0).args[2];
-      expect(actual).toEqual(expectedArgB);
+      cfApi.fetchOne('/thing/asdfz', spy, expectedArgA, expectedArgB).then(() => {
+        let actual = spy.getCall(0).args[1];
+        expect(actual).toEqual(expectedArgA);
+        actual = spy.getCall(0).args[2];
+        expect(actual).toEqual(expectedArgB);
+        done();
+      });;
     });
   });
 
   describe('getAuthStatus()', function() {
-    it('calls http get request for auth status', () => {
+    it('calls http get request for auth status', (done) => {
       var spy = sandbox.spy(http, 'get');
 
-      cfApi.getAuthStatus();
-
-      expect(spy).toHaveBeenCalledOnce();
-      let actual = spy.getCall(0).args[0];
-      expect(actual).toMatch('authstatus');
+      cfApi.getAuthStatus().then(() => {
+        expect(spy).toHaveBeenCalledOnce();
+        let actual = spy.getCall(0).args[0];
+        expect(actual).toMatch('authstatus');
+        done();
+      });
     });
 
-    it('calls received status with status on success', () => {
+    it('calls received status with status on success', (done) => {
       var expectedStatus = 'logged_in',
           expected = { data: { status: expectedStatus } },
           stub = sandbox.stub(http, 'get'),
@@ -127,13 +134,14 @@ describe('cfApi', function() {
 
       stub.returns(testPromise);
 
-      cfApi.getAuthStatus();
-
-      expect(spy).toHaveBeenCalledOnce();
-      expect(spy).toHaveBeenCalledWith(expected.data.status);
+      cfApi.getAuthStatus().then(() => {
+        expect(spy).toHaveBeenCalledOnce();
+        expect(spy).toHaveBeenCalledWith(expected.data.status);
+        done();
+      });;
     });
 
-    it('calls received status with false on failure', () => {
+    it('calls received status with false on failure', (done) => {
       // Note: the getAuthStatus call will return 401 when not logged in, so
       // failure here means the user was likely not logged in. Although there
       // could be the additional problem that there was a problem with the req.
@@ -144,10 +152,11 @@ describe('cfApi', function() {
       let testPromise = createPromise(true, expected);
       stub.returns(testPromise);
 
-      let actual = cfApi.getAuthStatus();
-
-      expect(spy).toHaveBeenCalledOnce();
-      expect(spy).toHaveBeenCalledWith(false);
+      let actual = cfApi.getAuthStatus().then(() => {
+        expect(spy).toHaveBeenCalledOnce();
+        expect(spy).toHaveBeenCalledWith(false);
+        done();
+      });
     });
   });
 
@@ -190,17 +199,19 @@ describe('cfApi', function() {
   });
 
   describe('fetchOrgs()', function() {
-    it('calls http get request for orgs', function() {
+    it('calls http get request for orgs', function(done) {
       var spy = sandbox.spy(http, 'get');
 
-      cfApi.fetchOrgs();
+      cfApi.fetchOrgs().then(() => {
+        expect(spy).toHaveBeenCalledOnce();
+        let actual = spy.getCall(0).args[0];
+        expect(actual).toMatch('organizations');
+        done();
+      });;
 
-      expect(spy).toHaveBeenCalledOnce();
-      let actual = spy.getCall(0).args[0];
-      expect(actual).toMatch('organizations');
     });
 
-    it('calls orgs received with orgs on success', function() {
+    it('calls orgs received with orgs on success', function(done) {
       var expectedOrgs = [
         { metadata: { guid: 'xxxaasdf' }, entity: { name: 'testA' }},
         { metadata: { guid: 'xxxaasdg' }, entity: { name: 'testB' }}
@@ -212,18 +223,21 @@ describe('cfApi', function() {
       let testPromise = createPromise(expected);
       stub.returns(testPromise);
 
-      let actual = cfApi.fetchOrgs();
+      let actual = cfApi.fetchOrgs().then(() => {
+        expect(spy).toHaveBeenCalledOnce();
+        expect(spy).toHaveBeenCalledWith(expectedOrgs);
+        done();
+      });;
 
-      expect(spy).toHaveBeenCalledOnce();
-      expect(spy).toHaveBeenCalledWith(expectedOrgs);
     });
 
-    it('calls error action with error on failure', function() {
+    it('calls error action with error on failure', function(done) {
       var spy = fetchErrorSetup();
 
-      cfApi.fetchOrgs();
-
-      assertFetchError(spy);
+      cfApi.fetchOrgs().then(() => {
+        assertFetchError(spy);
+        done();
+      });
     });
   });
 
@@ -348,7 +362,8 @@ describe('cfApi', function() {
       expect(actual).toMatch(new RegExp('accepts_incomplete'));
     });
 
-    it('should call service action for instance created on success', function() {
+    it('should call service action for instance created on success',
+        function(done) {
       var stub = sandbox.stub(http, 'post'),
           spy = sandbox.spy(serviceActions, 'createdInstance'),
           expected = { data: { guid: 'znvmjahskf' }};
@@ -359,14 +374,15 @@ describe('cfApi', function() {
       cfApi.createServiceInstance(
           expectedName,
           expectedSpaceGuid,
-          expectedServicePlanGuid);
-
-      expect(spy).toHaveBeenCalledOnce();
-      let actual = spy.getCall(0).args[0];
-      expect(actual).toEqual(expected.data);
+          expectedServicePlanGuid).then(() => {
+            expect(spy).toHaveBeenCalledOnce();
+            let actual = spy.getCall(0).args[0];
+            expect(actual).toEqual(expected.data);
+            done();
+          });
     });
 
-    it('should call an service error action on failure', function() {
+    it('should call an service error action on failure', function(done) {
       var stub = sandbox.stub(http, 'post'),
           spy = sandbox.stub(serviceActions, 'errorCreateInstance'),
           expectedErr = { status: 'error' };
@@ -377,11 +393,12 @@ describe('cfApi', function() {
       cfApi.createServiceInstance(
           expectedName,
           expectedSpaceGuid,
-          expectedServicePlanGuid);
-
-      expect(spy).toHaveBeenCalledOnce();
-      let actual = spy.getCall(0).args[0];
-      expect(actual).toEqual(expectedErr);
+          expectedServicePlanGuid).then(() => {
+            expect(spy).toHaveBeenCalledOnce();
+            let actual = spy.getCall(0).args[0];
+            expect(actual).toEqual(expectedErr);
+            done();
+        });
     });
   });
 
@@ -399,7 +416,7 @@ describe('cfApi', function() {
       expect(actual).toMatch(new RegExp(expectedGuid));
     });
 
-    it('should call service deleted action with guid', function() {
+    it('should call service deleted action with guid', function(done) {
       var stub = sandbox.stub(http, 'delete'),
           spy = sandbox.spy(serviceActions, 'deletedInstance'),
           expectedGuid = '38wofjasd',
@@ -408,11 +425,12 @@ describe('cfApi', function() {
       let testPromise = createPromise({status: true});
       stub.returns(testPromise);
 
-      cfApi.deleteUnboundServiceInstance(expected);
-
-      expect(spy).toHaveBeenCalledOnce();
-      let actual = spy.getCall(0).args[0];
-      expect(actual).toEqual(expectedGuid);
+      cfApi.deleteUnboundServiceInstance(expected).then(() => {
+        expect(spy).toHaveBeenCalledOnce();
+        let actual = spy.getCall(0).args[0];
+        expect(actual).toEqual(expectedGuid);
+        done();
+      });
     });
 
     // TODO should be error action for non fetch errors.
@@ -507,7 +525,7 @@ describe('cfApi', function() {
       expect(actual).toMatch(new RegExp(expectedOrgGuid));
     });
 
-    it('should call org deleted action with guid', function() {
+    it('should call org deleted action with guid', function(done) {
       var stub = sandbox.stub(http, 'delete'),
           spy = sandbox.spy(userActions, 'deletedUser'),
           expectedUserGuid = 'aldfskjmcx',
@@ -516,12 +534,13 @@ describe('cfApi', function() {
       let testPromise = createPromise({status: true});
       stub.returns(testPromise);
 
-      cfApi.deleteUser(expectedUserGuid, expectedOrgGuid);
-
-      expect(spy).toHaveBeenCalledOnce();
-      let args = spy.getCall(0).args;
-      expect(args[0]).toEqual(expectedUserGuid);
-      expect(args[1]).toEqual(expectedOrgGuid);
+      cfApi.deleteUser(expectedUserGuid, expectedOrgGuid).then(() => {
+        expect(spy).toHaveBeenCalledOnce();
+        let args = spy.getCall(0).args;
+        expect(args[0]).toEqual(expectedUserGuid);
+        expect(args[1]).toEqual(expectedOrgGuid);
+        done();
+      });
     });
   });
 
@@ -546,7 +565,7 @@ describe('cfApi', function() {
     });
   });
 
-  describe('deleteOrgUserPermissions()', function() {
+  describe('deleteOrgUserPermissions()', function(done) {
     it('should call an http delete request on org user with permissions',
         function() {
       var spy = sandbox.spy(http, 'delete'),
@@ -557,17 +576,18 @@ describe('cfApi', function() {
       cfApi.deleteOrgUserPermissions(
         expectedUserGuid,
         expectedOrgGuid,
-        expectedPermission);
-
-      expect(spy).toHaveBeenCalledOnce();
-      let actual = spy.getCall(0).args[0];
-      expect(actual).toMatch(new RegExp(expectedUserGuid));
-      expect(actual).toMatch(new RegExp(expectedOrgGuid));
-      expect(actual).toMatch(new RegExp(expectedPermission));
+        expectedPermission).then(() => {
+          expect(spy).toHaveBeenCalledOnce();
+          let actual = spy.getCall(0).args[0];
+          expect(actual).toMatch(new RegExp(expectedUserGuid));
+          expect(actual).toMatch(new RegExp(expectedOrgGuid));
+          expect(actual).toMatch(new RegExp(expectedPermission));
+          done();
+        });
     });
 
     it(`should call user action on a 400 response that has code 10006 with
-        message about the error from cf`, function() {
+        message about the error from cf`, function(done) {
       var stub = sandbox.stub(http, 'delete'),
           spy = sandbox.spy(userActions, 'errorRemoveUser'),
           expectedUserGuid = 'zcvmzxncbvpafd',
@@ -580,12 +600,14 @@ describe('cfApi', function() {
       let testPromise = createPromise(true, { data: expected });
       stub.returns(testPromise);
 
-      cfApi.deleteOrgUserPermissions(expectedUserGuid, 'asdf', 'role');
-
-      expect(spy).toHaveBeenCalledOnce();
-      let args = spy.getCall(0).args;
-      expect(args[0]).toEqual(expectedUserGuid);
-      expect(args[1]).toEqual(expected);
+      cfApi.deleteOrgUserPermissions(expectedUserGuid, 'asdf', 'role').then(
+        () => {
+        expect(spy).toHaveBeenCalledOnce();
+        let args = spy.getCall(0).args;
+        expect(args[0]).toEqual(expectedUserGuid);
+        expect(args[1]).toEqual(expected);
+        done();
+      });
     });
   });
 

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -1,6 +1,5 @@
 
 import http from 'axios';
-import 'promises-done-polyfill';
 
 import appActions from '../actions/app_actions.js';
 import errorActions from '../actions/error_actions.js';
@@ -16,13 +15,13 @@ export default {
   version: APIV,
 
   fetch(url, action, multiple, ...params) {
-    return http.get(APIV + url).done((res) => {
+    return http.get(APIV + url).then((res) => {
       if (!multiple) {
         action(res.data, ...params);
       } else {
         action(res.data.resources, ...params);
       }
-    }, (err) => {
+    }).catch((err) => {
       errorActions.errorFetch(err);
     });
   },
@@ -36,9 +35,9 @@ export default {
   },
 
   getAuthStatus() {
-    return http.get(`${APIV}/authstatus`).done((res) => {
+    return http.get(`${APIV}/authstatus`).then((res) => {
       loginActions.receivedStatus(res.data.status);
-    }, () => {
+    }).catch(() => {
       loginActions.receivedStatus(false);
     });
   },
@@ -89,9 +88,9 @@ export default {
   },
 
   fetchOrgs() {
-    return http.get(`${APIV}/organizations`).done((res) => {
+    return http.get(`${APIV}/organizations`).then((res) => {
       orgActions.receivedOrgs(res.data.resources);
-    }, (err) => {
+    }).catch((err) => {
       errorActions.errorFetch(err);
     });
   },
@@ -122,18 +121,18 @@ export default {
     };
 
     return http.post(`${APIV}/service_instances?accepts_incomplete=true`, payload)
-      .done((res) => {
+      .then((res) => {
         serviceActions.createdInstance(res.data);
-      }, (err) => {
+      }).catch((err) => {
         serviceActions.errorCreateInstance(err.data);
       });
   },
 
   deleteUnboundServiceInstance(serviceInstance) {
     return http.delete(serviceInstance.url)
-    .done(() => {
+    .then(() => {
       serviceActions.deletedInstance(serviceInstance.guid);
-    }, () => {
+    }).catch(() => {
       // Do nothing.
     });
   },
@@ -173,9 +172,9 @@ export default {
 
   deleteUser(userGuid, orgGuid) {
     return http.delete(`${APIV}/organizations/${orgGuid}/users/${userGuid}`)
-      .done(() => {
+      .then(() => {
         userActions.deletedUser(userGuid, orgGuid);
-      }, (err) => {
+      }).catch((err) => {
         userActions.errorRemoveUser(userGuid, err.data);
       });
   },


### PR DESCRIPTION
Removes all instances of the `done()` method on promises favoring the use of `then()` and `catch()`. Changes the bulk of test code in `cf_api` tests to use a resolved or rejected promise, meaning the assertions have to be done in the `then`.