### PR TITLE
Redirect all unauthenticated requests to the login page

### DIFF
--- a/controllers/root.go
+++ b/controllers/root.go
@@ -2,10 +2,11 @@ package controllers
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/18F/cg-deck/helpers"
 	"github.com/gocraft/web"
 	"golang.org/x/oauth2"
-	"net/http"
 )
 
 // Context represents the context for all requests that do not need authentication.
@@ -66,25 +67,35 @@ func (c *Context) OAuthCallback(rw web.ResponseWriter, req *web.Request) {
 
 // LoginRequired is a middleware that requires a valid toker or redirects to the handshake page.
 func (c *Context) LoginRequired(rw web.ResponseWriter, r *web.Request, next web.NextMiddlewareFunc) {
+
 	// If there is no request just continue
-	if r != nil {
+	if r == nil {
 		next(rw, r)
 		return
 	}
 
+	// Don't cache anything
+	// right now, there's a problem where when you initially logout and then
+	// revisit the server, you will get a bad view due to a caching issue.
+	// for now, we clear the cache for everything.
+	// TODO: revist and cache static assets.
+	rw.Header().Set("cache-control", "priviate, max-age=0, no-cache")
+	rw.Header().Set("pragma", "no-cache")
+	rw.Header().Set("expires", "-1")
+
 	token := helpers.GetValidToken(r.Request, c.Settings)
-	public_urls := map[string]struct{}{
+	tokenPresent := token != nil
+	publicUrls := map[string]struct{}{
 		"/handshake":      {},
 		"/oauth2callback": {},
 		"/ping":           {},
 	}
 	// Check if URL is public so we skip validation
-	_, ok := public_urls[r.URL.EscapedPath()]
-
-	if ok || token != nil {
+	_, public := publicUrls[r.URL.EscapedPath()]
+	if public || tokenPresent {
 		next(rw, r)
 	} else {
-		rw.Header().Set("Location", "/handshake")
-		rw.WriteHeader(http.StatusMovedPermanently)
+		http.Redirect(rw, r.Request, c.Settings.OAuthConfig.AuthCodeURL("state", oauth2.AccessTypeOnline), http.StatusFound)
+		return
 	}
 }

--- a/controllers/routes.go
+++ b/controllers/routes.go
@@ -51,6 +51,9 @@ func InitRouter(settings *helpers.Settings) *web.Router {
 	logRouter.Middleware((*LogContext).OAuth)
 	logRouter.Get("/recent", (*LogContext).RecentLogs)
 
+	// Add auth middleware
+	router.Middleware((*Context).LoginRequired)
+
 	// Frontend Route Initialization
 	// Set up static file serving to load from the static folder.
 	router.Middleware(web.StaticMiddleware("static", web.StaticOption{IndexFile: "index.html"}))


### PR DESCRIPTION
To reduce the number of steps and clicks a user has to take to use the deck, unauthenticated visitors should be redirected to the login page.

@jcscottiii and I achieved this by removing all caching for the server and with @dlapiduz's `LoginRequired` middleware.

Refs #308 