### PR TITLE
Add links for Logs and Events

### DIFF
--- a/static_src/components/app_page.jsx
+++ b/static_src/components/app_page.jsx
@@ -29,13 +29,20 @@ export default class AppPage extends React.Component {
     });
   }
 
+  logsLink(appName) {
+    return `https://logs.cloud.gov/app/kibana#/dashboard/App-Overview?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now%2Fy,mode:quick,to:now))&_a=(filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:%5Blogs-app-%5DYYYY.MM.DD,key:'@source.app.name',negate:!f,value:${appName}),query:(match:('@source.app.name':(query:${appName},type:phrase))))),options:(darkTheme:!f),panels:!((col:1,id:App-logs-by-type,panelIndex:1,row:1,size_x:9,size_y:2,type:visualization),(col:10,id:App-names,panelIndex:2,row:1,size_x:3,size_y:2,type:visualization),(col:1,columns:!('@level','@source.name','@source.app.name','@message'),id:app-all,panelIndex:3,row:3,size_x:12,size_y:7,sort:!('@timestamp',desc),type:search)),query:(query_string:(analyze_wildcard:!t,query:'*')),title:'App%20-%20Overview',uiState:(P-1:(spy:(mode:(fill:!f,name:!n))),P-2:(spy:(mode:(fill:!f,name:!n)))))`;
+  }
+
+  eventsLink(appName) {
+    return `https://logs.cloud.gov/app/kibana?#/dashboard/App-Events?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now%2Fy,mode:quick,to:now))&_a=(filters:!(),options:(darkTheme:!f),panels:!((col:1,columns:!(app_event.app_name,'@message',app_event.actor_type,app_event.actor_name,app_event.actee_type,app_event.actee_name),id:AppEvent,panelIndex:1,row:3,size_x:12,size_y:6,sort:!('@timestamp',desc),type:search),(col:1,id:App-events,panelIndex:2,row:1,size_x:12,size_y:2,type:visualization)),query:(query_string:(analyze_wildcard:!t,query:'app_event.app_name:%20${appName}')),title:'App%20-%20Events',uiState:())`;
+  }
+
   formatMb(bytes) {
     return Math.round(bytes / 1000000);
   }
 
   render() {
     let content = <h4 className="test-none_message">No app</h4>;
-
     if (this.state.app.name) {
       content = (
         <div>
@@ -90,16 +97,26 @@ export default class AppPage extends React.Component {
               </p>
             </aside>
           </section>
-
-          <h3>Routes</h3>
-          <RouteList initialAppGuid={ this.state.app.guid } />
-
-          <h3>Services</h3>
-          <p>To bind or unbind a service instance to an app view<a
-            href="https://docs.cloud.gov/apps/managed-services/#bind-the-service-instance"
-            target="_blank">
-            <span>&nbsp;</span>managed services guide</a> for more information.
-          </p>
+          <section>
+            <h3>Routes</h3>
+            <RouteList initialAppGuid={ this.state.app.guid } />
+          </section>
+          <section>
+            <h3>Services</h3>
+            <p>To bind or unbind a service instance to an app view<a
+              href="https://docs.cloud.gov/apps/managed-services/#bind-the-service-instance"
+              target="_blank">
+              <span>&nbsp;</span>managed services guide</a> for more information.
+            </p>
+          </section>
+          <section>
+            <h3>Events</h3>
+            <p>Event are currently available at <a href={ this.eventsLink(this.state.app.name) }>logs.cloud.gov</a></p>
+          </section>
+          <section>
+            <h3>Logs</h3>
+            <p>Logs are currently available at <a href={ this.logsLink(this.state.app.name) }>logs.cloud.gov</a></p>
+          </section>
         </div>
       );
     }
@@ -115,4 +132,3 @@ export default class AppPage extends React.Component {
 AppPage.propTypes = {
   initialAppGuid: React.PropTypes.string.isRequired
 };
-


### PR DESCRIPTION
This PR adds a link for the current logs view of the application. There is no way to embed an iframe until we resolve 18F/logsearch-for-cloudfoundry#5, so in the meantime we are using plain links to direct users to the proper places on logs.cloud.gov. Screenshot:
![](https://s3.amazonaws.com/f.cl.ly/items/0K2E3b1c222p0V2P0Q2i/Screen%20Shot%202016-05-31%20at%203.32.31%20PM.png?v=571a6685)

Right now, the "Logs" link works but I'm having issues with the "Events" link. I'm not quite sure what it should link to. When I follow @mogul's instructions I get an empty dashboard. Screenshot: ![](https://s3.amazonaws.com/f.cl.ly/items/2v1I1e0X2f3n281G2u3M/Screen%20Shot%202016-05-31%20at%203.31.15%20PM.png?v=32de5d83)
The instructions I am referencing are:

0. Load logs.cloud.gov
0. Select "Load Saved Dashboard"
0. Select "App - Events"
0. No results found

Refs #289 