### PR TITLE
Moved env var to get it working

### DIFF
--- a/manifests/manifest-base.yml
+++ b/manifests/manifest-base.yml
@@ -8,6 +8,7 @@ env:
   CONSOLE_UAA_URL: https://uaa.cloud.gov/
   CONSOLE_API_URL: https://api.cloud.gov/
   CONSOLE_LOG_URL: https://loggregator.cloud.gov/
+  CONSOLE_NEW_RELIC_LICENSE: NEW_RELIC_LICENSE
   GOVERSION: go1.6.2
   GOPACKAGENAME: github.com/18F/cg-deck
   GO15VENDOREXPERIMENT: 1

--- a/manifests/manifest-staging.yml
+++ b/manifests/manifest-staging.yml
@@ -6,4 +6,3 @@ applications:
   host: console-staging
   env:
     CONSOLE_HOSTNAME: https://console-staging.cloud.gov
-    CONSOLE_NEW_RELIC_LICENSE: NEW_RELIC_LICENSE


### PR DESCRIPTION
I put the New relic var in staging manifest which isn't read in the
vars to manifest file, so it gets overwritten with the default
value (NEW_RELIC_LICENSE). This fixes that so it's in the base.