### PR TITLE
Deploy master branch to prod space

### DIFF
--- a/deploy/travis_deploy.sh
+++ b/deploy/travis_deploy.sh
@@ -13,11 +13,11 @@ CF_PATH="."
 if [ "$TRAVIS_BRANCH" == "master" ]
 then
 	CF_MANIFEST="manifests/manifest-master.yml"
-	CF_SPACE="deck-stage"
-elif [ "$TRAVIS_BRANCH" == "production" ]
-then
-	CF_MANIFEST="manifests/manifest-production.yml"
 	CF_SPACE="deck-prod"
+elif [ "$TRAVIS_BRANCH" == "staging-alpha" ]
+then
+	CF_MANIFEST="manifests/manifest-staging.yml"
+	CF_SPACE="deck-stage"
 fi
 
 echo $CF_MANIFEST

--- a/manifests/manifest-production.yml
+++ b/manifests/manifest-production.yml
@@ -1,7 +1,0 @@
----
-applications:
-- name: cf-deck
-  memory: 256M
-  host: 18f-deck
-  env:
-    CONSOLE_HOSTNAME: https://18f-deck.18f.gov

--- a/manifests/manifest-staging.yml
+++ b/manifests/manifest-staging.yml
@@ -1,0 +1,9 @@
+---
+inherit: manifest-base.yml
+applications:
+- name: cf-deck
+  memory: 256M
+  host: console-staging
+  env:
+    CONSOLE_HOSTNAME: https://console-staging.cloud.gov
+    CONSOLE_NEW_RELIC_LICENSE: NEW_RELIC_LICENSE


### PR DESCRIPTION
Instructs Travis to deploy `master` branch to production space and `staging-alpha` branch to the staging space. I also removed the `manifest-production.yml` and addd `manifest-staging.yml`.
 
To fix #356