### PR TITLE
Add GA to track pageviews

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -47,5 +47,22 @@
 			<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
 			<script src="bower_components/bootstrap/dist/js/bootstrap.min.js"></script>
 		</div>
+		<script>
+		  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+		  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+		  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+		  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+		  ga('create', 'UA-48605964-34', 'auto');
+		  ga('send', 'pageview');
+		</script>
+		<script>
+			window.addEventListener('hashchange', function(e) {
+				ga('send', {
+				  hitType: 'pageview',
+				  page: e.target.location.hash
+				});
+			});
+		</script>
 	</body>
 </html>


### PR DESCRIPTION
Added GA to track views on the deck. I also added a `hashchange` event listener to post synthetic page view events as the URL changes.

My only concern with this approach is that URLs from this app and the react app (`staging-alpha` branch work) will have similar URLs and it might not be possible for us to determine if an event comes from one or the other. I assume there is a way to filter based on domain/subdomain in Google Analytics (I have verified that the domain goes to GA along with the tracking call), but I haven't figured that out yet.

Refs #265