### PR TITLE
Stores use immutable data structures internally

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,13 +7,5 @@ static_src/actions/app_actions.js
 static_src/actions/error_actions.js
 static_src/actions/user_actions.js
 static_src/dispatcher.js
-static_src/stores/service_store.js
-static_src/stores/space_store.js
-static_src/stores/app_store.js
-static_src/stores/service_plan_store.js
-static_src/stores/org_store.js
-static_src/stores/base_store.js
-static_src/stores/login_store.js
-static_src/stores/service_instance_store.js
 static_src/tests.bundle.js
 static_src/constants.js

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6497,25 +6497,25 @@
                         }
                       }
                     },
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "from": "ansi-regex@^2.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                    },
                     "ansi": {
                       "version": "0.3.1",
                       "from": "ansi@~0.3.1",
                       "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz"
                     },
-                    "ansi-styles": {
-                      "version": "2.2.1",
-                      "from": "ansi-styles@^2.2.1",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "ansi-regex@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     },
                     "are-we-there-yet": {
                       "version": "1.1.2",
                       "from": "are-we-there-yet@~1.1.2",
                       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz"
+                    },
+                    "ansi-styles": {
+                      "version": "2.2.1",
+                      "from": "ansi-styles@^2.2.1",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                     },
                     "asn1": {
                       "version": "0.2.3",
@@ -6537,6 +6537,11 @@
                       "from": "async@^1.5.2",
                       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
                     },
+                    "bl": {
+                      "version": "1.0.3",
+                      "from": "bl@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz"
+                    },
                     "block-stream": {
                       "version": "0.0.8",
                       "from": "block-stream@*",
@@ -6546,11 +6551,6 @@
                       "version": "2.10.1",
                       "from": "boom@2.x.x",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                    },
-                    "bl": {
-                      "version": "1.0.3",
-                      "from": "bl@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz"
                     },
                     "caseless": {
                       "version": "0.11.0",
@@ -6567,6 +6567,11 @@
                       "from": "combined-stream@~1.0.5",
                       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
                     },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "from": "cryptiles@2.x.x",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                    },
                     "core-util-is": {
                       "version": "1.0.2",
                       "from": "core-util-is@~1.0.0",
@@ -6577,20 +6582,15 @@
                       "from": "commander@^2.9.0",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
                     },
-                    "cryptiles": {
-                      "version": "2.0.5",
-                      "from": "cryptiles@2.x.x",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                    "debug": {
+                      "version": "2.2.0",
+                      "from": "debug@~2.2.0",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
                     },
                     "deep-extend": {
                       "version": "0.4.1",
                       "from": "deep-extend@~0.4.0",
                       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
-                    },
-                    "debug": {
-                      "version": "2.2.0",
-                      "from": "debug@~2.2.0",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
                     },
                     "delayed-stream": {
                       "version": "1.0.0",
@@ -6617,25 +6617,20 @@
                       "from": "extend@~3.0.0",
                       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
                     },
-                    "forever-agent": {
-                      "version": "0.6.1",
-                      "from": "forever-agent@~0.6.1",
-                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-                    },
                     "extsprintf": {
                       "version": "1.0.2",
                       "from": "extsprintf@1.0.2",
                       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                     },
+                    "forever-agent": {
+                      "version": "0.6.1",
+                      "from": "forever-agent@~0.6.1",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                    },
                     "form-data": {
                       "version": "1.0.0-rc4",
                       "from": "form-data@~1.0.0-rc3",
                       "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz"
-                    },
-                    "gauge": {
-                      "version": "1.2.7",
-                      "from": "gauge@~1.2.5",
-                      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz"
                     },
                     "fstream": {
                       "version": "1.0.8",
@@ -6646,6 +6641,11 @@
                       "version": "2.0.0",
                       "from": "generate-function@^2.0.0",
                       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                    },
+                    "gauge": {
+                      "version": "1.2.7",
+                      "from": "gauge@~1.2.5",
+                      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz"
                     },
                     "graceful-fs": {
                       "version": "4.1.3",
@@ -6662,15 +6662,20 @@
                       "from": "graceful-readlink@>= 1.0.0",
                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "from": "has-ansi@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+                    },
                     "har-validator": {
                       "version": "2.0.6",
                       "from": "har-validator@~2.0.6",
                       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
                     },
-                    "has-ansi": {
-                      "version": "2.0.0",
-                      "from": "has-ansi@^2.0.0",
-                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+                    "hawk": {
+                      "version": "3.1.3",
+                      "from": "hawk@~3.1.0",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
                     },
                     "hoek": {
                       "version": "2.16.3",
@@ -6682,45 +6687,40 @@
                       "from": "has-unicode@^2.0.0",
                       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz"
                     },
-                    "hawk": {
-                      "version": "3.1.3",
-                      "from": "hawk@~3.1.0",
-                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
+                    "ini": {
+                      "version": "1.3.4",
+                      "from": "ini@~1.3.0",
+                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                     },
                     "http-signature": {
                       "version": "1.1.1",
                       "from": "http-signature@~1.1.0",
                       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
                     },
-                    "ini": {
-                      "version": "1.3.4",
-                      "from": "ini@~1.3.0",
-                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-                    },
                     "inherits": {
                       "version": "2.0.1",
                       "from": "inherits@*",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "is-my-json-valid": {
-                      "version": "2.13.1",
-                      "from": "is-my-json-valid@^2.12.4",
-                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz"
                     },
                     "is-property": {
                       "version": "1.0.2",
                       "from": "is-property@^1.0.0",
                       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                     },
-                    "is-typedarray": {
-                      "version": "1.0.0",
-                      "from": "is-typedarray@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+                    "is-my-json-valid": {
+                      "version": "2.13.1",
+                      "from": "is-my-json-valid@^2.12.4",
+                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz"
                     },
                     "isarray": {
                       "version": "1.0.0",
                       "from": "isarray@~1.0.0",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                    },
+                    "is-typedarray": {
+                      "version": "1.0.0",
+                      "from": "is-typedarray@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
                     },
                     "isstream": {
                       "version": "0.1.2",
@@ -6737,15 +6737,20 @@
                       "from": "jsbn@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                     },
+                    "json-schema": {
+                      "version": "0.2.2",
+                      "from": "json-schema@0.2.2",
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+                    },
                     "json-stringify-safe": {
                       "version": "5.0.1",
                       "from": "json-stringify-safe@~5.0.1",
                       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                     },
-                    "json-schema": {
-                      "version": "0.2.2",
-                      "from": "json-schema@0.2.2",
-                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+                    "jsonpointer": {
+                      "version": "2.0.0",
+                      "from": "jsonpointer@2.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                     },
                     "jsprim": {
                       "version": "1.2.2",
@@ -6762,30 +6767,25 @@
                       "from": "lodash.padstart@^4.1.0",
                       "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.2.0.tgz"
                     },
-                    "jsonpointer": {
-                      "version": "2.0.0",
-                      "from": "jsonpointer@2.0.0",
-                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                    "lodash.repeat": {
+                      "version": "4.0.0",
+                      "from": "lodash.repeat@^4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.0.0.tgz"
                     },
                     "lodash.padend": {
                       "version": "4.2.0",
                       "from": "lodash.padend@^4.1.0",
                       "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.2.0.tgz"
                     },
-                    "lodash.repeat": {
-                      "version": "4.0.0",
-                      "from": "lodash.repeat@^4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.0.0.tgz"
+                    "mime-db": {
+                      "version": "1.22.0",
+                      "from": "mime-db@~1.22.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
                     },
                     "lodash.tostring": {
                       "version": "4.1.2",
                       "from": "lodash.tostring@^4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.2.tgz"
-                    },
-                    "mime-db": {
-                      "version": "1.22.0",
-                      "from": "mime-db@~1.22.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
                     },
                     "mime-types": {
                       "version": "2.1.10",
@@ -6797,45 +6797,40 @@
                       "from": "minimist@0.0.8",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     },
-                    "ms": {
-                      "version": "0.7.1",
-                      "from": "ms@0.7.1",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                    },
                     "mkdirp": {
                       "version": "0.5.1",
                       "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
                     },
-                    "npmlog": {
-                      "version": "2.0.3",
-                      "from": "npmlog@~2.0.0",
-                      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.3.tgz"
+                    "ms": {
+                      "version": "0.7.1",
+                      "from": "ms@0.7.1",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     },
                     "node-uuid": {
                       "version": "1.4.7",
                       "from": "node-uuid@~1.4.7",
                       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
                     },
-                    "oauth-sign": {
-                      "version": "0.8.1",
-                      "from": "oauth-sign@~0.8.0",
-                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
+                    "npmlog": {
+                      "version": "2.0.3",
+                      "from": "npmlog@~2.0.0",
+                      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.3.tgz"
                     },
                     "once": {
                       "version": "1.3.3",
                       "from": "once@~1.3.3",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
                     },
+                    "oauth-sign": {
+                      "version": "0.8.1",
+                      "from": "oauth-sign@~0.8.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
+                    },
                     "pinkie": {
                       "version": "2.0.4",
                       "from": "pinkie@^2.0.0",
                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                    },
-                    "pinkie-promise": {
-                      "version": "2.0.0",
-                      "from": "pinkie-promise@^2.0.0",
-                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.6",
@@ -6847,6 +6842,11 @@
                       "from": "qs@~6.0.2",
                       "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz"
                     },
+                    "pinkie-promise": {
+                      "version": "2.0.0",
+                      "from": "pinkie-promise@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
+                    },
                     "readable-stream": {
                       "version": "2.0.6",
                       "from": "readable-stream@^2.0.0 || ^1.1.13",
@@ -6856,6 +6856,11 @@
                       "version": "2.69.0",
                       "from": "request@2.x",
                       "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz"
+                    },
+                    "semver": {
+                      "version": "5.1.0",
+                      "from": "semver@~5.1.0",
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
                     },
                     "sntp": {
                       "version": "1.0.9",
@@ -6867,35 +6872,30 @@
                       "from": "sshpk@^1.7.0",
                       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz"
                     },
-                    "semver": {
-                      "version": "5.1.0",
-                      "from": "semver@~5.1.0",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
                     "stringstream": {
                       "version": "0.0.5",
                       "from": "stringstream@~0.0.4",
                       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                     },
-                    "strip-json-comments": {
-                      "version": "1.0.4",
-                      "from": "strip-json-comments@~1.0.4",
-                      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "from": "strip-ansi@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
                     },
                     "supports-color": {
                       "version": "2.0.0",
                       "from": "supports-color@^2.0.0",
                       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                     },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "from": "strip-ansi@^3.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "strip-json-comments": {
+                      "version": "1.0.4",
+                      "from": "strip-json-comments@~1.0.4",
+                      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
                     },
                     "tar-pack": {
                       "version": "3.1.3",
@@ -6917,25 +6917,25 @@
                       "from": "tunnel-agent@~0.4.1",
                       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
                     },
-                    "uid-number": {
-                      "version": "0.0.6",
-                      "from": "uid-number@~0.0.6",
-                      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
-                    },
                     "tweetnacl": {
                       "version": "0.14.3",
                       "from": "tweetnacl@>=0.13.0 <1.0.0",
                       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
                     },
-                    "verror": {
-                      "version": "1.3.6",
-                      "from": "verror@1.3.6",
-                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                    "uid-number": {
+                      "version": "0.0.6",
+                      "from": "uid-number@~0.0.6",
+                      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
                       "from": "util-deprecate@~1.0.1",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    },
+                    "verror": {
+                      "version": "1.3.6",
+                      "from": "verror@1.3.6",
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                     },
                     "xtend": {
                       "version": "4.0.1",
@@ -9588,6 +9588,11 @@
         }
       }
     },
+    "immutable": {
+      "version": "3.8.1",
+      "from": "immutable@latest",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz"
+    },
     "imports-loader": {
       "version": "0.6.5",
       "from": "https://registry.npmjs.org/imports-loader/-/imports-loader-0.6.5.tgz",
@@ -10856,70 +10861,70 @@
                   "from": "ansi@~0.3.1",
                   "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz"
                 },
-                "ansi-styles": {
-                  "version": "2.2.1",
-                  "from": "ansi-styles@^2.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                },
                 "ansi-regex": {
                   "version": "2.0.0",
                   "from": "ansi-regex@^2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                },
+                "ansi-styles": {
+                  "version": "2.2.1",
+                  "from": "ansi-styles@^2.2.1",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                 },
                 "are-we-there-yet": {
                   "version": "1.1.2",
                   "from": "are-we-there-yet@~1.1.2",
                   "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz"
                 },
-                "assert-plus": {
-                  "version": "0.2.0",
-                  "from": "assert-plus@^0.2.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
-                },
                 "asn1": {
                   "version": "0.2.3",
                   "from": "asn1@>=0.2.3 <0.3.0",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
-                },
-                "aws-sign2": {
-                  "version": "0.6.0",
-                  "from": "aws-sign2@~0.6.0",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
                 },
                 "async": {
                   "version": "1.5.2",
                   "from": "async@^1.5.2",
                   "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
                 },
-                "block-stream": {
-                  "version": "0.0.8",
-                  "from": "block-stream@*",
-                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
+                "assert-plus": {
+                  "version": "0.2.0",
+                  "from": "assert-plus@^0.2.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                },
+                "aws-sign2": {
+                  "version": "0.6.0",
+                  "from": "aws-sign2@~0.6.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
                 },
                 "bl": {
                   "version": "1.0.3",
                   "from": "bl@~1.0.0",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz"
                 },
+                "block-stream": {
+                  "version": "0.0.8",
+                  "from": "block-stream@*",
+                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
+                },
                 "boom": {
                   "version": "2.10.1",
                   "from": "boom@2.x.x",
                   "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                 },
-                "chalk": {
-                  "version": "1.1.3",
-                  "from": "chalk@^1.1.1",
-                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+                "caseless": {
+                  "version": "0.11.0",
+                  "from": "caseless@~0.11.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
                 },
                 "combined-stream": {
                   "version": "1.0.5",
                   "from": "combined-stream@~1.0.5",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
                 },
-                "caseless": {
-                  "version": "0.11.0",
-                  "from": "caseless@~0.11.0",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+                "chalk": {
+                  "version": "1.1.3",
+                  "from": "chalk@^1.1.1",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
                 },
                 "core-util-is": {
                   "version": "1.0.2",
@@ -10946,20 +10951,20 @@
                   "from": "delayed-stream@~1.0.0",
                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                 },
-                "ecc-jsbn": {
-                  "version": "0.1.1",
-                  "from": "ecc-jsbn@>=0.0.1 <1.0.0",
-                  "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                "deep-extend": {
+                  "version": "0.4.1",
+                  "from": "deep-extend@~0.4.0",
+                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
                 },
                 "delegates": {
                   "version": "1.0.0",
                   "from": "delegates@^1.0.0",
                   "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
                 },
-                "deep-extend": {
-                  "version": "0.4.1",
-                  "from": "deep-extend@~0.4.0",
-                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
+                "ecc-jsbn": {
+                  "version": "0.1.1",
+                  "from": "ecc-jsbn@>=0.0.1 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
@@ -10986,25 +10991,30 @@
                   "from": "form-data@~1.0.0-rc3",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz"
                 },
-                "gauge": {
-                  "version": "1.2.7",
-                  "from": "gauge@~1.2.5",
-                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz"
-                },
                 "fstream": {
                   "version": "1.0.8",
                   "from": "fstream@^1.0.2",
                   "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
+                },
+                "generate-function": {
+                  "version": "2.0.0",
+                  "from": "generate-function@^2.0.0",
+                  "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                 },
                 "generate-object-property": {
                   "version": "1.2.0",
                   "from": "generate-object-property@^1.1.0",
                   "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
                 },
-                "generate-function": {
-                  "version": "2.0.0",
-                  "from": "generate-function@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                "graceful-fs": {
+                  "version": "4.1.3",
+                  "from": "graceful-fs@^4.1.2",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                },
+                "gauge": {
+                  "version": "1.2.7",
+                  "from": "gauge@~1.2.5",
+                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz"
                 },
                 "graceful-readlink": {
                   "version": "1.0.1",
@@ -11016,15 +11026,10 @@
                   "from": "har-validator@~2.0.6",
                   "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
                 },
-                "graceful-fs": {
-                  "version": "4.1.3",
-                  "from": "graceful-fs@^4.1.2",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
-                },
-                "hawk": {
-                  "version": "3.1.3",
-                  "from": "hawk@~3.1.0",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
+                "hoek": {
+                  "version": "2.16.3",
+                  "from": "hoek@2.x.x",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                 },
                 "has-unicode": {
                   "version": "2.0.0",
@@ -11036,10 +11041,10 @@
                   "from": "has-ansi@^2.0.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
                 },
-                "hoek": {
-                  "version": "2.16.3",
-                  "from": "hoek@2.x.x",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                "hawk": {
+                  "version": "3.1.3",
+                  "from": "hawk@~3.1.0",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
                 },
                 "http-signature": {
                   "version": "1.1.1",
@@ -11051,25 +11056,25 @@
                   "from": "inherits@*",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
-                "ini": {
-                  "version": "1.3.4",
-                  "from": "ini@~1.3.0",
-                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-                },
                 "is-my-json-valid": {
                   "version": "2.13.1",
                   "from": "is-my-json-valid@^2.12.4",
                   "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz"
                 },
-                "is-typedarray": {
-                  "version": "1.0.0",
-                  "from": "is-typedarray@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+                "ini": {
+                  "version": "1.3.4",
+                  "from": "ini@~1.3.0",
+                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                 },
                 "is-property": {
                   "version": "1.0.2",
                   "from": "is-property@^1.0.0",
                   "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                },
+                "is-typedarray": {
+                  "version": "1.0.0",
+                  "from": "is-typedarray@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
                 },
                 "isarray": {
                   "version": "1.0.0",
@@ -11091,15 +11096,15 @@
                   "from": "jodid25519@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
                 },
-                "json-stringify-safe": {
-                  "version": "5.0.1",
-                  "from": "json-stringify-safe@~5.0.1",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-                },
                 "json-schema": {
                   "version": "0.2.2",
                   "from": "json-schema@0.2.2",
                   "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "from": "json-stringify-safe@~5.0.1",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "jsonpointer": {
                   "version": "2.0.0",
@@ -11111,15 +11116,15 @@
                   "from": "jsprim@^1.2.2",
                   "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
                 },
-                "lodash.padend": {
-                  "version": "4.2.0",
-                  "from": "lodash.padend@^4.1.0",
-                  "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.2.0.tgz"
-                },
                 "lodash.pad": {
                   "version": "4.1.0",
                   "from": "lodash.pad@^4.1.0",
                   "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.1.0.tgz"
+                },
+                "lodash.padend": {
+                  "version": "4.2.0",
+                  "from": "lodash.padend@^4.1.0",
+                  "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.2.0.tgz"
                 },
                 "lodash.padstart": {
                   "version": "4.2.0",
@@ -11141,11 +11146,6 @@
                   "from": "mime-db@~1.22.0",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
                 },
-                "minimist": {
-                  "version": "0.0.8",
-                  "from": "minimist@0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                },
                 "mime-types": {
                   "version": "2.1.10",
                   "from": "mime-types@~2.1.7",
@@ -11156,20 +11156,25 @@
                   "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
                 },
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                },
                 "ms": {
                   "version": "0.7.1",
                   "from": "ms@0.7.1",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 },
-                "npmlog": {
-                  "version": "2.0.3",
-                  "from": "npmlog@~2.0.0",
-                  "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.3.tgz"
-                },
                 "node-uuid": {
                   "version": "1.4.7",
                   "from": "node-uuid@~1.4.7",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+                },
+                "npmlog": {
+                  "version": "2.0.3",
+                  "from": "npmlog@~2.0.0",
+                  "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.3.tgz"
                 },
                 "oauth-sign": {
                   "version": "0.8.1",
@@ -11181,25 +11186,25 @@
                   "from": "pinkie-promise@^2.0.0",
                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
                 },
+                "once": {
+                  "version": "1.3.3",
+                  "from": "once@~1.3.3",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+                },
                 "pinkie": {
                   "version": "2.0.4",
                   "from": "pinkie@^2.0.0",
                   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.6",
-                  "from": "process-nextick-args@~1.0.6",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "qs": {
                   "version": "6.0.2",
                   "from": "qs@~6.0.2",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz"
                 },
-                "once": {
-                  "version": "1.3.3",
-                  "from": "once@~1.3.3",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+                "process-nextick-args": {
+                  "version": "1.0.6",
+                  "from": "process-nextick-args@~1.0.6",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "readable-stream": {
                   "version": "2.0.6",
@@ -11210,11 +11215,6 @@
                   "version": "2.69.0",
                   "from": "request@2.x",
                   "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz"
-                },
-                "semver": {
-                  "version": "5.1.0",
-                  "from": "semver@~5.1.0",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
@@ -11231,10 +11231,10 @@
                   "from": "string_decoder@~0.10.x",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
-                "supports-color": {
-                  "version": "2.0.0",
-                  "from": "supports-color@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                "semver": {
+                  "version": "5.1.0",
+                  "from": "semver@~5.1.0",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.5",
@@ -11246,30 +11246,35 @@
                   "from": "strip-ansi@^3.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
                 },
-                "tar": {
-                  "version": "2.2.1",
-                  "from": "tar@~2.2.0",
-                  "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
-                },
                 "strip-json-comments": {
                   "version": "1.0.4",
                   "from": "strip-json-comments@~1.0.4",
                   "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "from": "supports-color@^2.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                },
+                "tar": {
+                  "version": "2.2.1",
+                  "from": "tar@~2.2.0",
+                  "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
                 },
                 "tough-cookie": {
                   "version": "2.2.2",
                   "from": "tough-cookie@~2.2.0",
                   "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
                 },
-                "tar-pack": {
-                  "version": "3.1.3",
-                  "from": "tar-pack@~3.1.0",
-                  "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.3.tgz"
-                },
                 "tunnel-agent": {
                   "version": "0.4.2",
                   "from": "tunnel-agent@~0.4.1",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
+                },
+                "tar-pack": {
+                  "version": "3.1.3",
+                  "from": "tar-pack@~3.1.0",
+                  "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.3.tgz"
                 },
                 "tweetnacl": {
                   "version": "0.14.3",
@@ -11291,15 +11296,15 @@
                   "from": "verror@1.3.6",
                   "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                 },
-                "xtend": {
-                  "version": "4.0.1",
-                  "from": "xtend@^4.0.0",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                },
                 "wrappy": {
                   "version": "1.0.1",
                   "from": "wrappy@1",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                },
+                "xtend": {
+                  "version": "4.0.1",
+                  "from": "xtend@^4.0.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 },
                 "dashdash": {
                   "version": "1.13.0",
@@ -15509,11 +15514,6 @@
         }
       }
     },
-    "promises-done-polyfill": {
-      "version": "1.0.0",
-      "from": "promises-done-polyfill@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/promises-done-polyfill/-/promises-done-polyfill-1.0.0.tgz"
-    },
     "react": {
       "version": "0.14.8",
       "from": "https://registry.npmjs.org/react/-/react-0.14.8.tgz",
@@ -16672,11 +16672,6 @@
                       "from": "ansi@~0.3.1",
                       "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz"
                     },
-                    "are-we-there-yet": {
-                      "version": "1.1.2",
-                      "from": "are-we-there-yet@~1.1.2",
-                      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz"
-                    },
                     "ansi-regex": {
                       "version": "2.0.0",
                       "from": "ansi-regex@^2.0.0",
@@ -16687,15 +16682,20 @@
                       "from": "ansi-styles@^2.2.1",
                       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                     },
-                    "assert-plus": {
-                      "version": "0.2.0",
-                      "from": "assert-plus@^0.2.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                    "are-we-there-yet": {
+                      "version": "1.1.2",
+                      "from": "are-we-there-yet@~1.1.2",
+                      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz"
                     },
                     "asn1": {
                       "version": "0.2.3",
                       "from": "asn1@>=0.2.3 <0.3.0",
                       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                    },
+                    "assert-plus": {
+                      "version": "0.2.0",
+                      "from": "assert-plus@^0.2.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
                     },
                     "aws-sign2": {
                       "version": "0.6.0",
@@ -16732,15 +16732,15 @@
                       "from": "chalk@^1.1.1",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
                     },
-                    "combined-stream": {
-                      "version": "1.0.5",
-                      "from": "combined-stream@~1.0.5",
-                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
-                    },
                     "commander": {
                       "version": "2.9.0",
                       "from": "commander@^2.9.0",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+                    },
+                    "combined-stream": {
+                      "version": "1.0.5",
+                      "from": "combined-stream@~1.0.5",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
                     },
                     "core-util-is": {
                       "version": "1.0.2",
@@ -16752,11 +16752,6 @@
                       "from": "cryptiles@2.x.x",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                     },
-                    "debug": {
-                      "version": "2.2.0",
-                      "from": "debug@~2.2.0",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
-                    },
                     "deep-extend": {
                       "version": "0.4.1",
                       "from": "deep-extend@~0.4.0",
@@ -16767,15 +16762,30 @@
                       "from": "delayed-stream@~1.0.0",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                     },
-                    "ecc-jsbn": {
-                      "version": "0.1.1",
-                      "from": "ecc-jsbn@>=0.0.1 <1.0.0",
-                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                    "debug": {
+                      "version": "2.2.0",
+                      "from": "debug@~2.2.0",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
                     },
                     "delegates": {
                       "version": "1.0.0",
                       "from": "delegates@^1.0.0",
                       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
+                    },
+                    "extend": {
+                      "version": "3.0.0",
+                      "from": "extend@~3.0.0",
+                      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "from": "ecc-jsbn@>=0.0.1 <1.0.0",
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                    },
+                    "forever-agent": {
+                      "version": "0.6.1",
+                      "from": "forever-agent@~0.6.1",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                     },
                     "escape-string-regexp": {
                       "version": "1.0.5",
@@ -16792,70 +16802,50 @@
                       "from": "form-data@~1.0.0-rc3",
                       "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz"
                     },
-                    "forever-agent": {
-                      "version": "0.6.1",
-                      "from": "forever-agent@~0.6.1",
-                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-                    },
-                    "extend": {
-                      "version": "3.0.0",
-                      "from": "extend@~3.0.0",
-                      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-                    },
                     "fstream": {
                       "version": "1.0.8",
                       "from": "fstream@^1.0.2",
                       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
-                    },
-                    "gauge": {
-                      "version": "1.2.7",
-                      "from": "gauge@~1.2.5",
-                      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz"
                     },
                     "generate-function": {
                       "version": "2.0.0",
                       "from": "generate-function@^2.0.0",
                       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
-                    "generate-object-property": {
-                      "version": "1.2.0",
-                      "from": "generate-object-property@^1.1.0",
-                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
-                    },
                     "graceful-fs": {
                       "version": "4.1.3",
                       "from": "graceful-fs@^4.1.2",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                    },
+                    "gauge": {
+                      "version": "1.2.7",
+                      "from": "gauge@~1.2.5",
+                      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz"
                     },
                     "graceful-readlink": {
                       "version": "1.0.1",
                       "from": "graceful-readlink@>= 1.0.0",
                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     },
+                    "generate-object-property": {
+                      "version": "1.2.0",
+                      "from": "generate-object-property@^1.1.0",
+                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+                    },
                     "har-validator": {
                       "version": "2.0.6",
                       "from": "har-validator@~2.0.6",
                       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
-                    },
-                    "has-ansi": {
-                      "version": "2.0.0",
-                      "from": "has-ansi@^2.0.0",
-                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
-                    },
-                    "hawk": {
-                      "version": "3.1.3",
-                      "from": "hawk@~3.1.0",
-                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
                     },
                     "has-unicode": {
                       "version": "2.0.0",
                       "from": "has-unicode@^2.0.0",
                       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz"
                     },
-                    "http-signature": {
-                      "version": "1.1.1",
-                      "from": "http-signature@~1.1.0",
-                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "from": "has-ansi@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
                     },
                     "hoek": {
                       "version": "2.16.3",
@@ -16867,30 +16857,35 @@
                       "from": "inherits@*",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
-                    "ini": {
-                      "version": "1.3.4",
-                      "from": "ini@~1.3.0",
-                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                    "http-signature": {
+                      "version": "1.1.1",
+                      "from": "http-signature@~1.1.0",
+                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
                     },
                     "is-my-json-valid": {
                       "version": "2.13.1",
                       "from": "is-my-json-valid@^2.12.4",
                       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz"
                     },
+                    "ini": {
+                      "version": "1.3.4",
+                      "from": "ini@~1.3.0",
+                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                    },
                     "is-property": {
                       "version": "1.0.2",
                       "from": "is-property@^1.0.0",
                       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                     },
+                    "hawk": {
+                      "version": "3.1.3",
+                      "from": "hawk@~3.1.0",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
+                    },
                     "isarray": {
                       "version": "1.0.0",
                       "from": "isarray@~1.0.0",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                    },
-                    "jodid25519": {
-                      "version": "1.0.2",
-                      "from": "jodid25519@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
                     },
                     "is-typedarray": {
                       "version": "1.0.0",
@@ -16907,20 +16902,30 @@
                       "from": "jsbn@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                     },
-                    "json-stringify-safe": {
-                      "version": "5.0.1",
-                      "from": "json-stringify-safe@~5.0.1",
-                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                    "jodid25519": {
+                      "version": "1.0.2",
+                      "from": "jodid25519@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
                     },
                     "json-schema": {
                       "version": "0.2.2",
                       "from": "json-schema@0.2.2",
                       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
                     },
+                    "json-stringify-safe": {
+                      "version": "5.0.1",
+                      "from": "json-stringify-safe@~5.0.1",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                    },
                     "jsonpointer": {
                       "version": "2.0.0",
                       "from": "jsonpointer@2.0.0",
                       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                    },
+                    "lodash.padend": {
+                      "version": "4.2.0",
+                      "from": "lodash.padend@^4.1.0",
+                      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.2.0.tgz"
                     },
                     "jsprim": {
                       "version": "1.2.2",
@@ -16937,11 +16942,6 @@
                       "from": "lodash.padstart@^4.1.0",
                       "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.2.0.tgz"
                     },
-                    "lodash.padend": {
-                      "version": "4.2.0",
-                      "from": "lodash.padend@^4.1.0",
-                      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.2.0.tgz"
-                    },
                     "lodash.repeat": {
                       "version": "4.0.0",
                       "from": "lodash.repeat@^4.0.0",
@@ -16952,55 +16952,60 @@
                       "from": "lodash.tostring@^4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.2.tgz"
                     },
-                    "mime-db": {
-                      "version": "1.22.0",
-                      "from": "mime-db@~1.22.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
-                    },
                     "mime-types": {
                       "version": "2.1.10",
                       "from": "mime-types@~2.1.7",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz"
                     },
-                    "minimist": {
-                      "version": "0.0.8",
-                      "from": "minimist@0.0.8",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                    },
-                    "ms": {
-                      "version": "0.7.1",
-                      "from": "ms@0.7.1",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                    "mime-db": {
+                      "version": "1.22.0",
+                      "from": "mime-db@~1.22.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
                     },
                     "mkdirp": {
                       "version": "0.5.1",
                       "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
                     },
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    },
                     "node-uuid": {
                       "version": "1.4.7",
                       "from": "node-uuid@~1.4.7",
                       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+                    },
+                    "ms": {
+                      "version": "0.7.1",
+                      "from": "ms@0.7.1",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     },
                     "oauth-sign": {
                       "version": "0.8.1",
                       "from": "oauth-sign@~0.8.0",
                       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
                     },
-                    "npmlog": {
-                      "version": "2.0.3",
-                      "from": "npmlog@~2.0.0",
-                      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.3.tgz"
-                    },
                     "once": {
                       "version": "1.3.3",
                       "from": "once@~1.3.3",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
                     },
+                    "npmlog": {
+                      "version": "2.0.3",
+                      "from": "npmlog@~2.0.0",
+                      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.3.tgz"
+                    },
                     "pinkie": {
                       "version": "2.0.4",
                       "from": "pinkie@^2.0.0",
                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                    },
+                    "qs": {
+                      "version": "6.0.2",
+                      "from": "qs@~6.0.2",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz"
                     },
                     "pinkie-promise": {
                       "version": "2.0.0",
@@ -17011,11 +17016,6 @@
                       "version": "1.0.6",
                       "from": "process-nextick-args@~1.0.6",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                    },
-                    "qs": {
-                      "version": "6.0.2",
-                      "from": "qs@~6.0.2",
-                      "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz"
                     },
                     "readable-stream": {
                       "version": "2.0.6",
@@ -17052,11 +17052,6 @@
                       "from": "stringstream@~0.0.4",
                       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                     },
-                    "supports-color": {
-                      "version": "2.0.0",
-                      "from": "supports-color@^2.0.0",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                    },
                     "strip-json-comments": {
                       "version": "1.0.4",
                       "from": "strip-json-comments@~1.0.4",
@@ -17067,50 +17062,55 @@
                       "from": "strip-ansi@^3.0.0",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
                     },
-                    "tar": {
-                      "version": "2.2.1",
-                      "from": "tar@~2.2.0",
-                      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
-                    },
-                    "tar-pack": {
-                      "version": "3.1.3",
-                      "from": "tar-pack@~3.1.0",
-                      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.3.tgz"
-                    },
                     "tough-cookie": {
                       "version": "2.2.2",
                       "from": "tough-cookie@~2.2.0",
                       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
                     },
-                    "tweetnacl": {
-                      "version": "0.14.3",
-                      "from": "tweetnacl@>=0.13.0 <1.0.0",
-                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
+                    "tar": {
+                      "version": "2.2.1",
+                      "from": "tar@~2.2.0",
+                      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "from": "supports-color@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                     },
                     "tunnel-agent": {
                       "version": "0.4.2",
                       "from": "tunnel-agent@~0.4.1",
                       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
                     },
+                    "tar-pack": {
+                      "version": "3.1.3",
+                      "from": "tar-pack@~3.1.0",
+                      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.3.tgz"
+                    },
                     "uid-number": {
                       "version": "0.0.6",
                       "from": "uid-number@~0.0.6",
                       "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
+                    },
+                    "tweetnacl": {
+                      "version": "0.14.3",
+                      "from": "tweetnacl@>=0.13.0 <1.0.0",
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
                       "from": "util-deprecate@~1.0.1",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     },
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    },
                     "verror": {
                       "version": "1.3.6",
                       "from": "verror@1.3.6",
                       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                    },
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@1",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     },
                     "xtend": {
                       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "director": "^1.2.8",
     "events": "^1.0.2",
     "flux": "^2.0.3",
+    "immutable": "^3.8.1",
     "json-loader": "^0.5.4",
     "keymirror": "^0.1.1",
     "less": "^2.5.3",

--- a/static_src/stores/app_store.js
+++ b/static_src/stores/app_store.js
@@ -4,6 +4,8 @@
  * server.
  */
 
+import Immutable from 'immutable';
+
 import AppDispatcher from '../dispatcher';
 import BaseStore from './base_store.js';
 import cfApi from '../util/cf_api.js';
@@ -13,8 +15,8 @@ import { appActionTypes } from '../constants.js';
 class AppStore extends BaseStore {
   constructor() {
     super();
+    this._data = Immutable.List();
     this.subscribe(() => this._registerToActions.bind(this));
-    this._data = [];
   }
 
   _registerToActions(action) {
@@ -24,9 +26,9 @@ class AppStore extends BaseStore {
         break;
 
       case appActionTypes.APP_RECEIVED:
-        // TODO only emit change event if updates actually change local data.
-        this._data = this._merge(this._data, [action.app]);
-        this.emitChange();
+        this.merge('guid', action.app, (changed) => {
+          if (changed) this.emitChange();
+        });
         break;
 
       default:

--- a/static_src/stores/app_store.js
+++ b/static_src/stores/app_store.js
@@ -6,21 +6,19 @@
 
 import Immutable from 'immutable';
 
-import AppDispatcher from '../dispatcher';
 import BaseStore from './base_store.js';
 import cfApi from '../util/cf_api.js';
-import LoginStore from './login_store.js';
 import { appActionTypes } from '../constants.js';
 
 class AppStore extends BaseStore {
   constructor() {
     super();
-    this._data = Immutable.List();
+    this._data = new Immutable.List();
     this.subscribe(() => this._registerToActions.bind(this));
   }
 
   _registerToActions(action) {
-    switch(action.type) {
+    switch (action.type) {
       case appActionTypes.APP_FETCH:
         cfApi.fetchApp(action.appGuid);
         break;
@@ -37,6 +35,6 @@ class AppStore extends BaseStore {
   }
 }
 
-let _AppStore = new AppStore();
+const _AppStore = new AppStore();
 
 export default _AppStore;

--- a/static_src/stores/base_store.js
+++ b/static_src/stores/base_store.js
@@ -60,6 +60,17 @@ export default class BaseStore extends EventEmitter {
     return !Immutable.is(this._data, c);
   }
 
+  delete(guid, cb = defaultChangedCallback.bind(this)) {
+    const index = this._data.findIndex((d) =>
+      d.get('guid') === guid
+    );
+
+    if (index === -1) return cb(false);
+
+    this._data = this._data.delete(index);
+    return cb(true);
+  }
+
   formatSplitResponse(resources) {
     return resources.map((r) => Object.assign(r.entity, r.metadata));
   }

--- a/static_src/stores/base_store.js
+++ b/static_src/stores/base_store.js
@@ -76,25 +76,6 @@ export default class BaseStore extends EventEmitter {
     this.removeListener('CHANGE', cb);
   }
 
-  // TODO determine if we can remove this function
-  _merge(currents, updates) {
-    if (!currents.length) return updates;
-
-    updates.forEach((update) => {
-      const same = currents.find((current) =>
-        current.guid === update.guid
-      );
-
-      if (same) {
-        Object.assign(same, update);
-      } else {
-        currents.push(update);
-      }
-    });
-
-    return currents;
-  }
-
   /* merge with no side effects
    *
    * If the dataToMerge exists in the store (as found by

--- a/static_src/stores/base_store.js
+++ b/static_src/stores/base_store.js
@@ -4,13 +4,15 @@
  */
 
 import { EventEmitter } from 'events';
+import Immutable from 'immutable';
+
 import AppDispatcher from '../dispatcher.js';
 
 export default class BaseStore extends EventEmitter {
 
   constructor() {
     super();
-    this._data = [];
+    this._data = Immutable.List();
   }
 
   subscribe(actionSubscribe) {
@@ -19,6 +21,44 @@ export default class BaseStore extends EventEmitter {
 
   get dispatchToken() {
     return this._dispatchToken;
+  }
+
+  isEmpty() {
+    if (this._data.count() === 0) return true;
+    return false;
+  }
+
+  push(val) {
+    let newData = Immutable.fromJS(val);
+    this._data = this._data.push(newData);
+    this.emitChange();
+
+    return this._data;
+  }
+
+  get(guid) {
+    if (guid && !this.isEmpty()) {
+      let item =  this._data.find((space) => {
+        return space.get('guid') === guid;
+      });
+
+      if (item) return item.toJS();
+    }
+  }
+
+  getAll() {
+    return this._data.toJS();
+  }
+
+  dataHasChanged(toCompare) {
+    let c = Immutable.fromJS(toCompare);
+    return !Immutable.is(this._data, c);
+  }
+
+  formatSplitResponse(resources) {
+    return resources.map((resource) => {
+      return Object.assign(resource.entity, resource.metadata);
+    });
   }
 
   emitChange() {
@@ -33,32 +73,14 @@ export default class BaseStore extends EventEmitter {
     this.removeListener('CHANGE', cb);
   }
 
-  get(guid) {
-    if (guid) {
-      return this._data.find((space) => {
-        return space.guid === guid;
-      });
-    }
-  }
-
-  getAll() {
-    return this._data;
-  }
-
-  formatSplitResponse(resources) {
-    return resources.map((resource) => {
-      return Object.assign(resource.entity, resource.metadata);
-    });
-  }
-
-  // TODO make this have no side effects.
+  // TODO determine if we can remove this function
   _merge(currents, updates) {
     if (currents.length) {
       updates.forEach(function(update) {
         var same = currents.find(function(current) {
           return current.guid === update.guid;
         });
-         
+
         same ? Object.assign(same, update) : currents.push(update);
       });
     } else {
@@ -66,4 +88,58 @@ export default class BaseStore extends EventEmitter {
     }
     return currents;
   }
+
+  /* merge with no side effects
+   *
+   * If the dataToMerge exists in the store (as found by
+   * the mergeKey), then merge in new data if there are
+   * changes. If it does not exist in the store, add it.
+   * When data changes, calls dataChangedCallback with
+   * true as the argument. Otherwise, false is used
+   *
+   * @param {string} mergeKey - use to match objects
+   * @param {object} dataToMerge - new object with data
+   * @param {fn} cb - defaults to calling this.emitChange()
+   *                  when the store's data has changed
+   *
+   */
+  merge(mergeKey, dataToMerge, cb) {
+    cb = cb || defaultChangedCallback.bind(this);
+    dataToMerge = Immutable.fromJS(dataToMerge);
+    let oldDataItem = this._data.find((d) => {
+      return d.get(mergeKey) === dataToMerge.get(mergeKey);
+    });
+
+    if (oldDataItem) {
+      if (Immutable.is(oldDataItem, dataToMerge)) {
+        return cb(false);
+      }
+
+      this._data = this._data.map((d) => {
+        if (Immutable.is(d, oldDataItem)) {
+          return oldDataItem.merge(dataToMerge);
+        }
+        return d;
+      });
+    } else {
+      this._data = this._data.push(dataToMerge);
+    }
+    return cb(true);
+  }
+
+  mergeMany(mergeKey, arrayOfDataToMerge, cb) {
+    cb = cb || defaultChangedCallback.bind(this);
+    let dataHasChanged = false;
+    arrayOfDataToMerge.forEach((newData) => {
+      this.merge(mergeKey, newData, (changed) => {
+        if (changed) dataHasChanged = true;
+      });
+    });
+
+    cb(dataHasChanged)
+  }
+}
+
+function defaultChangedCallback(changed) {
+  if (changed) this.emitChange();
 }

--- a/static_src/stores/login_store.js
+++ b/static_src/stores/login_store.js
@@ -10,12 +10,12 @@ import { loginActionTypes } from '../constants.js';
 class LoginStore extends BaseStore {
   constructor() {
     super();
-    this.subscribe(() => this._registerToActions.bind(this))
+    this.subscribe(() => this._registerToActions.bind(this));
     this._isAuthenticated = true;
   }
 
   _registerToActions(action) {
-    switch(action.type) {
+    switch (action.type) {
       case loginActionTypes.RECEIVED_STATUS:
         this._isAuthenticated = action.status;
         this.emitChange();
@@ -29,9 +29,8 @@ class LoginStore extends BaseStore {
   isLoggedIn() {
     return !!this._isAuthenticated;
   }
+}
 
-};
-
-let _LoginStore = new LoginStore();
+const _LoginStore = new LoginStore();
 
 export default _LoginStore;

--- a/static_src/stores/org_store.js
+++ b/static_src/stores/org_store.js
@@ -12,73 +12,75 @@ import cfApi from '../util/cf_api.js';
 import LoginStore from './login_store.js';
 import { orgActionTypes } from '../constants.js';
 
-function formatData(resources) {
-  return resources.map((resource) => {
-    return Object.assign(resource.entity, resource.metadata);
-  });
-}
-
 class OrgStore extends BaseStore {
   constructor() {
     super();
     this.subscribe(() => this._registerToActions.bind(this));
     this._currentOrgGuid = null;
-    this._data = Immutable.List();
+    this._data = new Immutable.List();
   }
 
   _registerToActions(action) {
     switch (action.type) {
-      case orgActionTypes.ORG_FETCH:
+      case orgActionTypes.ORG_FETCH: {
         cfApi.fetchOrg(action.orgGuid);
         break;
+      }
 
-      case orgActionTypes.ORGS_FETCH:
+      case orgActionTypes.ORGS_FETCH: {
         AppDispatcher.waitFor([LoginStore.dispatchToken]);
         cfApi.fetchOrgs();
         break;
+      }
 
-      case orgActionTypes.ORG_RECEIVED:
-        debugger;
-        if (action.org) this.merge('guid', action.org, (changed) => {
-          if (changed) this.emitChange();
-        });
+      case orgActionTypes.ORG_RECEIVED: {
+        if (action.org) {
+          this.merge('guid', action.org, (changed) => {
+            if (changed) this.emitChange();
+          });
+        }
         break;
+      }
 
-      case orgActionTypes.ORGS_RECEIVED:
-        let updates = this.formatSplitResponse(action.orgs).map((d) => {
+      case orgActionTypes.ORGS_RECEIVED: {
+        const updates = this.formatSplitResponse(action.orgs).map((d) => {
           if (d.spaces) {
             return d;
           }
-          return Object.assign(d, { spaces: []});
+          return Object.assign(d, { spaces: [] });
         });
-        cfApi.fetchOrgsSummaries(updates.map((u) => { return u.guid; }));
+        cfApi.fetchOrgsSummaries(updates.map((u) => u.guid));
 
         this.mergeMany('guid', updates, (changed) => {
           if (changed) this.emitChange();
         });
         break;
+      }
 
-      case orgActionTypes.ORGS_SUMMARIES_RECEIVED:
-        this.mergeMany('guid', actions.orgs, (changed) => {
+      case orgActionTypes.ORGS_SUMMARIES_RECEIVED: {
+        this.mergeMany('guid', action.orgs, (changed) => {
           if (changed) this.emitChange();
         });
         break;
+      }
 
-      case orgActionTypes.ORG_CHANGE_CURRENT:
+      case orgActionTypes.ORG_CHANGE_CURRENT: {
         this._currentOrgGuid = action.orgGuid;
         if (this.get(action.orgGuid)) {
           this.emitChange();
         }
         break;
+      }
 
-      case orgActionTypes.ORG_TOGGLE_SPACE_MENU:
-        let org = this.get(action.orgGuid);
-        let open = org.space_menu_open || false;
-        let toUpdate = Object.assign(org, { space_menu_open: !open });
+      case orgActionTypes.ORG_TOGGLE_SPACE_MENU: {
+        const org = this.get(action.orgGuid);
+        const open = org.space_menu_open || false;
+        const toUpdate = Object.assign(org, { space_menu_open: !open });
         this.merge('guid', toUpdate, (changed) => {
           if (changed) this.emitChange();
         });
         break;
+      }
 
       default:
         break;
@@ -90,6 +92,6 @@ class OrgStore extends BaseStore {
   }
 }
 
-let _OrgStore = new OrgStore();
+const _OrgStore = new OrgStore();
 
 export default _OrgStore;

--- a/static_src/stores/service_instance_store.js
+++ b/static_src/stores/service_instance_store.js
@@ -17,7 +17,7 @@ class ServiceInstanceStore extends BaseStore {
     super();
     this.subscribe(() => this._registerToActions.bind(this));
 
-    this._data = Immutable.List();
+    this._data = new Immutable.List();
     this._createInstanceForm = null;
     this._createError = null;
   }
@@ -32,17 +32,19 @@ class ServiceInstanceStore extends BaseStore {
 
   _registerToActions(action) {
     switch (action.type) {
-      case serviceActionTypes.SERVICE_INSTANCES_FETCH:
+      case serviceActionTypes.SERVICE_INSTANCES_FETCH: {
         cfApi.fetchServiceInstances(action.spaceGuid);
         break;
+      }
 
-      case serviceActionTypes.SERVICE_INSTANCES_RECEIVED:
-        var services = this.formatSplitResponse(action.serviceInstances);
+      case serviceActionTypes.SERVICE_INSTANCES_RECEIVED: {
+        const services = this.formatSplitResponse(action.serviceInstances);
         this._data = Immutable.fromJS(services);
         this.emitChange();
         break;
+      }
 
-      case serviceActionTypes.SERVICE_INSTANCE_CREATE_FORM:
+      case serviceActionTypes.SERVICE_INSTANCE_CREATE_FORM: {
         AppDispatcher.waitFor([ServiceStore.dispatchToken]);
         this._createInstanceForm = {
           service: ServiceStore.get(action.serviceGuid),
@@ -50,16 +52,18 @@ class ServiceInstanceStore extends BaseStore {
         };
         this.emitChange();
         break;
+      }
 
-      case serviceActionTypes.SERVICE_INSTANCE_CREATE:
+      case serviceActionTypes.SERVICE_INSTANCE_CREATE: {
         cfApi.createServiceInstance(
           action.name,
           action.spaceGuid,
           action.servicePlanGuid
         );
         break;
+      }
 
-      case serviceActionTypes.SERVICE_INSTANCE_CREATED:
+      case serviceActionTypes.SERVICE_INSTANCE_CREATED: {
         this.merge('guid', action.serviceInstance, (changed) => {
           if (!changed) return;
 
@@ -67,39 +71,40 @@ class ServiceInstanceStore extends BaseStore {
           this.emitChange();
         });
         break;
+      }
 
-      case serviceActionTypes.SERVICE_INSTANCE_ERROR:
-
+      case serviceActionTypes.SERVICE_INSTANCE_ERROR: {
         this._createError = action.error;
         this.emitChange();
         break;
+      }
 
-      case serviceActionTypes.SERVICE_INSTANCE_DELETE:
-        var toDelete = this.get(action.serviceInstanceGuid);
+      case serviceActionTypes.SERVICE_INSTANCE_DELETE: {
+        const toDelete = this.get(action.serviceInstanceGuid);
         if (toDelete) {
           cfApi.deleteUnboundServiceInstance(toDelete);
         }
         break;
+      }
 
-      case serviceActionTypes.SERVICE_INSTANCE_DELETED:
-        let index = this._data.findIndex((d) => {
-          return d.get('guid') === action.serviceInstanceGuid;
-        });
-
+      case serviceActionTypes.SERVICE_INSTANCE_DELETED: {
+        const index = this._data.findIndex((d) =>
+          d.get('guid') === action.serviceInstanceGuid
+        );
         if (index > -1) {
           this._data = this._data.delete(index);
           this.emitChange();
         }
-
         break;
+      }
 
       default:
         break;
 
     }
   }
+}
 
-};
-let _ServiceInstanceStore = new ServiceInstanceStore();
+const _ServiceInstanceStore = new ServiceInstanceStore();
 
 export default _ServiceInstanceStore;

--- a/static_src/stores/service_instance_store.js
+++ b/static_src/stores/service_instance_store.js
@@ -88,13 +88,9 @@ class ServiceInstanceStore extends BaseStore {
       }
 
       case serviceActionTypes.SERVICE_INSTANCE_DELETED: {
-        const index = this._data.findIndex((d) =>
-          d.get('guid') === action.serviceInstanceGuid
-        );
-        if (index > -1) {
-          this._data = this._data.delete(index);
-          this.emitChange();
-        }
+        this.delete(action.serviceInstanceGuid, (changed) => {
+          if (changed) this.emitChange();
+        });
         break;
       }
 

--- a/static_src/stores/service_store.js
+++ b/static_src/stores/service_store.js
@@ -6,7 +6,6 @@
 
 import Immutable from 'immutable';
 
-import AppDispatcher from '../dispatcher';
 import BaseStore from './base_store.js';
 import cfApi from '../util/cf_api.js';
 import { serviceActionTypes } from '../constants.js';
@@ -15,33 +14,34 @@ class ServiceStore extends BaseStore {
   constructor() {
     super();
     this.subscribe(() => this._registerToActions.bind(this));
-    this._data = Immutable.List();
+    this._data = new Immutable.List();
   }
 
   _registerToActions(action) {
     switch (action.type) {
-      case serviceActionTypes.SERVICES_FETCH:
+      case serviceActionTypes.SERVICES_FETCH: {
         cfApi.fetchAllServices(action.orgGuid);
         break;
+      }
 
-      case serviceActionTypes.SERVICES_RECEIVED:
-        let services = this.formatSplitResponse(action.services);
-        let immutableServices = Immutable.fromJS(services);
+      case serviceActionTypes.SERVICES_RECEIVED: {
+        const services = this.formatSplitResponse(action.services);
+        const immutableServices = Immutable.fromJS(services);
 
         if (this.dataHasChanged(immutableServices)) {
           this._data = immutableServices;
           this.emitChange();
         }
-        
         break;
+      }
 
       default:
         break;
 
     }
   }
+}
 
-};
-let _ServiceStore = new ServiceStore();
+const _ServiceStore = new ServiceStore();
 
 export default _ServiceStore;

--- a/static_src/stores/service_store.js
+++ b/static_src/stores/service_store.js
@@ -4,6 +4,8 @@
  * UI and server.
  */
 
+import Immutable from 'immutable';
+
 import AppDispatcher from '../dispatcher';
 import BaseStore from './base_store.js';
 import cfApi from '../util/cf_api.js';
@@ -13,7 +15,7 @@ class ServiceStore extends BaseStore {
   constructor() {
     super();
     this.subscribe(() => this._registerToActions.bind(this));
-    this._data = [];
+    this._data = Immutable.List();
   }
 
   _registerToActions(action) {
@@ -23,9 +25,14 @@ class ServiceStore extends BaseStore {
         break;
 
       case serviceActionTypes.SERVICES_RECEIVED:
-        var services = this.formatSplitResponse(action.services);
-        this._data = services;
-        this.emitChange();
+        let services = this.formatSplitResponse(action.services);
+        let immutableServices = Immutable.fromJS(services);
+
+        if (this.dataHasChanged(immutableServices)) {
+          this._data = immutableServices;
+          this.emitChange();
+        }
+        
         break;
 
       default:

--- a/static_src/stores/space_store.js
+++ b/static_src/stores/space_store.js
@@ -6,38 +6,41 @@
 
 import Immutable from 'immutable';
 
-import AppDispatcher from '../dispatcher';
 import BaseStore from './base_store.js';
-import cfApi from '../util/cf_api.js';
 import { orgActionTypes, spaceActionTypes } from '../constants.js';
 
 class SpaceStore extends BaseStore {
   constructor() {
     super();
-    this._data = Immutable.List();
+    this._data = new Immutable.List();
     this.subscribe(() => this._registerToActions.bind(this));
   }
 
   _registerToActions(action) {
     switch (action.type) {
-      case orgActionTypes.ORG_RECEIVED:
-        let spaces = action.org.spaces;
-        if (spaces) this.mergeMany('guid', spaces, (changed) => {
-          console.log('CHANGED', changed);
-          if (changed) this.emitChange();
-        });
-
+      case orgActionTypes.ORG_RECEIVED: {
+        const spaces = action.org.spaces;
+        if (spaces) {
+          this.mergeMany('guid', spaces, (changed) => {
+            if (changed) this.emitChange();
+          });
+        }
         break;
+      }
 
-      case spaceActionTypes.SPACE_RECEIVED:
+      case spaceActionTypes.SPACE_RECEIVED: {
         this.merge('guid', action.space, (changed) => {
           if (changed) this.emitChange();
         });
+        break;
+      }
+
+      default:
         break;
     }
   }
 }
 
-let _SpaceStore = new SpaceStore();
+const _SpaceStore = new SpaceStore();
 
 export default _SpaceStore;

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -166,15 +166,9 @@ class UserStore extends BaseStore {
       }
 
       case userActionTypes.USER_DELETED: {
-        const index = this._data.findIndex((d) =>
-          d.get('guid') === action.userGuid
-        );
-
-        if (index > -1) {
-          this._data = this._data.delete(index);
-          this.emitChange();
-        }
-
+        this.delete(action.userGuid, (changed) => {
+          if (changed) this.emitChange();
+        });
         break;
       }
 

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -4,6 +4,8 @@
  * server.
  */
 
+import Immutable from 'immutable';
+
 import BaseStore from './base_store.js';
 import cfApi from '../util/cf_api.js';
 import userActions from '../actions/user_actions.js';
@@ -19,7 +21,7 @@ class UserStore extends BaseStore {
   constructor() {
     super();
     this.subscribe(() => this._registerToActions.bind(this));
-    this._data = [];
+    this._data = Immutable.List();
     this._error = null;
   }
 
@@ -43,8 +45,9 @@ class UserStore extends BaseStore {
       case userActionTypes.ORG_USER_ROLES_RECEIVED: {
         const updates = this.formatSplitResponse(action.orgUserRoles);
         if (updates.length) {
-          this._data = this._merge(this._data, updates);
-          this.emitChange();
+          this.mergeMany('guid', updates, (changed) => {
+            if (changed) this.emitChange();
+          });
         }
         break;
       }
@@ -78,8 +81,10 @@ class UserStore extends BaseStore {
           if (user.organization_roles &&
               user.organization_roles.indexOf(role) === -1) {
             user.organization_roles.push(role);
-            this.emitChange();
           }
+          this.merge('guid', user, (changed) => {
+            if (changed) this.emitChange();
+          });
         }
         break;
       }
@@ -114,8 +119,11 @@ class UserStore extends BaseStore {
             user.organization_roles.indexOf(role);
           if (idx > -1) {
             user.organization_roles.splice(idx, 1);
-            this.emitChange();
           }
+
+          this.merge('guid', user, (changed) => {
+            if (changed) this.emitChange();
+          });
         }
         break;
       }
@@ -124,7 +132,7 @@ class UserStore extends BaseStore {
       case userActionTypes.ORG_USERS_RECEIVED: {
         let updates = this.formatSplitResponse(action.users);
         updates = updates.map((update) => {
-          const updateCopy = Object.assign({}, update);
+          let updateCopy = Object.assign({}, update);
           if (action.orgGuid) {
             updateCopy.orgGuid = action.orgGuid;
           }
@@ -134,9 +142,12 @@ class UserStore extends BaseStore {
           return updateCopy;
         });
         if (updates.length) {
-          this._data = this._merge(this._data, updates);
-          this._error = null;
-          this.emitChange();
+          this.mergeMany('guid', updates, (changed) => {
+            if (changed) {
+              this._error = null;
+              this.emitChange();
+            }
+          });
         }
         break;
       }
@@ -155,13 +166,15 @@ class UserStore extends BaseStore {
       }
 
       case userActionTypes.USER_DELETED: {
-        const deleted = this.get(action.userGuid);
-        if (deleted) {
-          const index = this._data.indexOf(deleted);
-          this._data.splice(index, 1);
-          this._error = null;
+        const index = this._data.findIndex((d) => {
+          return d.get('guid') === action.userGuid;
+        });
+
+        if (index > -1) {
+          this._data = this._data.delete(index);
           this.emitChange();
         }
+
         break;
       }
 
@@ -180,11 +193,17 @@ class UserStore extends BaseStore {
    * Get all users in a certain space
    */
   getAllInSpace(spaceGuid) {
-    return this._data.filter((user) => user.spaceGuid === spaceGuid);
+    const inSpace = this._data.filter((user) => {
+      return user.get('spaceGuid') === spaceGuid;
+    });
+    return inSpace.toJS();
   }
 
   getAllInOrg(orgGuid) {
-    return this._data.filter((user) => user.orgGuid === orgGuid);
+    const inOrg = this._data.filter((user) => {
+      return user.get('orgGuid') === orgGuid;
+    });
+    return inOrg.toJS();
   }
 
   getError() {

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -21,7 +21,7 @@ class UserStore extends BaseStore {
   constructor() {
     super();
     this.subscribe(() => this._registerToActions.bind(this));
-    this._data = Immutable.List();
+    this._data = new Immutable.List();
     this._error = null;
   }
 
@@ -132,7 +132,7 @@ class UserStore extends BaseStore {
       case userActionTypes.ORG_USERS_RECEIVED: {
         let updates = this.formatSplitResponse(action.users);
         updates = updates.map((update) => {
-          let updateCopy = Object.assign({}, update);
+          const updateCopy = Object.assign({}, update);
           if (action.orgGuid) {
             updateCopy.orgGuid = action.orgGuid;
           }
@@ -166,9 +166,9 @@ class UserStore extends BaseStore {
       }
 
       case userActionTypes.USER_DELETED: {
-        const index = this._data.findIndex((d) => {
-          return d.get('guid') === action.userGuid;
-        });
+        const index = this._data.findIndex((d) =>
+          d.get('guid') === action.userGuid
+        );
 
         if (index > -1) {
           this._data = this._data.delete(index);
@@ -193,16 +193,16 @@ class UserStore extends BaseStore {
    * Get all users in a certain space
    */
   getAllInSpace(spaceGuid) {
-    const inSpace = this._data.filter((user) => {
-      return user.get('spaceGuid') === spaceGuid;
-    });
+    const inSpace = this._data.filter((user) =>
+      user.get('spaceGuid') === spaceGuid
+    );
     return inSpace.toJS();
   }
 
   getAllInOrg(orgGuid) {
-    const inOrg = this._data.filter((user) => {
-      return user.get('orgGuid') === orgGuid;
-    });
+    const inOrg = this._data.filter((user) =>
+      user.get('orgGuid') === orgGuid
+    );
     return inOrg.toJS();
   }
 

--- a/static_src/test/unit/stores/app_store.spec.js
+++ b/static_src/test/unit/stores/app_store.spec.js
@@ -1,4 +1,6 @@
 
+import Immutable from 'immutable';
+
 import '../../global_setup.js';
 
 import AppDispatcher from '../../../dispatcher.js';
@@ -11,7 +13,7 @@ describe('AppStore', function() {
   var sandbox;
 
   beforeEach(() => {
-    AppStore._data = [];
+    AppStore._data = Immutable.List();
     sandbox = sinon.sandbox.create();
   });
 
@@ -53,13 +55,28 @@ describe('AppStore', function() {
       expect(spy).toHaveBeenCalledOnce();
     });
 
+    it('should not emit a change event if data was not changed', function() {
+      var spy = sandbox.spy(AppStore, 'emitChange');
+      var app = { guid: 'asdf' };
+
+      AppStore.push(app);
+
+      AppDispatcher.handleViewAction({
+        type: appActionTypes.APP_RECEIVED,
+        app: app
+      });
+
+      expect(spy).toHaveBeenCalledOnce();
+    });
+
     it('should merge app with existing app if it exists', function() {
       var sharedGuid = 'cmadkljcsa';
 
       let existingApp = { guid: sharedGuid, name: 'adsfa' };
       let newApp = { guid: sharedGuid, instances: [{ guid: 'dfs' }] }
 
-      AppStore._data.push(existingApp);
+      AppStore.push(existingApp);
+
       expect(AppStore.get(sharedGuid)).toEqual(existingApp);
 
       AppDispatcher.handleServerAction({

--- a/static_src/test/unit/stores/base_store.spec.js
+++ b/static_src/test/unit/stores/base_store.spec.js
@@ -171,6 +171,34 @@ describe('BaseStore', () => {
     });
   });
 
+  describe('delete()', function() {
+    it('should remove items that match the guid and call .emitChange()', function () {
+      var spy = sandbox.spy(store, 'emitChange');
+      var guid = 'deleteFakeGuid';
+      store._data = Immutable.fromJS([{ guid }]);
+
+      expect(store.getAll().length).toEqual(1);
+
+      store.delete(guid);
+
+      expect(spy).toHaveBeenCalledOnce();
+      expect(store.getAll().length).toEqual(0);
+    });
+
+    it('should do nothing if the guid does not match', function () {
+      var spy = sandbox.spy(store, 'emitChange');
+      var guid = 'deleteFakeGuid';
+      store._data = Immutable.fromJS([{ guid }]);
+
+      expect(store.getAll().length).toEqual(1);
+
+      store.delete('nonExistentFakeGuid');
+
+      expect(spy).not.toHaveBeenCalledOnce();
+      expect(store.getAll().length).toEqual(1);
+    });
+  });
+
   describe('formatSplitResponse()', function() {
     var testRezs;
 
@@ -224,14 +252,15 @@ describe('BaseStore', () => {
       });
     });
 
-    it('should call cb with false when no data is updated', function () {
+    it('should call cb with false when no data is updated', function (done) {
       store.merge('guid', existingEntityA, (changed) => {
         expect(changed).toEqual(false);
+        done();
       });
     });
 
     it('should update a single existing entity with the same guid ',
-        function() {
+        function(done) {
       var updateA = {
         guid: existingEntityA.guid,
         name: 'zzz',
@@ -241,9 +270,10 @@ describe('BaseStore', () => {
       store.merge('guid', updateA, (changed) => {
         let updated = store.get(updateA.guid);
         expect(updated).toEqual(Object.assign({}, existingEntityA, updateA));
-      });
+        expect(store.get(existingEntityB.guid)).toEqual(existingEntityB);
 
-      expect(store.get(existingEntityB.guid)).toEqual(existingEntityB);
+        done();
+      });
     });
 
     it('should update a multiple existing entities with the same guids ',

--- a/static_src/test/unit/stores/base_store.spec.js
+++ b/static_src/test/unit/stores/base_store.spec.js
@@ -196,62 +196,7 @@ describe('BaseStore', () => {
     });
   });
 
-  describe('_merge()', function() {
-    var existingEntityA = {
-      guid: 'zznbmbz',
-      name: 'ea',
-      cpu: 34
-    };
-    var existingEntityB = {
-      guid: 'zzlkcxv',
-      name: 'eb'
-    };
-    var existingEntities = [existingEntityA, existingEntityB];
-
-    it('should update existing entities with updated with same guid ',
-        function() {
-      var updateA = {
-        guid: existingEntityA.guid,
-        name: 'zzz',
-        memory: 1024
-      };
-
-      let actual = store._merge(existingEntities, [updateA]);
-
-      expect(actual[0]).toEqual({
-        guid: updateA.guid,
-        name: updateA.name,
-        memory: updateA.memory,
-        cpu: existingEntityA.cpu
-      });
-      expect(actual[1]).toEqual(existingEntityB);
-    });
-
-    it('should not modify the source data', function() {
-      var clone = existingEntities.slice(0);
-      var updateA = {
-        guid: existingEntityA.guid,
-        memory: 1024
-      };
-
-      store._merge(existingEntities, [updateA]);
-
-      expect(existingEntities).toEqual(clone);
-    });
-
-    it('should return the updates if there\'s no current data', function() {
-      var updates = [
-        { guid: 'zxb', name: 'a1' },
-        { guid: 'kjl', name: 'a2' }
-      ];
-
-      let actual = store._merge([], updates);
-
-      expect(actual).toEqual(updates);
-    });
-  });
-
-  describe('merge() -- no side effects function', function() {
+  describe('merge()', function() {
     var existingEntityA = {
       guid: 'zznbmbz',
       name: 'ea',

--- a/static_src/test/unit/stores/base_store.spec.js
+++ b/static_src/test/unit/stores/base_store.spec.js
@@ -1,4 +1,6 @@
 
+import Immutable from 'immutable';
+
 import '../../global_setup.js';
 
 import BaseStore from '../../../stores/base_store.js';
@@ -76,23 +78,22 @@ describe('BaseStore', () => {
       var expectedGuid = 'adkfjlzcxv',
           expected = { guid: expectedGuid };
 
-      store._data.push(expected);
+      store.push(expected);
 
       let actual = store.get(expectedGuid);
 
       expect(actual).toEqual(expected);
     });
-    
+
     it('should returned undefined if entity with guid it doesn\'t exist',
         function() {
-      store._data = [];
       let actual = store.get('adjlfk');
 
       expect(actual).toBe(undefined);
     });
 
     it('should return undefined if not guid is passed in', function() {
-      store._data = [{ guid: 'adsf' }]; 
+      store.push({ guid: 'adsf' });
 
       let actual = store.get();
 
@@ -104,7 +105,7 @@ describe('BaseStore', () => {
     it('should get all entities if there are some', function() {
       var expected = [{ guid: 'adf' }, { guid: 'adsfjk' }];
 
-      store._data = expected;
+      expected.forEach((e) => store.push(e) );
 
       let actual = store.getAll();
 
@@ -114,11 +115,59 @@ describe('BaseStore', () => {
     });
 
     it('should return an empty array if there are no entities', function() {
-      store._data = [];
-
       let actual = store.getAll();
 
       expect(actual).toBeEmptyArray();
+    });
+  });
+
+  describe('push()', function() {
+    it('should increment the count when an item is added', function() {
+      let initialCount = store.getAll().length;
+      store.push({ guid: 'pushtest' });
+      let pushedCount = store.getAll().length;
+
+      expect(pushedCount).toEqual(initialCount + 1);
+    });
+
+    it('should convert any pushed data to immutable types', function() {
+      store.push({ guid: 'pushtest' });
+      let pushed = store._data.get(0);
+
+      expect(pushed.asImmutable).toBeDefined();
+    });
+  });
+
+  describe('dataHasChanged()', function() {
+    describe('passed regular JS objects', function() {
+      it('should return true if new data is different from _data', function() {
+        let oldData = { guid: 'pushtest'};
+        let newData = { guid: 'pushtestyetagain' };
+
+        store.push(oldData);
+
+        expect(store.dataHasChanged(newData)).toBe(true);
+      });
+
+      it('should return false if the data is the same as _data', function() {
+        let oldData = { guid: 'pushtest' };
+        let newData = Immutable.fromJS([oldData]);
+
+        store.push(oldData);
+
+        expect(store.dataHasChanged(newData)).toBe(false);
+      });
+    });
+
+    describe('passed ImmutableJS objects', function() {
+      it('should return true if new data is different from _data', function() {
+        let oldData = { guid: 'pushtest'};
+        let newData = { guid: 'pushtestyetagain' };
+
+        store.push(oldData);
+
+        expect(store.dataHasChanged(newData)).toBe(true);
+      });
     });
   });
 
@@ -147,19 +196,19 @@ describe('BaseStore', () => {
     });
   });
 
-  describe('merge()', function() {
+  describe('_merge()', function() {
     var existingEntityA = {
       guid: 'zznbmbz',
       name: 'ea',
       cpu: 34
-    }; 
+    };
     var existingEntityB = {
       guid: 'zzlkcxv',
       name: 'eb'
-    }; 
+    };
     var existingEntities = [existingEntityA, existingEntityB];
 
-    it('should update existing entities with updated with same guid ', 
+    it('should update existing entities with updated with same guid ',
         function() {
       var updateA = {
         guid: existingEntityA.guid,
@@ -199,6 +248,81 @@ describe('BaseStore', () => {
       let actual = store._merge([], updates);
 
       expect(actual).toEqual(updates);
+    });
+  });
+
+  describe('merge() -- no side effects function', function() {
+    var existingEntityA = {
+      guid: 'zznbmbz',
+      name: 'ea',
+      cpu: 34
+    };
+    var existingEntityB = {
+      guid: 'zzlkcxv',
+      name: 'eb'
+    };
+
+    beforeEach(function() {
+      store.push(existingEntityA);
+      store.push(existingEntityB);
+    });
+
+    it('should call cb with true when data is updated', function () {
+      var updateA = {
+        guid: existingEntityA.guid,
+        name: 'zzz',
+        memory: 1024
+      };
+
+      store.merge('guid', updateA, (changed) => {
+        expect(changed).toEqual(true);
+      });
+    });
+
+    it('should call cb with false when no data is updated', function () {
+      store.merge('guid', existingEntityA, (changed) => {
+        expect(changed).toEqual(false);
+      });
+    });
+
+    it('should update a single existing entity with the same guid ',
+        function() {
+      var updateA = {
+        guid: existingEntityA.guid,
+        name: 'zzz',
+        memory: 1024
+      };
+
+      store.merge('guid', updateA, (changed) => {
+        let updated = store.get(updateA.guid);
+        expect(updated).toEqual(Object.assign({}, existingEntityA, updateA));
+      });
+
+      expect(store.get(existingEntityB.guid)).toEqual(existingEntityB);
+    });
+
+    it('should update a multiple existing entities with the same guids ',
+        function() {
+      var toUpdateA = {
+        guid: existingEntityA.guid,
+        name: 'ea',
+        memory: 1024
+      };
+      var toUpdateB = {
+        guid: existingEntityB.guid,
+        name: 'eb',
+        memory: 1024
+      };
+
+      store.mergeMany('guid', [toUpdateA, toUpdateB], (changed) => {
+        expect(changed).toBeTruthy();
+
+        let updatedA = store.get(toUpdateA.guid);
+        expect(updatedA).toEqual(Object.assign({}, existingEntityA, toUpdateA));
+
+        let updatedB = store.get(toUpdateB.guid);
+        expect(updatedB).toEqual(Object.assign({}, existingEntityB, toUpdateB));
+      });
     });
   });
 });

--- a/static_src/test/unit/stores/service_instance_store.spec.js
+++ b/static_src/test/unit/stores/service_instance_store.spec.js
@@ -1,6 +1,8 @@
 
 import '../../global_setup.js';
 
+import Immutable from 'immutable';
+
 import AppDispatcher from '../../../dispatcher.js';
 import cfApi from '../../../util/cf_api.js';
 import { wrapInRes, unwrapOfRes } from '../helpers.js';
@@ -14,7 +16,7 @@ describe('ServiceInstanceStore', function() {
   var sandbox;
 
   beforeEach(() => {
-    ServiceInstanceStore._data = [];
+    ServiceInstanceStore._data = Immutable.List();
     ServiceInstanceStore._createError = null;
     sandbox = sinon.sandbox.create();
   });
@@ -25,7 +27,7 @@ describe('ServiceInstanceStore', function() {
 
   describe('constructor()', () => {
     it('should set _data to empty array', () => {
-      expect(ServiceInstanceStore._data).toBeEmptyArray();
+      expect(ServiceInstanceStore.getAll()).toBeEmptyArray();
     });
   });
 
@@ -95,7 +97,7 @@ describe('ServiceInstanceStore', function() {
 
       sandbox.stub(ServiceStore, 'get').returns(expectedService);
       sandbox.stub(ServicePlanStore, 'get').returns(expectedServicePlan);
-      
+
       serviceActions.createInstanceForm('adfkjvnzxczv', 'aldsfjalqwe');
 
       let actual = ServiceInstanceStore.createInstanceForm;
@@ -157,7 +159,7 @@ describe('ServiceInstanceStore', function() {
     it('should add received instance to the data', function() {
       var expectedInstance = { guid: 'asdf9a8fasss' };
 
-      ServiceInstanceStore._data.push({ guid: 'zzxcvz' });
+      ServiceInstanceStore.push({ guid: 'zzxcvz' });
 
       serviceActions.createdInstance(expectedInstance);
 
@@ -215,7 +217,7 @@ describe('ServiceInstanceStore', function() {
           expectedGuid = 'qp98wfj',
           expected = { guid: expectedGuid, url: '/' + expectedGuid };
 
-      ServiceInstanceStore._data.push(expected);
+      ServiceInstanceStore.push(expected);
 
       AppDispatcher.handleViewAction({
         type: serviceActionTypes.SERVICE_INSTANCE_DELETE,
@@ -233,7 +235,7 @@ describe('ServiceInstanceStore', function() {
       var expectedGuid = 'macldksajpi',
           expected = { guid: expectedGuid, url: '/' + expectedGuid };
 
-      ServiceInstanceStore._data.push(expected);
+      ServiceInstanceStore.push(expected);
 
       expect(ServiceInstanceStore.get(expectedGuid)).toEqual(expected);
 
@@ -250,7 +252,7 @@ describe('ServiceInstanceStore', function() {
       var expectedGuid = 'macldksajpi',
           expected = { guid: expectedGuid, url: '/' + expectedGuid };
 
-      ServiceInstanceStore._data.push(expected);
+      ServiceInstanceStore._data = Immutable.fromJS([expected]);
 
       AppDispatcher.handleServerAction({
         type: serviceActionTypes.SERVICE_INSTANCE_DELETED,
@@ -265,7 +267,7 @@ describe('ServiceInstanceStore', function() {
 
       AppDispatcher.handleServerAction({
         type: serviceActionTypes.SERVICE_INSTANCE_DELETED,
-        serviceInstanceGuid: 'adsfas' 
+        serviceInstanceGuid: 'adsfas'
       });
 
       expect(spy).not.toHaveBeenCalled();

--- a/static_src/test/unit/stores/service_plan_store.spec.js
+++ b/static_src/test/unit/stores/service_plan_store.spec.js
@@ -1,6 +1,8 @@
 
 import '../../global_setup.js';
 
+import Immutable from 'immutable';
+
 import AppDispatcher from '../../../dispatcher.js';
 import cfApi from '../../../util/cf_api.js';
 import { wrapInRes, unwrapOfRes } from '../helpers.js';
@@ -12,7 +14,7 @@ describe('ServicePlanStore', function() {
   var sandbox;
 
   beforeEach(() => {
-    ServicePlanStore._data = [];
+    ServicePlanStore._data = Immutable.List();
     sandbox = sinon.sandbox.create();
   });
 
@@ -22,7 +24,7 @@ describe('ServicePlanStore', function() {
 
   describe('constructor()', () => {
     it('should set _data to empty array', () => {
-      expect(ServicePlanStore._data).toBeEmptyArray();
+      expect(ServicePlanStore.getAll()).toBeEmptyArray();
     });
   });
 
@@ -36,8 +38,8 @@ describe('ServicePlanStore', function() {
       ];
       let unexpectedService = { service_guid: 'zxklcjv', guid: 'qwpoerui' };
 
-      ServicePlanStore._data = ServicePlanStore._data.concat(expectedServices);
-      ServicePlanStore._data.push(unexpectedService);
+      ServicePlanStore._data = Immutable.fromJS(expectedServices);
+      ServicePlanStore.push(unexpectedService);
 
       let actual = ServicePlanStore.getAllFromService(expectedServiceGuid);
 
@@ -70,7 +72,7 @@ describe('ServicePlanStore', function() {
       let existing = { guid: 'alkdjsfzxcv' };
 
       let testRes = wrapInRes(expected);
-      ServicePlanStore._data.push(existing);
+      ServicePlanStore.push(existing);
 
       serviceActions.receivedPlans(testRes);
 
@@ -104,7 +106,7 @@ describe('ServicePlanStore', function() {
     it('should do nothing if there are no service plans', function() {
       var spy = sandbox.spy(ServicePlanStore, 'emitChange');
 
-      ServicePlanStore._data = [{ guid: 'adsfklj'}];
+      ServicePlanStore._data = Immutable.fromJS([{ guid: 'adsfklj'}]);
 
       serviceActions.receivedPlans();
 
@@ -121,4 +123,3 @@ describe('ServicePlanStore', function() {
     });
   });
 });
-

--- a/static_src/test/unit/stores/space_store.spec.js
+++ b/static_src/test/unit/stores/space_store.spec.js
@@ -1,40 +1,42 @@
 
 import '../../global_setup.js';
 
+import Immutable from 'immutable';
+
 import AppDispatcher from '../../../dispatcher.js';
 import { wrapInRes, unwrapOfRes } from '../helpers.js';
 import orgActions from '../../../actions/org_actions.js';
+import spaceActions from '../../../actions/space_actions.js';
 import SpaceStore from '../../../stores/space_store.js';
-import { spaceActionTypes } from '../../../constants';
 
-describe('SpaceStore', () => {
+describe('SpaceStore', function() {
   var sandbox;
 
-  beforeEach(() => {
-    SpaceStore._data = [];
+  beforeEach(function() {
     sandbox = sinon.sandbox.create();
+    SpaceStore._data = Immutable.List();
   });
 
-  afterEach(() => {
+  afterEach(function() {
     sandbox.restore();
   });
 
-  describe('constructor()', () => {
+  describe('constructor()', function() {
     it('should set _data to empty array', () => {
-      expect(SpaceStore._data).toBeEmptyArray();
+      expect(SpaceStore.getAll()).toBeEmptyArray();
     });
   });
 
   describe('on org actions org received', function() {
     it('should merge the org spaces data in with any current spaces', function() {
-      var expectedSpace = { guid: 'adfadsbcvbqwrsdfadsf32' },
-          existingSpace = { guid: 'xczczxczczxcv2' };
+      var expectedSpace = { guid: 'adfadsbcvbqwrsdfadsf32' };
+      var existingSpace = { guid: 'xczczxczczxcv2' };
       var org = {
         guid: 'adsfadzcxvzdfaew',
         spaces: [expectedSpace]
       };
 
-      SpaceStore._data.push(existingSpace);
+      SpaceStore.push(existingSpace);
       orgActions.receivedOrg(org);
 
       expect(SpaceStore.getAll().length).toEqual(2);
@@ -43,11 +45,34 @@ describe('SpaceStore', () => {
 
     it('should emit a change event if there are spaces', function() {
       var spy = sandbox.spy(SpaceStore, 'emitChange');
+      const testGuid = 'adfadsafdacxvx';
 
-      orgActions.receivedOrg({ guid: 'adfadsafdacxvx', spaces: [{}]});
-      orgActions.receivedOrg({ guid: 'adfadsafdacxvx'});
+      orgActions.receivedOrg({ guid: testGuid, spaces: [{}]});
+      orgActions.receivedOrg({ guid: testGuid });
 
       expect(spy).toHaveBeenCalledOnce();
     });
+  });
+
+  describe('on space actions space received', function() {
+    it('should not emit a change event if data is the same', function() {
+      let space = { guid: 'testSpaceGuid' };
+      let spy = sandbox.spy(SpaceStore, 'emitChange');
+
+      SpaceStore._data = Immutable.fromJS([space]);
+
+      spaceActions.receivedSpace(space);
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('should emit a change event if new data is present', function () {
+      let space = { guid: 'testSpaceGuid' };
+      let spy = sandbox.spy(SpaceStore, 'emitChange');
+
+      spaceActions.receivedSpace(space);
+
+      expect(spy).toHaveBeenCalledOnce();
+    })
   });
 });

--- a/static_src/test/unit/util/cf_api.spec.js
+++ b/static_src/test/unit/util/cf_api.spec.js
@@ -2,6 +2,7 @@
 import '../../global_setup.js';
 
 import http from 'axios';
+import Immutable from 'immutable';
 
 import appActions from '../../../actions/app_actions.js';
 import cfApi from '../../../util/cf_api.js';
@@ -29,7 +30,7 @@ describe('cfApi', function() {
       errorFetchRes = { message: 'error' };
 
   beforeEach(() => {
-    OrgStore._data = [];
+    OrgStore._data = new Immutable.List();
     sandbox = sinon.sandbox.create();
   });
 


### PR DESCRIPTION
This PR should change all stores so that the underlying data they maintain is kept in immutable data structures using [Immutable.JS](facebook.github.io/immutable-js). This was done in a way that only stores need to be concerned with keeping their data structure in immutable types and that any components that get data from those stores are still working with plain JavaScript objects. I've been casually calling this the "immutable barrier". The stores are implemented so that anything returned from a method that begins with `get` such as `getAll()` will convert the immutable data back to regular JS objects before returning them.

I also changed the API of the BaseStore a bit to make dealing with immutable data a bit easier. For example, I added a [`.push()`](https://github.com/18F/cg-deck/blob/0e57e66b12a5719bad4385ec7509e8de7d99384d/static_src/stores/base_store.js#L31-L37) method which takes an argument, converts it to the respective immutable data type and then creates a new list with that item pushed on and sets that array to be `_data` on the store. It also emits a change event as the underlying data has changed.

One of the benefits of using immutability is that we can easily compare nested objects for sameness. This means that we can quickly/cheaply do checks to see if data has changed or not and act accordingly. I added [`dataHasChanged()`](https://github.com/18F/cg-deck/blob/0e57e66b12a5719bad4385ec7509e8de7d99384d/static_src/stores/base_store.js#L53-L56) to the BaseStore which returns a boolean. This gives every store the ability to only emit change events when the data has actually changed. It also provides an interface for components to be able to use the fast equality checking of immutable data types without having to know about them.

I also added two new merge functions that account for the fact that the data is immutable. A nice benefit is that these merges no longer have unexpected side effects. There are [two new merge APIs](https://github.com/18F/cg-deck/blob/0e57e66b12a5719bad4385ec7509e8de7d99384d/static_src/stores/base_store.js#L106-L141) that have very similar function signatures:

* `merge(mergeKey, dataToMerge, optionalCallback)`
* `mergeMany(mergeKey, arrayOfDataToMerge, optionalCallback)`

Each takes three arguments, with the last being an optional callback. The first argument is the key by which to identify similar objects and merge them (generally speaking this is `guid` in our project), the data to merge in, and a callback that is passed `true` or `false` depending on if there was any data that changed. `merge` takes a single object as the data to merge and `mergeMany` takes an array of objects. By default, the callback will call `this.emitChange()` if there is a data change.

Open questions (probably for @msecret):

0. Many of our APIs in this project are promised-based instead of callbacks. For example, all the methods in `cfApi` return promises instead of using callbacks. I wrote the initial version of these merge functions to use callbacks instead of returning a promise, but it might be best to be consistent and use promises throughout. What do you think?
0. Can we remove [`_merge()`](https://github.com/18F/cg-deck/blob/0e57e66b12a5719bad4385ec7509e8de7d99384d/static_src/stores/base_store.js#L77-L90) now that we have these new methods? It doesn't look like its being used at all anymore.