### PR TITLE
Enable ability to click label on user role list

### DIFF
--- a/static_src/components/user_role_control.jsx
+++ b/static_src/components/user_role_control.jsx
@@ -22,11 +22,12 @@ export default class UserRoleControl extends React.Component {
   render() {
     return (
       <span>
-        <label htmlFor={ this.props.roleKey }>
+        <label htmlFor={ this.props.roleKey + this.props.userId }>
           <input type="checkbox"
             onChange={ this._handleChange }
             name={ this.props.roleKey }
             checked={ this.state.checked }
+            id={ this.props.roleKey + this.props.userId }
           />
           { this.props.roleName }
         </label>

--- a/static_src/components/user_role_list_control.jsx
+++ b/static_src/components/user_role_list_control.jsx
@@ -58,6 +58,7 @@ export default class UserRoleListControl extends React.Component {
               roleKey={ role.key }
               initialValue={ this.checkRole(role.key) }
               onChange={ this._onChange.bind(this, role.key) }
+              userId={ this.props.user.guid }
             />
           </span>
         );


### PR DESCRIPTION
This PR adds a unique ID for each role checkbox and enables the `checked` value on label click.

## Before
![a6iztwbzps](https://cloud.githubusercontent.com/assets/955558/15964355/217ba980-2ee6-11e6-9359-bec9573aaf89.gif)

## After
![p2elffcizl](https://cloud.githubusercontent.com/assets/955558/15964365/2e561d52-2ee6-11e6-9ef2-074ca554f19d.gif)