### PR TITLE
Use login/logout link the global navigation

### DIFF
--- a/static_src/components/header.jsx
+++ b/static_src/components/header.jsx
@@ -1,6 +1,8 @@
 
 import React from 'react';
 
+import LoginStore from '../stores/login_store.js';
+
 import createStyler from '../util/create_styler';
 
 import headerStyle from 'cloudgov-style/css/components/header.css';
@@ -20,6 +22,8 @@ export default class Header extends React.Component {
   }
 
   render() {
+    const loggedIn = LoginStore.isLoggedIn();
+    let loginLink = (!loggedIn) ? <a href="/handshake">Login</a> : <a href="/v2/logout">Logout</a>;
     return (
     <header className={ this.styler('header') }>
       <div className={ this.styler('header-wrap') }>
@@ -50,6 +54,9 @@ export default class Header extends React.Component {
             </li>
             <li className={ this.styler('nav-link') }>
               <a href="https://cloud.gov/#contact">Contact</a>
+            </li>
+            <li className={ this.styler('nav-link') }>
+              { loginLink }
             </li>
           </ul>
         </nav>


### PR DESCRIPTION
Quick sketch of what using a header link for login/logout might look like in the global nav. I substituted the previous "Deck" link with a link at the far right of the navigation because user testing revealed that the "Deck" link was of very little value to users.

The link will be "Login" when the user is not yet authenticated and "Logout" when the user is properly authenticated.

Screenshots:

Logged out:
![](https://s3.amazonaws.com/f.cl.ly/items/0w3j0J3v0W1A42322w0t/Screen%20Shot%202016-05-27%20at%205.39.54%20PM.png?v=95176ffd)

Logged in:
![](https://s3.amazonaws.com/f.cl.ly/items/123V10181A3j381u3o1d/Screen%20Shot%202016-05-27%20at%205.40.36%20PM.png?v=6b2a0922)

Refs #179 