### PR TITLE
Remove .bowerrc

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,0 @@
-{
-  "directory": "static/bower_components"
-}


### PR DESCRIPTION
We are no longer using bower for front end dependency management so I removed the related files.