### PR TITLE
Fix broken table management on org users

### DIFF
--- a/static_src/components/user_list.jsx
+++ b/static_src/components/user_list.jsx
@@ -56,6 +56,7 @@ export default class UserList extends React.Component {
       content = (
       <table sortable={ true }>
         <thead>
+          <tr>
           { this.columns.map((column) => {
             return (
               <th column={ column.label } className={ column.key }
@@ -63,6 +64,7 @@ export default class UserList extends React.Component {
                 { column.label }</th>
             )
           })}
+          </tr>
         </thead>
         <tbody>
         { this.state.users.map((user) => {


### PR DESCRIPTION
Was broken due to lack of a `<tr>` tag wrapping the `<th>` elements.

Ref #312