### PR TITLE
Force install of autopilot

### DIFF
--- a/deploy/travis_deploy.sh
+++ b/deploy/travis_deploy.sh
@@ -26,6 +26,6 @@ echo $CF_SPACE
 export CF_BIN=$CLIPATH/out/cf
 # Log in
 $CF_BIN api $CF_API
-$CF_BIN auth $CF_USERNAME $CF_PASSWORD && $CF_BIN target -o $CF_ORGANIZATION -s $CF_SPACE && $CF_BIN install-plugin $GOAUTOPILOT_BIN
+$CF_BIN auth $CF_USERNAME $CF_PASSWORD && $CF_BIN target -o $CF_ORGANIZATION -s $CF_SPACE && $CF_BIN install-plugin -f $GOAUTOPILOT_BIN
 # Run autopilot plugin
 $CF_BIN zero-downtime-push cf-deck -f $CF_MANIFEST -p $CF_PATH


### PR DESCRIPTION
New version of CF cli prompts you for plugin installation. This patch
will skip the prompt