### PR TITLE
Ms service delete confirmation

### DIFF
--- a/static_src/actions/service_actions.js
+++ b/static_src/actions/service_actions.js
@@ -90,6 +90,13 @@ export default {
     });
   },
 
+  deleteInstanceCancel(instanceGuid) {
+    AppDispatcher.handleUIAction({
+      type: serviceActionTypes.SERVICE_INSTANCE_DELETE_CANCEL,
+      serviceInstanceGuid: instanceGuid
+    });
+  },
+
   deleteInstance(instanceGuid) {
     AppDispatcher.handleViewAction({
       type: serviceActionTypes.SERVICE_INSTANCE_DELETE,

--- a/static_src/actions/service_actions.js
+++ b/static_src/actions/service_actions.js
@@ -83,6 +83,13 @@ export default {
     });
   },
 
+  deleteInstanceConfirm(instanceGuid) {
+    AppDispatcher.handleUIAction({
+      type: serviceActionTypes.SERVICE_INSTANCE_DELETE_CONFIRM,
+      serviceInstanceGuid: instanceGuid
+    });
+  },
+
   deleteInstance(instanceGuid) {
     AppDispatcher.handleViewAction({
       type: serviceActionTypes.SERVICE_INSTANCE_DELETE,

--- a/static_src/components/button.jsx
+++ b/static_src/components/button.jsx
@@ -23,7 +23,8 @@ export default class Button extends React.Component {
     var classes = classNames(...this.props.classes);
     return (
       <button type="button" className={ classes }
-          aria-label={ this.props.label } onClick={ this._handleClick }>
+          aria-label={ this.props.label } onClick={ this._handleClick }
+          disabled={this.props.disabled}>
         { this.props.children }
       </button>
     );
@@ -33,11 +34,13 @@ export default class Button extends React.Component {
 Button.propTypes = {
   classes: React.PropTypes.array,
   label: React.PropTypes.string,
-  onClickHandler: React.PropTypes.func
+  onClickHandler: React.PropTypes.func,
+  disabled: React.PropTypes.boolean
 };
 
 Button.defaultProps = {
   classes: [],
   label: '',
-  onClickHandler: function() { return true; }
+  onClickHandler: function() { return true; },
+  disabled: false
 };

--- a/static_src/components/confirmation_box.jsx
+++ b/static_src/components/confirmation_box.jsx
@@ -31,7 +31,11 @@ export default class ConfirmationBox extends React.Component {
 
   render() {
     return (
+<<<<<<< HEAD
       <div className={ this.styler('actions-confirm') }>
+=======
+      <div className={ this.styler('action_box') }>
+>>>>>>> Service isntance delete confirmation
         <Button label="Confirm"
             classes={[this.styler("usa-button-secondary")]}
             onClickHandler={ this._confirmHandler }>

--- a/static_src/components/confirmation_box.jsx
+++ b/static_src/components/confirmation_box.jsx
@@ -1,0 +1,57 @@
+
+/**
+ * A component that renders a box with a different style and background
+ */
+
+import React from 'react';
+
+import createStyler from '../util/create_styler';
+import actionBoxStyles from 'cloudgov-style/css/components/action_box.css';
+import baseStyles from 'cloudgov-style/css/base.css';
+
+import Button from './button.jsx';
+
+export default class ConfirmationBox extends React.Component {
+  constructor(props) {
+    super(props);
+    this.props = props;
+    this.state = {};
+    this.styler = createStyler(actionBoxStyles, baseStyles);
+    this._confirmHandler = this._confirmHandler.bind(this);
+    this._cancelHandler = this._cancelHandler.bind(this);
+  }
+
+  _confirmHandler(ev) {
+    this.props.confirmHandler(ev);
+  }
+
+  _cancelHandler(ev) {
+    this.props.cancelHandler(ev);
+  }
+
+  render() {
+    return (
+      <div className={ this.styler('action_box') }>
+        <Button label="Confirm"
+            classes={[this.styler("usa-button-secondary")]}
+            onClickHandler={ this._confirmHandler }>
+          <span>Confirm delete</span>
+        </Button>
+        <Button label="cancel"
+            classes={[this.styler("usa-button-outline")]}
+            onClickHandler={ this._cancelHandler }>
+          <span>Cancel</span>
+        </Button>
+      </div>
+    );
+  }
+}
+ConfirmationBox.propTypes = {
+  confirmHandler: React.PropTypes.func.isRequired,
+  cancelHandler: React.PropTypes.func.isRequired
+};
+ConfirmationBox.defaultProps = {
+  confirmHandler: (ev) => { console.log('confirm ev', ev); },
+  cancelHandler: (ev) => { console.log('cancel ev', ev); }
+};
+

--- a/static_src/components/confirmation_box.jsx
+++ b/static_src/components/confirmation_box.jsx
@@ -6,7 +6,7 @@
 import React from 'react';
 
 import createStyler from '../util/create_styler';
-import actionBoxStyles from 'cloudgov-style/css/components/action_box.css';
+import actionStyles from 'cloudgov-style/css/components/actions.css';
 import baseStyles from 'cloudgov-style/css/base.css';
 
 import Button from './button.jsx';
@@ -16,7 +16,7 @@ export default class ConfirmationBox extends React.Component {
     super(props);
     this.props = props;
     this.state = {};
-    this.styler = createStyler(actionBoxStyles, baseStyles);
+    this.styler = createStyler(actionStyles, baseStyles);
     this._confirmHandler = this._confirmHandler.bind(this);
     this._cancelHandler = this._cancelHandler.bind(this);
   }
@@ -31,7 +31,7 @@ export default class ConfirmationBox extends React.Component {
 
   render() {
     return (
-      <div className={ this.styler('action_box') }>
+      <div className={ this.styler('actions-confirm') }>
         <Button label="Confirm"
             classes={[this.styler("usa-button-secondary")]}
             onClickHandler={ this._confirmHandler }>

--- a/static_src/components/confirmation_box.jsx
+++ b/static_src/components/confirmation_box.jsx
@@ -31,11 +31,7 @@ export default class ConfirmationBox extends React.Component {
 
   render() {
     return (
-<<<<<<< HEAD
       <div className={ this.styler('actions-confirm') }>
-=======
-      <div className={ this.styler('action_box') }>
->>>>>>> Service isntance delete confirmation
         <Button label="Confirm"
             classes={[this.styler("usa-button-secondary")]}
             onClickHandler={ this._confirmHandler }>

--- a/static_src/components/service_instance_list.jsx
+++ b/static_src/components/service_instance_list.jsx
@@ -9,6 +9,7 @@ import baseStyle from 'cloudgov-style/css/base.css';
 import tableStyles from 'cloudgov-style/css/base.css';
 
 import Button from './button.jsx';
+import ConfirmationBox from './confirmation_box.jsx';
 import serviceActions from '../actions/service_actions.js';
 import ServiceInstanceStore from '../stores/service_instance_store.js';
 
@@ -83,13 +84,16 @@ export default class ServiceInstanceList extends React.Component {
                   { formatDateTime(lastOpTime) }
                 </Td>
                 <Td column="Delete">
-                  <Button
-                    classes={ ["test-delete_instance",
-                      this.styler("usa-button-secondary")] }
-                    onClickHandler={ this._handleDelete.bind(this, instance.guid)}
-                    label="delete">
-                    <span>Delete Instance</span>
-                  </Button>
+                  <span>
+                    <Button
+                      classes={ ["test-delete_instance",
+                        this.styler("usa-button-secondary")] }
+                      onClickHandler={ this._handleDelete.bind(this, instance.guid)}
+                      label="delete">
+                      <span>Delete Instance</span>
+                    </Button>
+                    <ConfirmationBox />
+                  </span>
                 </Td>
               </Tr>
             )

--- a/static_src/components/service_instance_list.jsx
+++ b/static_src/components/service_instance_list.jsx
@@ -1,6 +1,5 @@
 
 import React from 'react';
-import Reactable from 'reactable';
 
 import formatDateTime from '../util/format_date';
 
@@ -12,12 +11,6 @@ import Button from './button.jsx';
 import ConfirmationBox from './confirmation_box.jsx';
 import serviceActions from '../actions/service_actions.js';
 import ServiceInstanceStore from '../stores/service_instance_store.js';
-
-const Table = Reactable.Table;
-const Thead = Reactable.Thead;
-const Th = Reactable.Th;
-const Tr = Reactable.Tr;
-const Td = Reactable.Td;
 
 function stateSetter(props) {
   return {
@@ -83,37 +76,45 @@ export default class ServiceInstanceList extends React.Component {
 
   render() {
     let content = <h4 className="test-none_message">No service instances</h4>;
+    const specialtdStyles = {
+      whiteSpace: 'nowrap',
+      width: '25%'
+    };
 
     if (this.state.serviceInstances.length) {
       content = (
-        <Table sortable={ true }>
-          <Thead>
+        <table>
+          <thead>
+            <tr>
             { this.columns.map((column) => {
               return (
-                <Th column={ column.label } className={ column.key }
+                <th column={ column.label } className={ column.key }
                     key={ column.key }>
-                  { column.label }</Th>
+                  { column.label }</th>
               )
             })}
-          </Thead>
+            </tr>
+          </thead>
+          <tbody>
           { this.state.serviceInstances.map((instance) => {
             const lastOp = instance.last_operation;
             const lastOpTime = lastOp.updated_at || lastOp.created_at;
             return (
-              <Tr key={ instance.guid }>
-                <Td column="Name"><span>{ instance.name }</span></Td>
-                <Td column="Last operation">{ instance.last_operation.type }</Td>
-                <Td column="Updated at">
+              <tr key={ instance.guid }>
+                <td column="Name"><span>{ instance.name }</span></td>
+                <td column="Last operation">{ instance.last_operation.type }</td>
+                <td column="Updated at">
                   { formatDateTime(lastOpTime) }
-                </Td>
-                <Td column="Delete">
+                </td>
+                <td column="Delete" style={specialtdStyles}>
                   <span>
                     <div style={{float: 'left'}}>
                       <Button
                         classes={ ["test-delete_instance",
-                          this.styler("usa-button-secondary")] }
+                                  this.styler("usa-button-secondary")] }
                         onClickHandler={ this._handleDeleteConfirmation.bind(
                             this, instance.guid)}
+                        disabled={instance.confirmDelete}
                         label="delete">
                         <span>Delete Instance</span>
                       </Button>
@@ -121,11 +122,12 @@ export default class ServiceInstanceList extends React.Component {
                     { (instance.confirmDelete) ? this.renderConfirmationBox(
                       instance.guid) : '' }
                   </span>
-                </Td>
-              </Tr>
-            )
-          })}
-        </Table>
+                </td>
+              </tr>
+              )
+            })}
+          </tbody>
+        </table>
       );
     }
 

--- a/static_src/components/service_instance_list.jsx
+++ b/static_src/components/service_instance_list.jsx
@@ -111,7 +111,10 @@ export default class ServiceInstanceList extends React.Component {
                     <div style={{float: 'left'}}>
                       <Button
                         classes={ ["test-delete_instance",
-                                  this.styler("usa-button-secondary")] }
+                          (instance.confirmDelete) ?
+                          '' : this.styler("usa-button-secondary"),
+                          (instance.confirmDelete) ?
+                            this.styler('usa-button-disabled') : '']}
                         onClickHandler={ this._handleDeleteConfirmation.bind(
                             this, instance.guid)}
                         disabled={instance.confirmDelete}

--- a/static_src/components/service_instance_list.jsx
+++ b/static_src/components/service_instance_list.jsx
@@ -33,7 +33,10 @@ export default class ServiceInstanceList extends React.Component {
     this.state = stateSetter(props);
     this._onChange = this._onChange.bind(this);
     this._handleDelete = this._handleDelete.bind(this);
-    this.styler = createStyler(baseStyle, tableStyles);
+    this._handleDeleteConfirmation = this._handleDeleteConfirmation.bind(this);
+    this._handleDeleteCancel = this._handleDeleteCancel.bind(this);
+    this.renderConfirmationBox = this.renderConfirmationBox.bind(this);
+    this.styler = createStyler(baseStyle);
   }
 
   componentDidMount() {
@@ -50,6 +53,16 @@ export default class ServiceInstanceList extends React.Component {
     serviceActions.deleteInstance(instanceGuid);
   }
 
+  _handleDeleteConfirmation(instanceGuid, ev) {
+    ev.preventDefault();
+    serviceActions.deleteInstanceConfirm(instanceGuid);
+  }
+
+  _handleDeleteCancel(instanceGuid, ev) {
+    ev.preventDefault();
+    serviceActions.deleteInstanceCancel(instanceGuid);
+  }
+
   get columns() {
     return [
       { label: 'Name', key: 'name' },
@@ -57,6 +70,15 @@ export default class ServiceInstanceList extends React.Component {
       { label: 'Updated at', key: 'updated_at' },
       { label: 'Delete', key: 'delete_istance' }
     ];
+  }
+
+  renderConfirmationBox(instanceGuid) {
+    return (
+      <ConfirmationBox
+        confirmHandler={ this._handleDelete.bind(this, instanceGuid) }
+        cancelHandler={ this._handleDeleteCancel.bind(this, instanceGuid) }
+      />
+    );
   }
 
   render() {
@@ -68,7 +90,8 @@ export default class ServiceInstanceList extends React.Component {
           <Thead>
             { this.columns.map((column) => {
               return (
-                <Th column={ column.label } className={ column.key }>
+                <Th column={ column.label } className={ column.key }
+                    key={ column.key }>
                   { column.label }</Th>
               )
             })}
@@ -85,14 +108,18 @@ export default class ServiceInstanceList extends React.Component {
                 </Td>
                 <Td column="Delete">
                   <span>
-                    <Button
-                      classes={ ["test-delete_instance",
-                        this.styler("usa-button-secondary")] }
-                      onClickHandler={ this._handleDelete.bind(this, instance.guid)}
-                      label="delete">
-                      <span>Delete Instance</span>
-                    </Button>
-                    <ConfirmationBox />
+                    <div style={{float: 'left'}}>
+                      <Button
+                        classes={ ["test-delete_instance",
+                          this.styler("usa-button-secondary")] }
+                        onClickHandler={ this._handleDeleteConfirmation.bind(
+                            this, instance.guid)}
+                        label="delete">
+                        <span>Delete Instance</span>
+                      </Button>
+                    </div>
+                    { (instance.confirmDelete) ? this.renderConfirmationBox(
+                      instance.guid) : '' }
                   </span>
                 </Td>
               </Tr>

--- a/static_src/components/user_list.jsx
+++ b/static_src/components/user_list.jsx
@@ -7,9 +7,6 @@ import React from 'react';
 
 import formatDateTime from '../util/format_date';
 
-import createStyler from '../util/create_styler';
-import baseStyle from 'cloudgov-style/css/base.css';
-
 import Button from './button.jsx';
 import UserRoleListControl from './user_role_list_control.jsx';
 

--- a/static_src/components/user_list.jsx
+++ b/static_src/components/user_list.jsx
@@ -13,6 +13,9 @@ import baseStyle from 'cloudgov-style/css/base.css';
 import Button from './button.jsx';
 import UserRoleListControl from './user_role_list_control.jsx';
 
+import createStyler from '../util/create_styler';
+import tableStyles from 'cloudgov-style/css/base.css';
+
 export default class UserList extends React.Component {
   constructor(props) {
     super(props);
@@ -20,7 +23,7 @@ export default class UserList extends React.Component {
     this.state = {
       users: props.initialUsers
     };
-    this.styler = createStyler(baseStyle);
+    this.styler = createStyler(tableStyles);
     this._handleDelete = this._handleDelete.bind(this);
   }
 

--- a/static_src/constants.js
+++ b/static_src/constants.js
@@ -47,6 +47,8 @@ const serviceActionTypes = keymirror({
   SERVICE_PLANS_FETCH: null,
   // Action when all service plans for a service were received from the server.
   SERVICE_PLANS_RECEIVED: null,
+  // Action to decide whether to delete a single service instance.
+  SERVICE_INSTANCE_DELETE_CONFIRM: null,
   // Action to delete a single service instance.
   SERVICE_INSTANCE_DELETE: null,
   // Action when a single service instance was deleted on the server.

--- a/static_src/constants.js
+++ b/static_src/constants.js
@@ -49,6 +49,8 @@ const serviceActionTypes = keymirror({
   SERVICE_PLANS_RECEIVED: null,
   // Action to decide whether to delete a single service instance.
   SERVICE_INSTANCE_DELETE_CONFIRM: null,
+  // Action to decide whether to cancel deletion of a single service instance.
+  SERVICE_INSTANCE_DELETE_CANCEL: null,
   // Action to delete a single service instance.
   SERVICE_INSTANCE_DELETE: null,
   // Action when a single service instance was deleted on the server.

--- a/static_src/stores/service_instance_store.js
+++ b/static_src/stores/service_instance_store.js
@@ -93,6 +93,21 @@ class ServiceInstanceStore extends BaseStore {
         break;
       }
 
+      case serviceActionTypes.SERVICE_INSTANCE_DELETE_CANCEL: {
+        const exists = this.get(action.serviceInstanceGuid);
+        if (exists) {
+          const toConfirm = {
+            guid: action.serviceInstanceGuid,
+            confirmDelete: false
+          };
+          this.merge('guid', toConfirm, (changed) => {
+            if (changed) this.emitChange();
+          });
+        }
+
+        break;
+      }
+
       case serviceActionTypes.SERVICE_INSTANCE_DELETE: {
         const toDelete = this.get(action.serviceInstanceGuid);
         if (toDelete) {

--- a/static_src/stores/service_instance_store.js
+++ b/static_src/stores/service_instance_store.js
@@ -79,6 +79,20 @@ class ServiceInstanceStore extends BaseStore {
         break;
       }
 
+      case serviceActionTypes.SERVICE_INSTANCE_DELETE_CONFIRM: {
+        const exists = this.get(action.serviceInstanceGuid);
+        if (exists) {
+          const toConfirm = {
+            guid: action.serviceInstanceGuid,
+            confirmDelete: true
+          };
+          this.merge('guid', toConfirm, (changed) => {
+            if (changed) this.emitChange();
+          });
+        }
+        break;
+      }
+
       case serviceActionTypes.SERVICE_INSTANCE_DELETE: {
         const toDelete = this.get(action.serviceInstanceGuid);
         if (toDelete) {

--- a/static_src/test/unit/actions/service_actions.spec.js
+++ b/static_src/test/unit/actions/service_actions.spec.js
@@ -200,9 +200,10 @@ describe('serviceActions', function() {
     });
   });
 
-  describe('deleteInstance()', function() {
-    it('should dispatch a instance delete view event with instance guid', () => {
-      var expectedInstanceGuid = 'asdfasdf';
+  describe('deleteInstanceConfirm()', function() {
+    it('should dispatch a instance delete confirm ui event with instance guid',
+       () => {
+      var expectedInstanceGuid = '09zxcn1dsf';
       var expectedParams = {
         serviceInstanceGuid: expectedInstanceGuid
       }
@@ -211,6 +212,22 @@ describe('serviceActions', function() {
       serviceActions.deleteInstanceConfirm(expectedInstanceGuid);
 
       assertAction(spy, serviceActionTypes.SERVICE_INSTANCE_DELETE_CONFIRM,
+                   expectedParams);
+    });
+  });
+
+  describe('deleteInstanceCancel()', function() {
+    it('should dispatch a instance delete cancel ui event with instance guid',
+       () => {
+      var expectedInstanceGuid = '23098znxb';
+      var expectedParams = {
+        serviceInstanceGuid: expectedInstanceGuid
+      }
+
+      let spy = setupUISpy(sandbox)
+      serviceActions.deleteInstanceCancel(expectedInstanceGuid);
+
+      assertAction(spy, serviceActionTypes.SERVICE_INSTANCE_DELETE_CANCEL,
                    expectedParams);
     });
   });

--- a/static_src/test/unit/actions/service_actions.spec.js
+++ b/static_src/test/unit/actions/service_actions.spec.js
@@ -2,7 +2,8 @@
 import '../../global_setup.js';
 
 import AppDispatcher from '../../../dispatcher.js';
-import { assertAction, setupViewSpy, setupServerSpy } from '../helpers.js';
+import { assertAction, setupViewSpy, setupServerSpy, setupUISpy } from
+  '../helpers.js';
 import cfApi from '../../../util/cf_api.js';
 import serviceActions from '../../../actions/service_actions.js';
 import { serviceActionTypes } from '../../../constants.js';
@@ -84,14 +85,14 @@ describe('serviceActions', function() {
       var expectedSpaceGuid = 'aksfdsaaa8899';
 
       let expectedParams = {
-        spaceGuid: expectedSpaceGuid 
+        spaceGuid: expectedSpaceGuid
       }
 
       let spy = setupViewSpy(sandbox)
 
       serviceActions.fetchAllInstances(expectedSpaceGuid);
 
-      assertAction(spy, serviceActionTypes.SERVICE_INSTANCES_FETCH, 
+      assertAction(spy, serviceActionTypes.SERVICE_INSTANCES_FETCH,
                    expectedParams)
     });
   });
@@ -195,6 +196,21 @@ describe('serviceActions', function() {
       serviceActions.receivedInstances(expected);
 
       assertAction(spy, serviceActionTypes.SERVICE_INSTANCES_RECEIVED,
+                   expectedParams);
+    });
+  });
+
+  describe('deleteInstance()', function() {
+    it('should dispatch a instance delete view event with instance guid', () => {
+      var expectedInstanceGuid = 'asdfasdf';
+      var expectedParams = {
+        serviceInstanceGuid: expectedInstanceGuid
+      }
+
+      let spy = setupUISpy(sandbox)
+      serviceActions.deleteInstanceConfirm(expectedInstanceGuid);
+
+      assertAction(spy, serviceActionTypes.SERVICE_INSTANCE_DELETE_CONFIRM,
                    expectedParams);
     });
   });

--- a/static_src/test/unit/actions/service_actions.spec.js
+++ b/static_src/test/unit/actions/service_actions.spec.js
@@ -239,6 +239,21 @@ describe('serviceActions', function() {
         serviceInstanceGuid: expectedInstanceGuid
       }
 
+      let spy = setupUISpy(sandbox)
+      serviceActions.deleteInstanceConfirm(expectedInstanceGuid);
+
+      assertAction(spy, serviceActionTypes.SERVICE_INSTANCE_DELETE_CONFIRM,
+                   expectedParams);
+    });
+  });
+
+  describe('deleteInstance()', function() {
+    it('should dispatch a instance delete view event with instance guid', () => {
+      var expectedInstanceGuid = 'asdfasdf';
+      var expectedParams = {
+        serviceInstanceGuid: expectedInstanceGuid
+      }
+
       let spy = setupViewSpy(sandbox)
       serviceActions.deleteInstance(expectedInstanceGuid);
 

--- a/static_src/test/unit/stores/service_instance_store.spec.js
+++ b/static_src/test/unit/stores/service_instance_store.spec.js
@@ -230,6 +230,36 @@ describe('ServiceInstanceStore', function() {
     });
   });
 
+  describe('on service instance delete confirm', function() {
+    it('should emit a change event if the instance exists', function() {
+      const spy = sandbox.spy(ServiceInstanceStore, 'emitChange');
+      const instanceGuid = '2903fdkhgasd980';
+      let existingInstance = {
+        guid: instanceGuid
+      };
+
+      ServiceInstanceStore._data = Immutable.fromJS([existingInstance]);
+
+      serviceActions.deleteInstanceConfirm(instanceGuid);;
+
+      expect(spy).toHaveBeenCalledOnce();
+    });
+
+    it('should add a confirmDelete key on the service instance to delete',
+       function() {
+      const instanceGuid = '2903fdkhgasd980';
+      let existingInstance = {
+        guid: instanceGuid
+      };
+
+      ServiceInstanceStore._data = Immutable.fromJS([existingInstance]);
+      serviceActions.deleteInstanceConfirm(instanceGuid);;
+
+      const actual = ServiceInstanceStore.get(instanceGuid);
+      expect(actual.confirmDelete).toBeTruthy();
+    });
+  });
+
   describe('on service instance deleted', function() {
     it('should remove the service from the data', function() {
       var expectedGuid = 'macldksajpi',

--- a/static_src/test/unit/stores/service_instance_store.spec.js
+++ b/static_src/test/unit/stores/service_instance_store.spec.js
@@ -260,6 +260,41 @@ describe('ServiceInstanceStore', function() {
     });
   });
 
+  describe('on service instance delete cancel', function() {
+    it('should emit a change event if the instance exists', function() {
+      const instanceGuid = '2903fdkhzxcvzxcv';
+      let existingInstance = {
+        guid: instanceGuid
+      };
+
+      ServiceInstanceStore._data = Immutable.fromJS([existingInstance]);
+      serviceActions.deleteInstanceConfirm(instanceGuid);;
+
+      const spy = sandbox.spy(ServiceInstanceStore, 'emitChange');
+      serviceActions.deleteInstanceCancel(instanceGuid);;
+
+      expect(spy).toHaveBeenCalledOnce();
+    });
+
+    it('should add a confirmDelete key on the service instance to delete',
+       function() {
+      const instanceGuid = 'zxcvqwehgasd980';
+      let existingInstance = {
+        guid: instanceGuid
+      };
+
+      ServiceInstanceStore._data = Immutable.fromJS([existingInstance]);
+      serviceActions.deleteInstanceConfirm(instanceGuid);;
+      let actual = ServiceInstanceStore.get(instanceGuid);
+      expect(actual.confirmDelete).toBeTruthy();
+
+      serviceActions.deleteInstanceCancel(instanceGuid);;
+      actual = ServiceInstanceStore.get(instanceGuid);
+
+      expect(actual.confirmDelete).toBeFalsy();
+    });
+  });
+
   describe('on service instance deleted', function() {
     it('should remove the service from the data', function() {
       var expectedGuid = 'macldksajpi',


### PR DESCRIPTION
Added confirmation UI to service instance delete. Uses actions for the confirm coming up, canceling and confirming the delete which map to a boolean on each service instance to track whether the confirmation is currently showing. This boolean is used to show the confirmation component and disable the delete button.

Other changes:
- Removed Reactable on service actions because it sucks and can't take style attributes.