### PR TITLE
Use mock API testing server to get started easily

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,3 +6,4 @@ static_src/actions/space_actions.js
 static_src/actions/error_actions.js
 static_src/actions/user_actions.js
 static_src/tests.bundle.js
+test/**/*.js

--- a/README.md
+++ b/README.md
@@ -109,6 +109,21 @@ npm install -g eslint-plugin-react
 - `go run server.go`
 - Navigate browser to [`http://localhost:9999`](http://localhost:9999)
 
+### Run locally without needing Go
+This is an easy way to test out front end changes without needing to set up environment variables or `Go`. We will use a small server with fake data (used for automated testing) to get going quickly. If you want to see live data, you'll need to follow the instructions above.
+
+The command `npm run testing-server` will run the server. We will still be using `npm run watch` to build the front end application when the file changes.
+
+#### Start it
+- `npm install` to get the Javascript dependencies
+- `npm run testing-server & npm run watch` to start the server and build process
+
+#### Stop it
+Now when you're done, you'll want to stop the `testing-server` that is running in the background. You can find it by running `jobs`, and the line that looks like this:
+
+`[N]  + running    npm run testing-server`
+
+To kill that process, run `kill %N` where "N" is the number from the line.
 
 ## Unit Testing
 ### Running Go unit tests

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -412,236 +412,236 @@
     },
     "babel-eslint": {
       "version": "4.1.8",
-      "from": "babel-eslint@>=4.1.6 <5.0.0",
+      "from": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-4.1.8.tgz",
       "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-4.1.8.tgz",
       "dependencies": {
         "babel-core": {
           "version": "5.8.38",
-          "from": "babel-core@>=5.8.33 <6.0.0",
+          "from": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
           "dependencies": {
             "babel-plugin-constant-folding": {
               "version": "1.0.1",
-              "from": "babel-plugin-constant-folding@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz"
             },
             "babel-plugin-dead-code-elimination": {
               "version": "1.0.2",
-              "from": "babel-plugin-dead-code-elimination@>=1.0.2 <2.0.0",
+              "from": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz"
             },
             "babel-plugin-eval": {
               "version": "1.0.1",
-              "from": "babel-plugin-eval@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz"
             },
             "babel-plugin-inline-environment-variables": {
               "version": "1.0.1",
-              "from": "babel-plugin-inline-environment-variables@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz"
             },
             "babel-plugin-jscript": {
               "version": "1.0.4",
-              "from": "babel-plugin-jscript@>=1.0.4 <2.0.0",
+              "from": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz"
             },
             "babel-plugin-member-expression-literals": {
               "version": "1.0.1",
-              "from": "babel-plugin-member-expression-literals@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz"
             },
             "babel-plugin-property-literals": {
               "version": "1.0.1",
-              "from": "babel-plugin-property-literals@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz"
             },
             "babel-plugin-proto-to-assign": {
               "version": "1.0.4",
-              "from": "babel-plugin-proto-to-assign@>=1.0.3 <2.0.0",
+              "from": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz"
             },
             "babel-plugin-react-constant-elements": {
               "version": "1.0.3",
-              "from": "babel-plugin-react-constant-elements@>=1.0.3 <2.0.0",
+              "from": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz"
             },
             "babel-plugin-react-display-name": {
               "version": "1.0.3",
-              "from": "babel-plugin-react-display-name@>=1.0.3 <2.0.0",
+              "from": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz"
             },
             "babel-plugin-remove-console": {
               "version": "1.0.1",
-              "from": "babel-plugin-remove-console@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz"
             },
             "babel-plugin-remove-debugger": {
               "version": "1.0.1",
-              "from": "babel-plugin-remove-debugger@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz"
             },
             "babel-plugin-runtime": {
               "version": "1.0.7",
-              "from": "babel-plugin-runtime@>=1.0.7 <2.0.0",
+              "from": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz",
               "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz"
             },
             "babel-plugin-undeclared-variables-check": {
               "version": "1.0.2",
-              "from": "babel-plugin-undeclared-variables-check@>=1.0.2 <2.0.0",
+              "from": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
               "dependencies": {
                 "leven": {
                   "version": "1.0.2",
-                  "from": "leven@>=1.0.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz"
                 }
               }
             },
             "babel-plugin-undefined-to-void": {
               "version": "1.1.6",
-              "from": "babel-plugin-undefined-to-void@>=1.1.6 <2.0.0",
+              "from": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz",
               "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz"
             },
             "babylon": {
               "version": "5.8.38",
-              "from": "babylon@>=5.8.38 <6.0.0",
+              "from": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
               "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz"
             },
             "bluebird": {
               "version": "2.10.2",
-              "from": "bluebird@>=2.9.33 <3.0.0",
+              "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
               "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
             },
             "chalk": {
               "version": "1.1.3",
-              "from": "chalk@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.2.1",
-                  "from": "ansi-styles@>=2.2.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "convert-source-map": {
               "version": "1.2.0",
-              "from": "convert-source-map@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.2.0.tgz"
             },
             "core-js": {
               "version": "1.2.6",
-              "from": "core-js@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
               "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
             },
             "debug": {
               "version": "2.2.0",
-              "from": "debug@>=2.1.1 <3.0.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
-                  "from": "ms@0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
             },
             "detect-indent": {
               "version": "3.0.1",
-              "from": "detect-indent@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
               "dependencies": {
                 "get-stdin": {
                   "version": "4.0.1",
-                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 },
                 "minimist": {
                   "version": "1.2.0",
-                  "from": "minimist@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                 }
               }
             },
             "esutils": {
               "version": "2.0.2",
-              "from": "esutils@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
               "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
             },
             "fs-readdir-recursive": {
               "version": "0.1.2",
-              "from": "fs-readdir-recursive@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
             },
             "globals": {
               "version": "6.4.1",
-              "from": "globals@>=6.4.0 <7.0.0",
+              "from": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
               "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
             },
             "home-or-tmp": {
               "version": "1.0.0",
-              "from": "home-or-tmp@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
               "dependencies": {
                 "os-tmpdir": {
                   "version": "1.0.1",
-                  "from": "os-tmpdir@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                 },
                 "user-home": {
                   "version": "1.1.1",
-                  "from": "user-home@>=1.1.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
                 }
               }
             },
             "is-integer": {
               "version": "1.0.6",
-              "from": "is-integer@>=1.0.4 <2.0.0",
+              "from": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
               "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
               "dependencies": {
                 "is-finite": {
                   "version": "1.0.1",
-                  "from": "is-finite@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     }
                   }
@@ -650,37 +650,37 @@
             },
             "js-tokens": {
               "version": "1.0.1",
-              "from": "js-tokens@1.0.1",
+              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz"
             },
             "json5": {
               "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
             },
             "lodash": {
               "version": "3.10.1",
-              "from": "lodash@>=3.10.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
             },
             "minimatch": {
               "version": "2.0.10",
-              "from": "minimatch@>=2.0.3 <3.0.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.3",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.3.0",
-                      "from": "balanced-match@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -689,12 +689,12 @@
             },
             "output-file-sync": {
               "version": "1.1.1",
-              "from": "output-file-sync@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
               "dependencies": {
                 "mkdirp": {
                   "version": "0.5.1",
-                  "from": "mkdirp@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "dependencies": {
                     "minimist": {
@@ -706,95 +706,95 @@
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "from": "xtend@>=4.0.0 <5.0.0",
+                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
             },
             "path-exists": {
               "version": "1.0.0",
-              "from": "path-exists@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             },
             "private": {
               "version": "0.1.6",
-              "from": "private@>=0.1.6 <0.2.0",
+              "from": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
               "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
             },
             "regenerator": {
               "version": "0.8.40",
-              "from": "regenerator@0.8.40",
+              "from": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
               "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
               "dependencies": {
                 "commoner": {
                   "version": "0.10.4",
-                  "from": "commoner@>=0.10.3 <0.11.0",
+                  "from": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
                   "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
                   "dependencies": {
                     "commander": {
                       "version": "2.9.0",
-                      "from": "commander@>=2.5.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                       "dependencies": {
                         "graceful-readlink": {
                           "version": "1.0.1",
-                          "from": "graceful-readlink@>=1.0.0",
+                          "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                         }
                       }
                     },
                     "detective": {
                       "version": "4.3.1",
-                      "from": "detective@>=4.3.1 <5.0.0",
+                      "from": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
                       "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
                       "dependencies": {
                         "acorn": {
                           "version": "1.2.2",
-                          "from": "acorn@>=1.0.3 <2.0.0",
+                          "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
                           "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
                         },
                         "defined": {
                           "version": "1.0.0",
-                          "from": "defined@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
                         }
                       }
                     },
                     "glob": {
                       "version": "5.0.15",
-                      "from": "glob@>=5.0.15 <6.0.0",
+                      "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                       "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                       "dependencies": {
                         "inflight": {
                           "version": "1.0.4",
-                          "from": "inflight@>=1.0.4 <2.0.0",
+                          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.1",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                             }
                           }
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "once": {
                           "version": "1.3.3",
-                          "from": "once@>=1.3.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.1",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                             }
                           }
@@ -803,171 +803,171 @@
                     },
                     "graceful-fs": {
                       "version": "4.1.3",
-                      "from": "graceful-fs@>=4.1.2 <5.0.0",
+                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                     },
                     "iconv-lite": {
                       "version": "0.4.13",
-                      "from": "iconv-lite@>=0.4.5 <0.5.0",
+                      "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
                       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
                     },
                     "mkdirp": {
                       "version": "0.5.1",
-                      "from": "mkdirp@>=0.5.0 <0.6.0",
+                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "dependencies": {
                         "minimist": {
                           "version": "0.0.8",
-                          "from": "minimist@0.0.8",
+                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                         }
                       }
                     },
                     "q": {
                       "version": "1.4.1",
-                      "from": "q@>=1.1.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
                       "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
                     }
                   }
                 },
                 "defs": {
                   "version": "1.1.1",
-                  "from": "defs@>=1.1.0 <1.2.0",
+                  "from": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
                   "dependencies": {
                     "alter": {
                       "version": "0.2.0",
-                      "from": "alter@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
                       "dependencies": {
                         "stable": {
                           "version": "0.1.5",
-                          "from": "stable@>=0.1.3 <0.2.0",
+                          "from": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz",
                           "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
                         }
                       }
                     },
                     "ast-traverse": {
                       "version": "0.1.1",
-                      "from": "ast-traverse@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz"
                     },
                     "breakable": {
                       "version": "1.0.0",
-                      "from": "breakable@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz"
                     },
                     "simple-fmt": {
                       "version": "0.1.0",
-                      "from": "simple-fmt@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz"
                     },
                     "simple-is": {
                       "version": "0.2.0",
-                      "from": "simple-is@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz"
                     },
                     "stringmap": {
                       "version": "0.2.2",
-                      "from": "stringmap@>=0.2.2 <0.3.0",
+                      "from": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz"
                     },
                     "stringset": {
                       "version": "0.2.1",
-                      "from": "stringset@>=0.2.1 <0.3.0",
+                      "from": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz"
                     },
                     "tryor": {
                       "version": "0.1.2",
-                      "from": "tryor@>=0.1.2 <0.2.0",
+                      "from": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz"
                     },
                     "yargs": {
                       "version": "3.27.0",
-                      "from": "yargs@>=3.27.0 <3.28.0",
+                      "from": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
                       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
                       "dependencies": {
                         "camelcase": {
                           "version": "1.2.1",
-                          "from": "camelcase@>=1.2.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
                           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                         },
                         "cliui": {
                           "version": "2.1.0",
-                          "from": "cliui@>=2.1.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                           "dependencies": {
                             "center-align": {
                               "version": "0.1.3",
-                              "from": "center-align@>=0.1.1 <0.2.0",
+                              "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                               "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                               "dependencies": {
                                 "align-text": {
                                   "version": "0.1.4",
-                                  "from": "align-text@>=0.1.3 <0.2.0",
+                                  "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                   "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                   "dependencies": {
                                     "kind-of": {
                                       "version": "3.0.2",
-                                      "from": "kind-of@>=3.0.2 <4.0.0",
+                                      "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                                       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                                       "dependencies": {
                                         "is-buffer": {
                                           "version": "1.1.3",
-                                          "from": "is-buffer@>=1.0.2 <2.0.0",
+                                          "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
                                           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                         }
                                       }
                                     },
                                     "longest": {
                                       "version": "1.0.1",
-                                      "from": "longest@>=1.0.1 <2.0.0",
+                                      "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
                                       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                     },
                                     "repeat-string": {
                                       "version": "1.5.4",
-                                      "from": "repeat-string@>=1.5.2 <2.0.0",
+                                      "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
                                       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                     }
                                   }
                                 },
                                 "lazy-cache": {
                                   "version": "1.0.4",
-                                  "from": "lazy-cache@>=1.0.3 <2.0.0",
+                                  "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
                                   "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
                                 }
                               }
                             },
                             "right-align": {
                               "version": "0.1.3",
-                              "from": "right-align@>=0.1.1 <0.2.0",
+                              "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                               "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                               "dependencies": {
                                 "align-text": {
                                   "version": "0.1.4",
-                                  "from": "align-text@>=0.1.3 <0.2.0",
+                                  "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                   "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                   "dependencies": {
                                     "kind-of": {
                                       "version": "3.0.2",
-                                      "from": "kind-of@>=3.0.2 <4.0.0",
+                                      "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                                       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                                       "dependencies": {
                                         "is-buffer": {
                                           "version": "1.1.3",
-                                          "from": "is-buffer@>=1.0.2 <2.0.0",
+                                          "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
                                           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                         }
                                       }
                                     },
                                     "longest": {
                                       "version": "1.0.1",
-                                      "from": "longest@>=1.0.1 <2.0.0",
+                                      "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
                                       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                     },
                                     "repeat-string": {
                                       "version": "1.5.4",
-                                      "from": "repeat-string@>=1.5.2 <2.0.0",
+                                      "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
                                       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                     }
                                   }
@@ -976,29 +976,29 @@
                             },
                             "wordwrap": {
                               "version": "0.0.2",
-                              "from": "wordwrap@0.0.2",
+                              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                             }
                           }
                         },
                         "decamelize": {
                           "version": "1.2.0",
-                          "from": "decamelize@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                         },
                         "os-locale": {
                           "version": "1.4.0",
-                          "from": "os-locale@>=1.4.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
                           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
                           "dependencies": {
                             "lcid": {
                               "version": "1.0.0",
-                              "from": "lcid@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
                               "dependencies": {
                                 "invert-kv": {
                                   "version": "1.0.0",
-                                  "from": "invert-kv@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
                                 }
                               }
@@ -1007,12 +1007,12 @@
                         },
                         "window-size": {
                           "version": "0.1.4",
-                          "from": "window-size@>=0.1.2 <0.2.0",
+                          "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
                           "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
                         },
                         "y18n": {
                           "version": "3.2.1",
-                          "from": "y18n@>=3.2.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
                           "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
                         }
                       }
@@ -1021,73 +1021,73 @@
                 },
                 "esprima-fb": {
                   "version": "15001.1001.0-dev-harmony-fb",
-                  "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
+                  "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
                   "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
                 },
                 "recast": {
                   "version": "0.10.33",
-                  "from": "recast@0.10.33",
+                  "from": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
                   "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
                   "dependencies": {
                     "ast-types": {
                       "version": "0.8.12",
-                      "from": "ast-types@0.8.12",
+                      "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
                       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
                     }
                   }
                 },
                 "through": {
                   "version": "2.3.8",
-                  "from": "through@>=2.3.8 <2.4.0",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
             },
             "regexpu": {
               "version": "1.3.0",
-              "from": "regexpu@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
               "dependencies": {
                 "esprima": {
                   "version": "2.7.2",
-                  "from": "esprima@>=2.6.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
                 },
                 "recast": {
                   "version": "0.10.43",
-                  "from": "recast@>=0.10.10 <0.11.0",
+                  "from": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
                   "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
                   "dependencies": {
                     "esprima-fb": {
                       "version": "15001.1001.0-dev-harmony-fb",
-                      "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
+                      "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
                       "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
                     },
                     "ast-types": {
                       "version": "0.8.15",
-                      "from": "ast-types@0.8.15",
+                      "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz",
                       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz"
                     }
                   }
                 },
                 "regenerate": {
                   "version": "1.2.1",
-                  "from": "regenerate@>=1.2.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
                 },
                 "regjsgen": {
                   "version": "0.2.0",
-                  "from": "regjsgen@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
                 },
                 "regjsparser": {
                   "version": "0.1.5",
-                  "from": "regjsparser@>=0.1.4 <0.2.0",
+                  "from": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
                   "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
                   "dependencies": {
                     "jsesc": {
                       "version": "0.5.0",
-                      "from": "jsesc@>=0.5.0 <0.6.0",
+                      "from": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
                       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
                     }
                   }
@@ -1096,17 +1096,17 @@
             },
             "repeating": {
               "version": "1.1.3",
-              "from": "repeating@>=1.1.2 <2.0.0",
+              "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
               "dependencies": {
                 "is-finite": {
                   "version": "1.0.1",
-                  "from": "is-finite@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     }
                   }
@@ -1115,37 +1115,37 @@
             },
             "resolve": {
               "version": "1.1.7",
-              "from": "resolve@>=1.1.6 <2.0.0",
+              "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
             },
             "shebang-regex": {
               "version": "1.0.0",
-              "from": "shebang-regex@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
             },
             "slash": {
               "version": "1.0.0",
-              "from": "slash@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
             },
             "source-map": {
               "version": "0.5.5",
-              "from": "source-map@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.5.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.5.tgz"
             },
             "source-map-support": {
               "version": "0.2.10",
-              "from": "source-map-support@>=0.2.10 <0.3.0",
+              "from": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
               "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
               "dependencies": {
                 "source-map": {
                   "version": "0.1.32",
-                  "from": "source-map@0.1.32",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "1.0.0",
-                      "from": "amdefine@>=0.0.4",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                     }
                   }
@@ -1154,78 +1154,78 @@
             },
             "to-fast-properties": {
               "version": "1.0.2",
-              "from": "to-fast-properties@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
             },
             "trim-right": {
               "version": "1.0.1",
-              "from": "trim-right@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
             },
             "try-resolve": {
               "version": "1.0.1",
-              "from": "try-resolve@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz"
             }
           }
         },
         "lodash.assign": {
           "version": "3.2.0",
-          "from": "lodash.assign@>=3.2.0 <4.0.0",
+          "from": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
           "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
           "dependencies": {
             "lodash._baseassign": {
               "version": "3.2.0",
-              "from": "lodash._baseassign@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
               "dependencies": {
                 "lodash._basecopy": {
                   "version": "3.0.1",
-                  "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
                 }
               }
             },
             "lodash._createassigner": {
               "version": "3.1.1",
-              "from": "lodash._createassigner@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
               "dependencies": {
                 "lodash._bindcallback": {
                   "version": "3.0.1",
-                  "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
                 },
                 "lodash._isiterateecall": {
                   "version": "3.0.9",
-                  "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
                 },
                 "lodash.restparam": {
                   "version": "3.6.1",
-                  "from": "lodash.restparam@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
                 }
               }
             },
             "lodash.keys": {
               "version": "3.1.2",
-              "from": "lodash.keys@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
               "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
               "dependencies": {
                 "lodash._getnative": {
                   "version": "3.9.1",
-                  "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                 },
                 "lodash.isarguments": {
                   "version": "3.0.8",
-                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
                 },
                 "lodash.isarray": {
                   "version": "3.0.4",
-                  "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                 }
               }
@@ -1234,59 +1234,59 @@
         },
         "lodash.pick": {
           "version": "3.1.0",
-          "from": "lodash.pick@>=3.1.0 <4.0.0",
+          "from": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-3.1.0.tgz",
           "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-3.1.0.tgz",
           "dependencies": {
             "lodash._baseflatten": {
               "version": "3.1.4",
-              "from": "lodash._baseflatten@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
               "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
               "dependencies": {
                 "lodash.isarguments": {
                   "version": "3.0.8",
-                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
                 },
                 "lodash.isarray": {
                   "version": "3.0.4",
-                  "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                 }
               }
             },
             "lodash._bindcallback": {
               "version": "3.0.1",
-              "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
             },
             "lodash._pickbyarray": {
               "version": "3.0.2",
-              "from": "lodash._pickbyarray@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz",
               "resolved": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz"
             },
             "lodash._pickbycallback": {
               "version": "3.0.0",
-              "from": "lodash._pickbycallback@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
               "dependencies": {
                 "lodash._basefor": {
                   "version": "3.0.3",
-                  "from": "lodash._basefor@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz"
                 },
                 "lodash.keysin": {
                   "version": "3.0.8",
-                  "from": "lodash.keysin@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
                   "dependencies": {
                     "lodash.isarguments": {
                       "version": "3.0.8",
-                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz",
                       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
                     },
                     "lodash.isarray": {
                       "version": "3.0.4",
-                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                     }
                   }
@@ -1295,77 +1295,77 @@
             },
             "lodash.restparam": {
               "version": "3.6.1",
-              "from": "lodash.restparam@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
             }
           }
         },
         "acorn-to-esprima": {
           "version": "1.0.7",
-          "from": "acorn-to-esprima@>=1.0.5 <2.0.0",
+          "from": "https://registry.npmjs.org/acorn-to-esprima/-/acorn-to-esprima-1.0.7.tgz",
           "resolved": "https://registry.npmjs.org/acorn-to-esprima/-/acorn-to-esprima-1.0.7.tgz"
         }
       }
     },
     "babel-loader": {
       "version": "6.2.4",
-      "from": "babel-loader@>=6.2.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.2.4.tgz",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.2.4.tgz",
       "dependencies": {
         "loader-utils": {
           "version": "0.2.14",
-          "from": "loader-utils@>=0.2.11 <0.3.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.14.tgz",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.14.tgz",
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.1.3 <4.0.0",
+              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "emojis-list": {
               "version": "1.0.1",
-              "from": "emojis-list@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.1.tgz"
             },
             "json5": {
               "version": "0.5.0",
-              "from": "json5@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz"
             }
           }
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@>=0.5.1 <0.6.0",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "minimist@0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "object-assign": {
           "version": "4.0.1",
-          "from": "object-assign@>=4.0.1 <5.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
         }
       }
     },
     "babel-plugin-transform-runtime": {
       "version": "6.7.5",
-      "from": "babel-plugin-transform-runtime@>=6.3.13 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.7.5.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.7.5.tgz",
       "dependencies": {
         "babel-runtime": {
           "version": "5.8.38",
-          "from": "babel-runtime@>=5.0.0 <6.0.0",
+          "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
           "dependencies": {
             "core-js": {
               "version": "1.2.6",
-              "from": "core-js@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
               "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
             }
           }
@@ -1403,22 +1403,22 @@
     },
     "babel-preset-es2015": {
       "version": "6.6.0",
-      "from": "babel-preset-es2015@>=6.3.13 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.6.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.6.0.tgz",
       "dependencies": {
         "babel-plugin-transform-es2015-template-literals": {
           "version": "6.6.5",
-          "from": "babel-plugin-transform-es2015-template-literals@>=6.6.0 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.6.5.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.6.5.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "5.8.38",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -1427,17 +1427,17 @@
         },
         "babel-plugin-transform-es2015-literals": {
           "version": "6.5.0",
-          "from": "babel-plugin-transform-es2015-literals@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.5.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.5.0.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "5.8.38",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -1446,122 +1446,122 @@
         },
         "babel-plugin-transform-es2015-function-name": {
           "version": "6.5.0",
-          "from": "babel-plugin-transform-es2015-function-name@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.5.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.5.0.tgz",
           "dependencies": {
             "babel-helper-function-name": {
               "version": "6.6.0",
-              "from": "babel-helper-function-name@>=6.4.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.6.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.6.0.tgz",
               "dependencies": {
                 "babel-traverse": {
                   "version": "6.7.6",
-                  "from": "babel-traverse@>=6.7.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
                   "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
                   "dependencies": {
                     "babel-code-frame": {
                       "version": "6.7.7",
-                      "from": "babel-code-frame@>=6.7.5 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                       "dependencies": {
                         "chalk": {
                           "version": "1.1.3",
-                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "dependencies": {
                             "ansi-styles": {
                               "version": "2.2.1",
-                              "from": "ansi-styles@>=2.2.1 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                             },
                             "escape-string-regexp": {
                               "version": "1.0.5",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                             },
                             "has-ansi": {
                               "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "strip-ansi": {
                               "version": "3.0.1",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "supports-color": {
                               "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                             }
                           }
                         },
                         "esutils": {
                           "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                         },
                         "js-tokens": {
                           "version": "1.0.3",
-                          "from": "js-tokens@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                         }
                       }
                     },
                     "babel-messages": {
                       "version": "6.7.2",
-                      "from": "babel-messages@>=6.7.2 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz",
                       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
                     },
                     "babylon": {
                       "version": "6.7.0",
-                      "from": "babylon@>=6.7.0 <7.0.0",
+                      "from": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz",
                       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
                     },
                     "debug": {
                       "version": "2.2.0",
-                      "from": "debug@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "dependencies": {
                         "ms": {
                           "version": "0.7.1",
-                          "from": "ms@0.7.1",
+                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                         }
                       }
                     },
                     "globals": {
                       "version": "8.18.0",
-                      "from": "globals@>=8.3.0 <9.0.0",
+                      "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
                       "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
                     },
                     "invariant": {
                       "version": "2.2.1",
-                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                       "dependencies": {
                         "loose-envify": {
                           "version": "1.1.0",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "dependencies": {
                             "js-tokens": {
                               "version": "1.0.3",
-                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                             }
                           }
@@ -1570,22 +1570,22 @@
                     },
                     "lodash": {
                       "version": "3.10.1",
-                      "from": "lodash@>=3.10.1 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                     },
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "repeating@>=1.1.3 <2.0.0",
+                      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.1",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.0",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                             }
                           }
@@ -1596,22 +1596,22 @@
                 },
                 "babel-helper-get-function-arity": {
                   "version": "6.6.5",
-                  "from": "babel-helper-get-function-arity@>=6.3.13 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.6.5.tgz",
                   "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.6.5.tgz"
                 },
                 "babel-template": {
                   "version": "6.7.0",
-                  "from": "babel-template@>=6.7.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.7.0.tgz",
                   "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.7.0.tgz",
                   "dependencies": {
                     "babylon": {
                       "version": "6.7.0",
-                      "from": "babylon@>=6.7.0 <7.0.0",
+                      "from": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz",
                       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
                     },
                     "lodash": {
                       "version": "3.10.1",
-                      "from": "lodash@>=3.10.1 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                     }
                   }
@@ -1620,112 +1620,112 @@
             },
             "babel-types": {
               "version": "6.7.7",
-              "from": "babel-types@>=6.3.13 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.7.tgz",
               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.7.tgz",
               "dependencies": {
                 "babel-traverse": {
                   "version": "6.7.6",
-                  "from": "babel-traverse@>=6.7.2 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
                   "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
                   "dependencies": {
                     "babel-code-frame": {
                       "version": "6.7.7",
-                      "from": "babel-code-frame@>=6.7.5 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                       "dependencies": {
                         "chalk": {
                           "version": "1.1.3",
-                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "dependencies": {
                             "ansi-styles": {
                               "version": "2.2.1",
-                              "from": "ansi-styles@>=2.2.1 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                             },
                             "escape-string-regexp": {
                               "version": "1.0.5",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                             },
                             "has-ansi": {
                               "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "strip-ansi": {
                               "version": "3.0.1",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "supports-color": {
                               "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                             }
                           }
                         },
                         "js-tokens": {
                           "version": "1.0.3",
-                          "from": "js-tokens@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                         }
                       }
                     },
                     "babel-messages": {
                       "version": "6.7.2",
-                      "from": "babel-messages@>=6.7.2 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz",
                       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
                     },
                     "babylon": {
                       "version": "6.7.0",
-                      "from": "babylon@>=6.7.0 <7.0.0",
+                      "from": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz",
                       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
                     },
                     "debug": {
                       "version": "2.2.0",
-                      "from": "debug@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "dependencies": {
                         "ms": {
                           "version": "0.7.1",
-                          "from": "ms@0.7.1",
+                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                         }
                       }
                     },
                     "globals": {
                       "version": "8.18.0",
-                      "from": "globals@>=8.3.0 <9.0.0",
+                      "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
                       "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
                     },
                     "invariant": {
                       "version": "2.2.1",
-                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                       "dependencies": {
                         "loose-envify": {
                           "version": "1.1.0",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "dependencies": {
                             "js-tokens": {
                               "version": "1.0.3",
-                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                             }
                           }
@@ -1734,17 +1734,17 @@
                     },
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "repeating@>=1.1.3 <2.0.0",
+                      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.1",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.0",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                             }
                           }
@@ -1755,29 +1755,29 @@
                 },
                 "esutils": {
                   "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                 },
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@>=3.10.1 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 },
                 "to-fast-properties": {
                   "version": "1.0.2",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
                 }
               }
             },
             "babel-runtime": {
               "version": "5.8.38",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -1786,17 +1786,17 @@
         },
         "babel-plugin-transform-es2015-arrow-functions": {
           "version": "6.7.7",
-          "from": "babel-plugin-transform-es2015-arrow-functions@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.7.7.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.7.7.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "5.8.38",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -1805,17 +1805,17 @@
         },
         "babel-plugin-transform-es2015-block-scoped-functions": {
           "version": "6.6.5",
-          "from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.6.5.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.6.5.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "5.8.38",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -1824,151 +1824,151 @@
         },
         "babel-plugin-transform-es2015-classes": {
           "version": "6.7.7",
-          "from": "babel-plugin-transform-es2015-classes@>=6.6.0 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.7.7.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.7.7.tgz",
           "dependencies": {
             "babel-helper-optimise-call-expression": {
               "version": "6.6.0",
-              "from": "babel-helper-optimise-call-expression@>=6.6.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.6.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.6.0.tgz"
             },
             "babel-helper-function-name": {
               "version": "6.6.0",
-              "from": "babel-helper-function-name@>=6.6.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.6.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.6.0.tgz",
               "dependencies": {
                 "babel-helper-get-function-arity": {
                   "version": "6.6.5",
-                  "from": "babel-helper-get-function-arity@>=6.3.13 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.6.5.tgz",
                   "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.6.5.tgz"
                 }
               }
             },
             "babel-helper-replace-supers": {
               "version": "6.7.0",
-              "from": "babel-helper-replace-supers@>=6.6.5 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.7.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.7.0.tgz"
             },
             "babel-template": {
               "version": "6.7.0",
-              "from": "babel-template@>=6.7.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.7.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.7.0.tgz",
               "dependencies": {
                 "babylon": {
                   "version": "6.7.0",
-                  "from": "babylon@>=6.7.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz",
                   "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
                 },
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@>=3.10.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 }
               }
             },
             "babel-traverse": {
               "version": "6.7.6",
-              "from": "babel-traverse@>=6.7.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
               "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
               "dependencies": {
                 "babel-code-frame": {
                   "version": "6.7.7",
-                  "from": "babel-code-frame@>=6.7.5 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                   "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                   "dependencies": {
                     "chalk": {
                       "version": "1.1.3",
-                      "from": "chalk@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                       "dependencies": {
                         "ansi-styles": {
                           "version": "2.2.1",
-                          "from": "ansi-styles@>=2.2.1 <3.0.0",
+                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                         },
                         "escape-string-regexp": {
                           "version": "1.0.5",
-                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                         },
                         "has-ansi": {
                           "version": "2.0.0",
-                          "from": "has-ansi@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                             }
                           }
                         },
                         "strip-ansi": {
                           "version": "3.0.1",
-                          "from": "strip-ansi@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                             }
                           }
                         },
                         "supports-color": {
                           "version": "2.0.0",
-                          "from": "supports-color@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                         }
                       }
                     },
                     "esutils": {
                       "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                     },
                     "js-tokens": {
                       "version": "1.0.3",
-                      "from": "js-tokens@>=1.0.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                     }
                   }
                 },
                 "babylon": {
                   "version": "6.7.0",
-                  "from": "babylon@>=6.7.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz",
                   "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
                 },
                 "debug": {
                   "version": "2.2.0",
-                  "from": "debug@>=2.2.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "dependencies": {
                     "ms": {
                       "version": "0.7.1",
-                      "from": "ms@0.7.1",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     }
                   }
                 },
                 "globals": {
                   "version": "8.18.0",
-                  "from": "globals@>=8.3.0 <9.0.0",
+                  "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
                   "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
                 },
                 "invariant": {
                   "version": "2.2.1",
-                  "from": "invariant@>=2.2.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                   "dependencies": {
                     "loose-envify": {
                       "version": "1.1.0",
-                      "from": "loose-envify@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                       "dependencies": {
                         "js-tokens": {
                           "version": "1.0.3",
-                          "from": "js-tokens@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                         }
                       }
@@ -1977,22 +1977,22 @@
                 },
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@>=3.10.1 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 },
                 "repeating": {
                   "version": "1.1.3",
-                  "from": "repeating@>=1.1.3 <2.0.0",
+                  "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                   "dependencies": {
                     "is-finite": {
                       "version": "1.0.1",
-                      "from": "is-finite@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                       "dependencies": {
                         "number-is-nan": {
                           "version": "1.0.0",
-                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                         }
                       }
@@ -2003,51 +2003,51 @@
             },
             "babel-helper-define-map": {
               "version": "6.6.5",
-              "from": "babel-helper-define-map@>=6.6.5 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.6.5.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.6.5.tgz",
               "dependencies": {
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@>=3.10.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 }
               }
             },
             "babel-messages": {
               "version": "6.7.2",
-              "from": "babel-messages@>=6.7.2 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz",
               "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
             },
             "babel-runtime": {
               "version": "5.8.38",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
             },
             "babel-types": {
               "version": "6.7.7",
-              "from": "babel-types@>=6.7.7 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.7.tgz",
               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.7.tgz",
               "dependencies": {
                 "esutils": {
                   "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                 },
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@>=3.10.1 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 },
                 "to-fast-properties": {
                   "version": "1.0.2",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
                 }
               }
@@ -2056,122 +2056,122 @@
         },
         "babel-plugin-transform-es2015-object-super": {
           "version": "6.6.5",
-          "from": "babel-plugin-transform-es2015-object-super@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.6.5.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.6.5.tgz",
           "dependencies": {
             "babel-helper-replace-supers": {
               "version": "6.7.0",
-              "from": "babel-helper-replace-supers@>=6.6.5 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.7.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.7.0.tgz",
               "dependencies": {
                 "babel-helper-optimise-call-expression": {
                   "version": "6.6.0",
-                  "from": "babel-helper-optimise-call-expression@>=6.6.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.6.0.tgz",
                   "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.6.0.tgz"
                 },
                 "babel-traverse": {
                   "version": "6.7.6",
-                  "from": "babel-traverse@>=6.7.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
                   "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
                   "dependencies": {
                     "babel-code-frame": {
                       "version": "6.7.7",
-                      "from": "babel-code-frame@>=6.7.5 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                       "dependencies": {
                         "chalk": {
                           "version": "1.1.3",
-                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "dependencies": {
                             "ansi-styles": {
                               "version": "2.2.1",
-                              "from": "ansi-styles@>=2.2.1 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                             },
                             "escape-string-regexp": {
                               "version": "1.0.5",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                             },
                             "has-ansi": {
                               "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "strip-ansi": {
                               "version": "3.0.1",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "supports-color": {
                               "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                             }
                           }
                         },
                         "esutils": {
                           "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                         },
                         "js-tokens": {
                           "version": "1.0.3",
-                          "from": "js-tokens@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                         }
                       }
                     },
                     "babylon": {
                       "version": "6.7.0",
-                      "from": "babylon@>=6.7.0 <7.0.0",
+                      "from": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz",
                       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
                     },
                     "debug": {
                       "version": "2.2.0",
-                      "from": "debug@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "dependencies": {
                         "ms": {
                           "version": "0.7.1",
-                          "from": "ms@0.7.1",
+                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                         }
                       }
                     },
                     "globals": {
                       "version": "8.18.0",
-                      "from": "globals@>=8.3.0 <9.0.0",
+                      "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
                       "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
                     },
                     "invariant": {
                       "version": "2.2.1",
-                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                       "dependencies": {
                         "loose-envify": {
                           "version": "1.1.0",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "dependencies": {
                             "js-tokens": {
                               "version": "1.0.3",
-                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                             }
                           }
@@ -2180,22 +2180,22 @@
                     },
                     "lodash": {
                       "version": "3.10.1",
-                      "from": "lodash@>=3.10.1 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                     },
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "repeating@>=1.1.3 <2.0.0",
+                      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.1",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.0",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                             }
                           }
@@ -2206,44 +2206,44 @@
                 },
                 "babel-messages": {
                   "version": "6.7.2",
-                  "from": "babel-messages@>=6.6.5 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz",
                   "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
                 },
                 "babel-template": {
                   "version": "6.7.0",
-                  "from": "babel-template@>=6.7.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.7.0.tgz",
                   "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.7.0.tgz",
                   "dependencies": {
                     "babylon": {
                       "version": "6.7.0",
-                      "from": "babylon@>=6.7.0 <7.0.0",
+                      "from": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz",
                       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
                     },
                     "lodash": {
                       "version": "3.10.1",
-                      "from": "lodash@>=3.10.1 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                     }
                   }
                 },
                 "babel-types": {
                   "version": "6.7.7",
-                  "from": "babel-types@>=6.6.5 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.7.tgz",
                   "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.7.tgz",
                   "dependencies": {
                     "esutils": {
                       "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                     },
                     "lodash": {
                       "version": "3.10.1",
-                      "from": "lodash@>=3.10.1 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                     },
                     "to-fast-properties": {
                       "version": "1.0.2",
-                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
                     }
                   }
@@ -2252,12 +2252,12 @@
             },
             "babel-runtime": {
               "version": "5.8.38",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -2266,117 +2266,117 @@
         },
         "babel-plugin-transform-es2015-shorthand-properties": {
           "version": "6.5.0",
-          "from": "babel-plugin-transform-es2015-shorthand-properties@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.5.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.5.0.tgz",
           "dependencies": {
             "babel-types": {
               "version": "6.7.7",
-              "from": "babel-types@>=6.3.13 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.7.tgz",
               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.7.tgz",
               "dependencies": {
                 "babel-traverse": {
                   "version": "6.7.6",
-                  "from": "babel-traverse@>=6.7.2 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
                   "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
                   "dependencies": {
                     "babel-code-frame": {
                       "version": "6.7.7",
-                      "from": "babel-code-frame@>=6.7.5 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                       "dependencies": {
                         "chalk": {
                           "version": "1.1.3",
-                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "dependencies": {
                             "ansi-styles": {
                               "version": "2.2.1",
-                              "from": "ansi-styles@>=2.2.1 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                             },
                             "escape-string-regexp": {
                               "version": "1.0.5",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                             },
                             "has-ansi": {
                               "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "strip-ansi": {
                               "version": "3.0.1",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "supports-color": {
                               "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                             }
                           }
                         },
                         "js-tokens": {
                           "version": "1.0.3",
-                          "from": "js-tokens@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                         }
                       }
                     },
                     "babel-messages": {
                       "version": "6.7.2",
-                      "from": "babel-messages@>=6.7.2 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz",
                       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
                     },
                     "babylon": {
                       "version": "6.7.0",
-                      "from": "babylon@>=6.7.0 <7.0.0",
+                      "from": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz",
                       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
                     },
                     "debug": {
                       "version": "2.2.0",
-                      "from": "debug@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "dependencies": {
                         "ms": {
                           "version": "0.7.1",
-                          "from": "ms@0.7.1",
+                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                         }
                       }
                     },
                     "globals": {
                       "version": "8.18.0",
-                      "from": "globals@>=8.3.0 <9.0.0",
+                      "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
                       "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
                     },
                     "invariant": {
                       "version": "2.2.1",
-                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                       "dependencies": {
                         "loose-envify": {
                           "version": "1.1.0",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "dependencies": {
                             "js-tokens": {
                               "version": "1.0.3",
-                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                             }
                           }
@@ -2385,17 +2385,17 @@
                     },
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "repeating@>=1.1.3 <2.0.0",
+                      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.1",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.0",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                             }
                           }
@@ -2406,29 +2406,29 @@
                 },
                 "esutils": {
                   "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                 },
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@>=3.10.1 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 },
                 "to-fast-properties": {
                   "version": "1.0.2",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
                 }
               }
             },
             "babel-runtime": {
               "version": "5.8.38",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -2437,127 +2437,127 @@
         },
         "babel-plugin-transform-es2015-computed-properties": {
           "version": "6.6.5",
-          "from": "babel-plugin-transform-es2015-computed-properties@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.6.5.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.6.5.tgz",
           "dependencies": {
             "babel-helper-define-map": {
               "version": "6.6.5",
-              "from": "babel-helper-define-map@>=6.6.5 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.6.5.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.6.5.tgz",
               "dependencies": {
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@>=3.10.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 },
                 "babel-types": {
                   "version": "6.7.7",
-                  "from": "babel-types@>=6.7.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.7.tgz",
                   "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.7.tgz",
                   "dependencies": {
                     "babel-traverse": {
                       "version": "6.7.6",
-                      "from": "babel-traverse@>=6.7.2 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
                       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
                       "dependencies": {
                         "babel-code-frame": {
                           "version": "6.7.7",
-                          "from": "babel-code-frame@>=6.7.5 <7.0.0",
+                          "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                           "dependencies": {
                             "chalk": {
                               "version": "1.1.3",
-                              "from": "chalk@>=1.1.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                               "dependencies": {
                                 "ansi-styles": {
                                   "version": "2.2.1",
-                                  "from": "ansi-styles@>=2.2.1 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                                 },
                                 "escape-string-regexp": {
                                   "version": "1.0.5",
-                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                                 },
                                 "has-ansi": {
                                   "version": "2.0.0",
-                                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                     }
                                   }
                                 },
                                 "strip-ansi": {
                                   "version": "3.0.1",
-                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                     }
                                   }
                                 },
                                 "supports-color": {
                                   "version": "2.0.0",
-                                  "from": "supports-color@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                                 }
                               }
                             },
                             "js-tokens": {
                               "version": "1.0.3",
-                              "from": "js-tokens@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                             }
                           }
                         },
                         "babel-messages": {
                           "version": "6.7.2",
-                          "from": "babel-messages@>=6.7.2 <7.0.0",
+                          "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz",
                           "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
                         },
                         "babylon": {
                           "version": "6.7.0",
-                          "from": "babylon@>=6.7.0 <7.0.0",
+                          "from": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz",
                           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
                         },
                         "debug": {
                           "version": "2.2.0",
-                          "from": "debug@>=2.2.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                           "dependencies": {
                             "ms": {
                               "version": "0.7.1",
-                              "from": "ms@0.7.1",
+                              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                             }
                           }
                         },
                         "globals": {
                           "version": "8.18.0",
-                          "from": "globals@>=8.3.0 <9.0.0",
+                          "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
                           "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
                         },
                         "invariant": {
                           "version": "2.2.1",
-                          "from": "invariant@>=2.2.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                           "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                           "dependencies": {
                             "loose-envify": {
                               "version": "1.1.0",
-                              "from": "loose-envify@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                               "dependencies": {
                                 "js-tokens": {
                                   "version": "1.0.3",
-                                  "from": "js-tokens@>=1.0.1 <2.0.0",
+                                  "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                                   "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                                 }
                               }
@@ -2566,17 +2566,17 @@
                         },
                         "repeating": {
                           "version": "1.1.3",
-                          "from": "repeating@>=1.1.3 <2.0.0",
+                          "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                 }
                               }
@@ -2587,129 +2587,129 @@
                     },
                     "esutils": {
                       "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                     },
                     "to-fast-properties": {
                       "version": "1.0.2",
-                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
                     }
                   }
                 },
                 "babel-helper-function-name": {
                   "version": "6.6.0",
-                  "from": "babel-helper-function-name@>=6.6.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.6.0.tgz",
                   "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.6.0.tgz",
                   "dependencies": {
                     "babel-traverse": {
                       "version": "6.7.6",
-                      "from": "babel-traverse@>=6.6.0 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
                       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
                       "dependencies": {
                         "babel-code-frame": {
                           "version": "6.7.7",
-                          "from": "babel-code-frame@>=6.7.5 <7.0.0",
+                          "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                           "dependencies": {
                             "chalk": {
                               "version": "1.1.3",
-                              "from": "chalk@>=1.1.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                               "dependencies": {
                                 "ansi-styles": {
                                   "version": "2.2.1",
-                                  "from": "ansi-styles@>=2.2.1 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                                 },
                                 "escape-string-regexp": {
                                   "version": "1.0.5",
-                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                                 },
                                 "has-ansi": {
                                   "version": "2.0.0",
-                                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                     }
                                   }
                                 },
                                 "strip-ansi": {
                                   "version": "3.0.1",
-                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                     }
                                   }
                                 },
                                 "supports-color": {
                                   "version": "2.0.0",
-                                  "from": "supports-color@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                                 }
                               }
                             },
                             "esutils": {
                               "version": "2.0.2",
-                              "from": "esutils@>=2.0.2 <3.0.0",
+                              "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                             },
                             "js-tokens": {
                               "version": "1.0.3",
-                              "from": "js-tokens@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                             }
                           }
                         },
                         "babel-messages": {
                           "version": "6.7.2",
-                          "from": "babel-messages@>=6.7.2 <7.0.0",
+                          "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz",
                           "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
                         },
                         "babylon": {
                           "version": "6.7.0",
-                          "from": "babylon@>=6.7.0 <7.0.0",
+                          "from": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz",
                           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
                         },
                         "debug": {
                           "version": "2.2.0",
-                          "from": "debug@>=2.2.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                           "dependencies": {
                             "ms": {
                               "version": "0.7.1",
-                              "from": "ms@0.7.1",
+                              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                             }
                           }
                         },
                         "globals": {
                           "version": "8.18.0",
-                          "from": "globals@>=8.3.0 <9.0.0",
+                          "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
                           "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
                         },
                         "invariant": {
                           "version": "2.2.1",
-                          "from": "invariant@>=2.2.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                           "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                           "dependencies": {
                             "loose-envify": {
                               "version": "1.1.0",
-                              "from": "loose-envify@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                               "dependencies": {
                                 "js-tokens": {
                                   "version": "1.0.3",
-                                  "from": "js-tokens@>=1.0.1 <2.0.0",
+                                  "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                                   "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                                 }
                               }
@@ -2718,17 +2718,17 @@
                         },
                         "repeating": {
                           "version": "1.1.3",
-                          "from": "repeating@>=1.1.3 <2.0.0",
+                          "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                 }
                               }
@@ -2739,7 +2739,7 @@
                     },
                     "babel-helper-get-function-arity": {
                       "version": "6.6.5",
-                      "from": "babel-helper-get-function-arity@>=6.3.13 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.6.5.tgz",
                       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.6.5.tgz"
                     }
                   }
@@ -2748,117 +2748,117 @@
             },
             "babel-template": {
               "version": "6.7.0",
-              "from": "babel-template@>=6.7.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.7.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.7.0.tgz",
               "dependencies": {
                 "babylon": {
                   "version": "6.7.0",
-                  "from": "babylon@>=6.7.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz",
                   "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
                 },
                 "babel-traverse": {
                   "version": "6.7.6",
-                  "from": "babel-traverse@>=6.7.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
                   "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
                   "dependencies": {
                     "babel-code-frame": {
                       "version": "6.7.7",
-                      "from": "babel-code-frame@>=6.7.5 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                       "dependencies": {
                         "chalk": {
                           "version": "1.1.3",
-                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "dependencies": {
                             "ansi-styles": {
                               "version": "2.2.1",
-                              "from": "ansi-styles@>=2.2.1 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                             },
                             "escape-string-regexp": {
                               "version": "1.0.5",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                             },
                             "has-ansi": {
                               "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "strip-ansi": {
                               "version": "3.0.1",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "supports-color": {
                               "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                             }
                           }
                         },
                         "esutils": {
                           "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                         },
                         "js-tokens": {
                           "version": "1.0.3",
-                          "from": "js-tokens@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                         }
                       }
                     },
                     "babel-messages": {
                       "version": "6.7.2",
-                      "from": "babel-messages@>=6.7.2 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz",
                       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
                     },
                     "debug": {
                       "version": "2.2.0",
-                      "from": "debug@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "dependencies": {
                         "ms": {
                           "version": "0.7.1",
-                          "from": "ms@0.7.1",
+                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                         }
                       }
                     },
                     "globals": {
                       "version": "8.18.0",
-                      "from": "globals@>=8.3.0 <9.0.0",
+                      "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
                       "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
                     },
                     "invariant": {
                       "version": "2.2.1",
-                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                       "dependencies": {
                         "loose-envify": {
                           "version": "1.1.0",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "dependencies": {
                             "js-tokens": {
                               "version": "1.0.3",
-                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                             }
                           }
@@ -2867,17 +2867,17 @@
                     },
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "repeating@>=1.1.3 <2.0.0",
+                      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.1",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.0",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                             }
                           }
@@ -2888,36 +2888,36 @@
                 },
                 "babel-types": {
                   "version": "6.7.7",
-                  "from": "babel-types@>=6.7.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.7.tgz",
                   "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.7.tgz",
                   "dependencies": {
                     "esutils": {
                       "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                     },
                     "to-fast-properties": {
                       "version": "1.0.2",
-                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
                     }
                   }
                 },
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@>=3.10.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 }
               }
             },
             "babel-runtime": {
               "version": "5.8.38",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -2926,129 +2926,129 @@
         },
         "babel-plugin-transform-es2015-duplicate-keys": {
           "version": "6.6.4",
-          "from": "babel-plugin-transform-es2015-duplicate-keys@>=6.6.0 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.6.4.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.6.4.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "5.8.38",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
             },
             "babel-types": {
               "version": "6.7.7",
-              "from": "babel-types@>=6.3.13 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.7.tgz",
               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.7.tgz",
               "dependencies": {
                 "babel-traverse": {
                   "version": "6.7.6",
-                  "from": "babel-traverse@>=6.7.2 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
                   "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
                   "dependencies": {
                     "babel-code-frame": {
                       "version": "6.7.7",
-                      "from": "babel-code-frame@>=6.7.5 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                       "dependencies": {
                         "chalk": {
                           "version": "1.1.3",
-                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "dependencies": {
                             "ansi-styles": {
                               "version": "2.2.1",
-                              "from": "ansi-styles@>=2.2.1 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                             },
                             "escape-string-regexp": {
                               "version": "1.0.5",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                             },
                             "has-ansi": {
                               "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "strip-ansi": {
                               "version": "3.0.1",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "supports-color": {
                               "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                             }
                           }
                         },
                         "js-tokens": {
                           "version": "1.0.3",
-                          "from": "js-tokens@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                         }
                       }
                     },
                     "babel-messages": {
                       "version": "6.7.2",
-                      "from": "babel-messages@>=6.7.2 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz",
                       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
                     },
                     "babylon": {
                       "version": "6.7.0",
-                      "from": "babylon@>=6.7.0 <7.0.0",
+                      "from": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz",
                       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
                     },
                     "debug": {
                       "version": "2.2.0",
-                      "from": "debug@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "dependencies": {
                         "ms": {
                           "version": "0.7.1",
-                          "from": "ms@0.7.1",
+                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                         }
                       }
                     },
                     "globals": {
                       "version": "8.18.0",
-                      "from": "globals@>=8.3.0 <9.0.0",
+                      "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
                       "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
                     },
                     "invariant": {
                       "version": "2.2.1",
-                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                       "dependencies": {
                         "loose-envify": {
                           "version": "1.1.0",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "dependencies": {
                             "js-tokens": {
                               "version": "1.0.3",
-                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                             }
                           }
@@ -3057,17 +3057,17 @@
                     },
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "repeating@>=1.1.3 <2.0.0",
+                      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.1",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.0",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                             }
                           }
@@ -3078,17 +3078,17 @@
                 },
                 "esutils": {
                   "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                 },
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@>=3.10.1 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 },
                 "to-fast-properties": {
                   "version": "1.0.2",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
                 }
               }
@@ -3097,17 +3097,17 @@
         },
         "babel-plugin-transform-es2015-for-of": {
           "version": "6.6.0",
-          "from": "babel-plugin-transform-es2015-for-of@>=6.6.0 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.6.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.6.0.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "5.8.38",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -3116,129 +3116,129 @@
         },
         "babel-plugin-transform-es2015-sticky-regex": {
           "version": "6.5.0",
-          "from": "babel-plugin-transform-es2015-sticky-regex@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.5.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.5.0.tgz",
           "dependencies": {
             "babel-helper-regex": {
               "version": "6.6.5",
-              "from": "babel-helper-regex@>=6.3.13 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.6.5.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.6.5.tgz",
               "dependencies": {
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@>=3.10.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 }
               }
             },
             "babel-types": {
               "version": "6.7.7",
-              "from": "babel-types@>=6.3.13 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.7.tgz",
               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.7.tgz",
               "dependencies": {
                 "babel-traverse": {
                   "version": "6.7.6",
-                  "from": "babel-traverse@>=6.7.2 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
                   "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
                   "dependencies": {
                     "babel-code-frame": {
                       "version": "6.7.7",
-                      "from": "babel-code-frame@>=6.7.5 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                       "dependencies": {
                         "chalk": {
                           "version": "1.1.3",
-                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "dependencies": {
                             "ansi-styles": {
                               "version": "2.2.1",
-                              "from": "ansi-styles@>=2.2.1 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                             },
                             "escape-string-regexp": {
                               "version": "1.0.5",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                             },
                             "has-ansi": {
                               "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "strip-ansi": {
                               "version": "3.0.1",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "supports-color": {
                               "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                             }
                           }
                         },
                         "js-tokens": {
                           "version": "1.0.3",
-                          "from": "js-tokens@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                         }
                       }
                     },
                     "babel-messages": {
                       "version": "6.7.2",
-                      "from": "babel-messages@>=6.7.2 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz",
                       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
                     },
                     "babylon": {
                       "version": "6.7.0",
-                      "from": "babylon@>=6.7.0 <7.0.0",
+                      "from": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz",
                       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
                     },
                     "debug": {
                       "version": "2.2.0",
-                      "from": "debug@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "dependencies": {
                         "ms": {
                           "version": "0.7.1",
-                          "from": "ms@0.7.1",
+                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                         }
                       }
                     },
                     "globals": {
                       "version": "8.18.0",
-                      "from": "globals@>=8.3.0 <9.0.0",
+                      "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
                       "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
                     },
                     "invariant": {
                       "version": "2.2.1",
-                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                       "dependencies": {
                         "loose-envify": {
                           "version": "1.1.0",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "dependencies": {
                             "js-tokens": {
                               "version": "1.0.3",
-                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                             }
                           }
@@ -3247,17 +3247,17 @@
                     },
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "repeating@>=1.1.3 <2.0.0",
+                      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.1",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.0",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                             }
                           }
@@ -3268,29 +3268,29 @@
                 },
                 "esutils": {
                   "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                 },
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@>=3.10.1 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 },
                 "to-fast-properties": {
                   "version": "1.0.2",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
                 }
               }
             },
             "babel-runtime": {
               "version": "5.8.38",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -3299,127 +3299,127 @@
         },
         "babel-plugin-transform-es2015-unicode-regex": {
           "version": "6.5.0",
-          "from": "babel-plugin-transform-es2015-unicode-regex@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.5.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.5.0.tgz",
           "dependencies": {
             "babel-helper-regex": {
               "version": "6.6.5",
-              "from": "babel-helper-regex@>=6.3.13 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.6.5.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.6.5.tgz",
               "dependencies": {
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@>=3.10.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 },
                 "babel-types": {
                   "version": "6.7.7",
-                  "from": "babel-types@>=6.7.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.7.tgz",
                   "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.7.tgz",
                   "dependencies": {
                     "babel-traverse": {
                       "version": "6.7.6",
-                      "from": "babel-traverse@>=6.7.2 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
                       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
                       "dependencies": {
                         "babel-code-frame": {
                           "version": "6.7.7",
-                          "from": "babel-code-frame@>=6.7.5 <7.0.0",
+                          "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                           "dependencies": {
                             "chalk": {
                               "version": "1.1.3",
-                              "from": "chalk@>=1.1.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                               "dependencies": {
                                 "ansi-styles": {
                                   "version": "2.2.1",
-                                  "from": "ansi-styles@>=2.2.1 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                                 },
                                 "escape-string-regexp": {
                                   "version": "1.0.5",
-                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                                 },
                                 "has-ansi": {
                                   "version": "2.0.0",
-                                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                     }
                                   }
                                 },
                                 "strip-ansi": {
                                   "version": "3.0.1",
-                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                     }
                                   }
                                 },
                                 "supports-color": {
                                   "version": "2.0.0",
-                                  "from": "supports-color@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                                 }
                               }
                             },
                             "js-tokens": {
                               "version": "1.0.3",
-                              "from": "js-tokens@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                             }
                           }
                         },
                         "babel-messages": {
                           "version": "6.7.2",
-                          "from": "babel-messages@>=6.7.2 <7.0.0",
+                          "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz",
                           "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
                         },
                         "babylon": {
                           "version": "6.7.0",
-                          "from": "babylon@>=6.7.0 <7.0.0",
+                          "from": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz",
                           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
                         },
                         "debug": {
                           "version": "2.2.0",
-                          "from": "debug@>=2.2.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                           "dependencies": {
                             "ms": {
                               "version": "0.7.1",
-                              "from": "ms@0.7.1",
+                              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                             }
                           }
                         },
                         "globals": {
                           "version": "8.18.0",
-                          "from": "globals@>=8.3.0 <9.0.0",
+                          "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
                           "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
                         },
                         "invariant": {
                           "version": "2.2.1",
-                          "from": "invariant@>=2.2.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                           "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                           "dependencies": {
                             "loose-envify": {
                               "version": "1.1.0",
-                              "from": "loose-envify@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                               "dependencies": {
                                 "js-tokens": {
                                   "version": "1.0.3",
-                                  "from": "js-tokens@>=1.0.1 <2.0.0",
+                                  "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                                   "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                                 }
                               }
@@ -3428,17 +3428,17 @@
                         },
                         "repeating": {
                           "version": "1.1.3",
-                          "from": "repeating@>=1.1.3 <2.0.0",
+                          "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                 }
                               }
@@ -3449,12 +3449,12 @@
                     },
                     "esutils": {
                       "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                     },
                     "to-fast-properties": {
                       "version": "1.0.2",
-                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
                     }
                   }
@@ -3463,39 +3463,39 @@
             },
             "babel-runtime": {
               "version": "5.8.38",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
             },
             "regexpu-core": {
               "version": "1.0.0",
-              "from": "regexpu-core@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
               "dependencies": {
                 "regenerate": {
                   "version": "1.2.1",
-                  "from": "regenerate@>=1.2.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
                 },
                 "regjsgen": {
                   "version": "0.2.0",
-                  "from": "regjsgen@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
                 },
                 "regjsparser": {
                   "version": "0.1.5",
-                  "from": "regjsparser@>=0.1.4 <0.2.0",
+                  "from": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
                   "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
                   "dependencies": {
                     "jsesc": {
                       "version": "0.5.0",
-                      "from": "jsesc@>=0.5.0 <0.6.0",
+                      "from": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
                       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
                     }
                   }
@@ -3506,17 +3506,17 @@
         },
         "babel-plugin-check-es2015-constants": {
           "version": "6.7.2",
-          "from": "babel-plugin-check-es2015-constants@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.7.2.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.7.2.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "5.8.38",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -3525,17 +3525,17 @@
         },
         "babel-plugin-transform-es2015-spread": {
           "version": "6.6.5",
-          "from": "babel-plugin-transform-es2015-spread@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.6.5.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.6.5.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "5.8.38",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -3544,117 +3544,117 @@
         },
         "babel-plugin-transform-es2015-parameters": {
           "version": "6.7.0",
-          "from": "babel-plugin-transform-es2015-parameters@>=6.6.0 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.7.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.7.0.tgz",
           "dependencies": {
             "babel-traverse": {
               "version": "6.7.6",
-              "from": "babel-traverse@>=6.7.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
               "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
               "dependencies": {
                 "babel-code-frame": {
                   "version": "6.7.7",
-                  "from": "babel-code-frame@>=6.7.5 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                   "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                   "dependencies": {
                     "chalk": {
                       "version": "1.1.3",
-                      "from": "chalk@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                       "dependencies": {
                         "ansi-styles": {
                           "version": "2.2.1",
-                          "from": "ansi-styles@>=2.2.1 <3.0.0",
+                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                         },
                         "escape-string-regexp": {
                           "version": "1.0.5",
-                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                         },
                         "has-ansi": {
                           "version": "2.0.0",
-                          "from": "has-ansi@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                             }
                           }
                         },
                         "strip-ansi": {
                           "version": "3.0.1",
-                          "from": "strip-ansi@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                             }
                           }
                         },
                         "supports-color": {
                           "version": "2.0.0",
-                          "from": "supports-color@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                         }
                       }
                     },
                     "esutils": {
                       "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                     },
                     "js-tokens": {
                       "version": "1.0.3",
-                      "from": "js-tokens@>=1.0.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                     }
                   }
                 },
                 "babel-messages": {
                   "version": "6.7.2",
-                  "from": "babel-messages@>=6.7.2 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz",
                   "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
                 },
                 "babylon": {
                   "version": "6.7.0",
-                  "from": "babylon@>=6.7.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz",
                   "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
                 },
                 "debug": {
                   "version": "2.2.0",
-                  "from": "debug@>=2.2.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "dependencies": {
                     "ms": {
                       "version": "0.7.1",
-                      "from": "ms@0.7.1",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     }
                   }
                 },
                 "globals": {
                   "version": "8.18.0",
-                  "from": "globals@>=8.3.0 <9.0.0",
+                  "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
                   "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
                 },
                 "invariant": {
                   "version": "2.2.1",
-                  "from": "invariant@>=2.2.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                   "dependencies": {
                     "loose-envify": {
                       "version": "1.1.0",
-                      "from": "loose-envify@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                       "dependencies": {
                         "js-tokens": {
                           "version": "1.0.3",
-                          "from": "js-tokens@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                         }
                       }
@@ -3663,22 +3663,22 @@
                 },
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@>=3.10.1 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 },
                 "repeating": {
                   "version": "1.1.3",
-                  "from": "repeating@>=1.1.3 <2.0.0",
+                  "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                   "dependencies": {
                     "is-finite": {
                       "version": "1.0.1",
-                      "from": "is-finite@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                       "dependencies": {
                         "number-is-nan": {
                           "version": "1.0.0",
-                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                         }
                       }
@@ -3689,68 +3689,68 @@
             },
             "babel-helper-call-delegate": {
               "version": "6.6.5",
-              "from": "babel-helper-call-delegate@>=6.6.5 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.6.5.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.6.5.tgz",
               "dependencies": {
                 "babel-helper-hoist-variables": {
                   "version": "6.6.5",
-                  "from": "babel-helper-hoist-variables@>=6.6.5 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.6.5.tgz",
                   "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.6.5.tgz"
                 }
               }
             },
             "babel-helper-get-function-arity": {
               "version": "6.6.5",
-              "from": "babel-helper-get-function-arity@>=6.6.5 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.6.5.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.6.5.tgz"
             },
             "babel-template": {
               "version": "6.7.0",
-              "from": "babel-template@>=6.7.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.7.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.7.0.tgz",
               "dependencies": {
                 "babylon": {
                   "version": "6.7.0",
-                  "from": "babylon@>=6.7.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz",
                   "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
                 },
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@>=3.10.1 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 }
               }
             },
             "babel-types": {
               "version": "6.7.7",
-              "from": "babel-types@>=6.3.13 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.7.tgz",
               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.7.tgz",
               "dependencies": {
                 "esutils": {
                   "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                 },
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@>=3.10.1 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 },
                 "to-fast-properties": {
                   "version": "1.0.2",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
                 }
               }
             },
             "babel-runtime": {
               "version": "5.8.38",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -3759,17 +3759,17 @@
         },
         "babel-plugin-transform-es2015-destructuring": {
           "version": "6.6.5",
-          "from": "babel-plugin-transform-es2015-destructuring@>=6.6.0 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.6.5.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.6.5.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "5.8.38",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -3778,117 +3778,117 @@
         },
         "babel-plugin-transform-es2015-block-scoping": {
           "version": "6.7.1",
-          "from": "babel-plugin-transform-es2015-block-scoping@>=6.6.0 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.7.1.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.7.1.tgz",
           "dependencies": {
             "babel-traverse": {
               "version": "6.7.6",
-              "from": "babel-traverse@>=6.7.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
               "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
               "dependencies": {
                 "babel-code-frame": {
                   "version": "6.7.7",
-                  "from": "babel-code-frame@>=6.7.5 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                   "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                   "dependencies": {
                     "chalk": {
                       "version": "1.1.3",
-                      "from": "chalk@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                       "dependencies": {
                         "ansi-styles": {
                           "version": "2.2.1",
-                          "from": "ansi-styles@>=2.2.1 <3.0.0",
+                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                         },
                         "escape-string-regexp": {
                           "version": "1.0.5",
-                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                         },
                         "has-ansi": {
                           "version": "2.0.0",
-                          "from": "has-ansi@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                             }
                           }
                         },
                         "strip-ansi": {
                           "version": "3.0.1",
-                          "from": "strip-ansi@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                             }
                           }
                         },
                         "supports-color": {
                           "version": "2.0.0",
-                          "from": "supports-color@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                         }
                       }
                     },
                     "esutils": {
                       "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                     },
                     "js-tokens": {
                       "version": "1.0.3",
-                      "from": "js-tokens@>=1.0.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                     }
                   }
                 },
                 "babel-messages": {
                   "version": "6.7.2",
-                  "from": "babel-messages@>=6.7.2 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz",
                   "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
                 },
                 "babylon": {
                   "version": "6.7.0",
-                  "from": "babylon@>=6.7.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz",
                   "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
                 },
                 "debug": {
                   "version": "2.2.0",
-                  "from": "debug@>=2.2.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "dependencies": {
                     "ms": {
                       "version": "0.7.1",
-                      "from": "ms@0.7.1",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     }
                   }
                 },
                 "globals": {
                   "version": "8.18.0",
-                  "from": "globals@>=8.3.0 <9.0.0",
+                  "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
                   "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
                 },
                 "invariant": {
                   "version": "2.2.1",
-                  "from": "invariant@>=2.2.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                   "dependencies": {
                     "loose-envify": {
                       "version": "1.1.0",
-                      "from": "loose-envify@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                       "dependencies": {
                         "js-tokens": {
                           "version": "1.0.3",
-                          "from": "js-tokens@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                         }
                       }
@@ -3897,17 +3897,17 @@
                 },
                 "repeating": {
                   "version": "1.1.3",
-                  "from": "repeating@>=1.1.3 <2.0.0",
+                  "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                   "dependencies": {
                     "is-finite": {
                       "version": "1.0.1",
-                      "from": "is-finite@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                       "dependencies": {
                         "number-is-nan": {
                           "version": "1.0.0",
-                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                         }
                       }
@@ -3918,46 +3918,46 @@
             },
             "babel-types": {
               "version": "6.7.7",
-              "from": "babel-types@>=6.3.13 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.7.tgz",
               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.7.tgz",
               "dependencies": {
                 "esutils": {
                   "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                 },
                 "to-fast-properties": {
                   "version": "1.0.2",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
                 }
               }
             },
             "babel-template": {
               "version": "6.7.0",
-              "from": "babel-template@>=6.7.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.7.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.7.0.tgz",
               "dependencies": {
                 "babylon": {
                   "version": "6.7.0",
-                  "from": "babylon@>=6.7.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz",
                   "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
                 }
               }
             },
             "lodash": {
               "version": "3.10.1",
-              "from": "lodash@>=3.10.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
             },
             "babel-runtime": {
               "version": "5.8.38",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -3966,17 +3966,17 @@
         },
         "babel-plugin-transform-es2015-typeof-symbol": {
           "version": "6.6.0",
-          "from": "babel-plugin-transform-es2015-typeof-symbol@>=6.6.0 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.6.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.6.0.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "5.8.38",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -3985,117 +3985,117 @@
         },
         "babel-plugin-transform-es2015-modules-commonjs": {
           "version": "6.7.7",
-          "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.6.0 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.7.7.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.7.7.tgz",
           "dependencies": {
             "babel-types": {
               "version": "6.7.7",
-              "from": "babel-types@>=6.3.13 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.7.tgz",
               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.7.tgz",
               "dependencies": {
                 "babel-traverse": {
                   "version": "6.7.6",
-                  "from": "babel-traverse@>=6.7.2 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
                   "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
                   "dependencies": {
                     "babel-code-frame": {
                       "version": "6.7.7",
-                      "from": "babel-code-frame@>=6.7.5 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                       "dependencies": {
                         "chalk": {
                           "version": "1.1.3",
-                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "dependencies": {
                             "ansi-styles": {
                               "version": "2.2.1",
-                              "from": "ansi-styles@>=2.2.1 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                             },
                             "escape-string-regexp": {
                               "version": "1.0.5",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                             },
                             "has-ansi": {
                               "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "strip-ansi": {
                               "version": "3.0.1",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "supports-color": {
                               "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                             }
                           }
                         },
                         "js-tokens": {
                           "version": "1.0.3",
-                          "from": "js-tokens@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                         }
                       }
                     },
                     "babel-messages": {
                       "version": "6.7.2",
-                      "from": "babel-messages@>=6.7.2 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz",
                       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
                     },
                     "babylon": {
                       "version": "6.7.0",
-                      "from": "babylon@>=6.7.0 <7.0.0",
+                      "from": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz",
                       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
                     },
                     "debug": {
                       "version": "2.2.0",
-                      "from": "debug@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "dependencies": {
                         "ms": {
                           "version": "0.7.1",
-                          "from": "ms@0.7.1",
+                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                         }
                       }
                     },
                     "globals": {
                       "version": "8.18.0",
-                      "from": "globals@>=8.3.0 <9.0.0",
+                      "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
                       "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
                     },
                     "invariant": {
                       "version": "2.2.1",
-                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                       "dependencies": {
                         "loose-envify": {
                           "version": "1.1.0",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "dependencies": {
                             "js-tokens": {
                               "version": "1.0.3",
-                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                             }
                           }
@@ -4104,17 +4104,17 @@
                     },
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "repeating@>=1.1.3 <2.0.0",
+                      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.1",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.0",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                             }
                           }
@@ -4125,146 +4125,146 @@
                 },
                 "esutils": {
                   "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                 },
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@>=3.10.1 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 },
                 "to-fast-properties": {
                   "version": "1.0.2",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
                 }
               }
             },
             "babel-runtime": {
               "version": "5.8.38",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
             },
             "babel-template": {
               "version": "6.7.0",
-              "from": "babel-template@>=6.7.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.7.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.7.0.tgz",
               "dependencies": {
                 "babylon": {
                   "version": "6.7.0",
-                  "from": "babylon@>=6.7.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz",
                   "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
                 },
                 "babel-traverse": {
                   "version": "6.7.6",
-                  "from": "babel-traverse@>=6.7.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
                   "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
                   "dependencies": {
                     "babel-code-frame": {
                       "version": "6.7.7",
-                      "from": "babel-code-frame@>=6.7.5 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                       "dependencies": {
                         "chalk": {
                           "version": "1.1.3",
-                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "dependencies": {
                             "ansi-styles": {
                               "version": "2.2.1",
-                              "from": "ansi-styles@>=2.2.1 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                             },
                             "escape-string-regexp": {
                               "version": "1.0.5",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                             },
                             "has-ansi": {
                               "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "strip-ansi": {
                               "version": "3.0.1",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                 }
                               }
                             },
                             "supports-color": {
                               "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                             }
                           }
                         },
                         "esutils": {
                           "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                         },
                         "js-tokens": {
                           "version": "1.0.3",
-                          "from": "js-tokens@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                         }
                       }
                     },
                     "babel-messages": {
                       "version": "6.7.2",
-                      "from": "babel-messages@>=6.7.2 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz",
                       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
                     },
                     "debug": {
                       "version": "2.2.0",
-                      "from": "debug@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "dependencies": {
                         "ms": {
                           "version": "0.7.1",
-                          "from": "ms@0.7.1",
+                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                         }
                       }
                     },
                     "globals": {
                       "version": "8.18.0",
-                      "from": "globals@>=8.3.0 <9.0.0",
+                      "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
                       "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
                     },
                     "invariant": {
                       "version": "2.2.1",
-                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                       "dependencies": {
                         "loose-envify": {
                           "version": "1.1.0",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                           "dependencies": {
                             "js-tokens": {
                               "version": "1.0.3",
-                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                             }
                           }
@@ -4273,17 +4273,17 @@
                     },
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "repeating@>=1.1.3 <2.0.0",
+                      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.1",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.0",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                             }
                           }
@@ -4294,143 +4294,143 @@
                 },
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@>=3.10.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 }
               }
             },
             "babel-plugin-transform-strict-mode": {
               "version": "6.6.5",
-              "from": "babel-plugin-transform-strict-mode@>=6.6.5 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.6.5.tgz",
               "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.6.5.tgz"
             }
           }
         },
         "babel-plugin-transform-regenerator": {
           "version": "6.6.5",
-          "from": "babel-plugin-transform-regenerator@>=6.6.0 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.6.5.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.6.5.tgz",
           "dependencies": {
             "babel-plugin-syntax-async-functions": {
               "version": "6.5.0",
-              "from": "babel-plugin-syntax-async-functions@>=6.3.13 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.5.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.5.0.tgz"
             },
             "babel-runtime": {
               "version": "5.8.38",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
             },
             "babel-traverse": {
               "version": "6.7.6",
-              "from": "babel-traverse@>=6.6.5 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
               "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
               "dependencies": {
                 "babel-code-frame": {
                   "version": "6.7.7",
-                  "from": "babel-code-frame@>=6.7.5 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                   "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                   "dependencies": {
                     "chalk": {
                       "version": "1.1.3",
-                      "from": "chalk@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                       "dependencies": {
                         "ansi-styles": {
                           "version": "2.2.1",
-                          "from": "ansi-styles@>=2.2.1 <3.0.0",
+                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                         },
                         "escape-string-regexp": {
                           "version": "1.0.5",
-                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                         },
                         "has-ansi": {
                           "version": "2.0.0",
-                          "from": "has-ansi@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                             }
                           }
                         },
                         "strip-ansi": {
                           "version": "3.0.1",
-                          "from": "strip-ansi@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                             }
                           }
                         },
                         "supports-color": {
                           "version": "2.0.0",
-                          "from": "supports-color@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                         }
                       }
                     },
                     "esutils": {
                       "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                     },
                     "js-tokens": {
                       "version": "1.0.3",
-                      "from": "js-tokens@>=1.0.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                     }
                   }
                 },
                 "babel-messages": {
                   "version": "6.7.2",
-                  "from": "babel-messages@>=6.7.2 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz",
                   "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
                 },
                 "debug": {
                   "version": "2.2.0",
-                  "from": "debug@>=2.2.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "dependencies": {
                     "ms": {
                       "version": "0.7.1",
-                      "from": "ms@0.7.1",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     }
                   }
                 },
                 "globals": {
                   "version": "8.18.0",
-                  "from": "globals@>=8.3.0 <9.0.0",
+                  "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
                   "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
                 },
                 "invariant": {
                   "version": "2.2.1",
-                  "from": "invariant@>=2.2.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                   "dependencies": {
                     "loose-envify": {
                       "version": "1.1.0",
-                      "from": "loose-envify@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                       "dependencies": {
                         "js-tokens": {
                           "version": "1.0.3",
-                          "from": "js-tokens@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                         }
                       }
@@ -4439,22 +4439,22 @@
                 },
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@>=3.10.1 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 },
                 "repeating": {
                   "version": "1.1.3",
-                  "from": "repeating@>=1.1.3 <2.0.0",
+                  "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                   "dependencies": {
                     "is-finite": {
                       "version": "1.0.1",
-                      "from": "is-finite@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                       "dependencies": {
                         "number-is-nan": {
                           "version": "1.0.0",
-                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                         }
                       }
@@ -4465,34 +4465,34 @@
             },
             "babel-types": {
               "version": "6.7.7",
-              "from": "babel-types@>=6.6.5 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.7.tgz",
               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.7.tgz",
               "dependencies": {
                 "esutils": {
                   "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                 },
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@>=3.10.1 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 },
                 "to-fast-properties": {
                   "version": "1.0.2",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
                 }
               }
             },
             "babylon": {
               "version": "6.7.0",
-              "from": "babylon@>=6.6.5 <7.0.0",
+              "from": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz",
               "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
             },
             "private": {
               "version": "0.1.6",
-              "from": "private@>=0.1.5 <0.2.0",
+              "from": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
               "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
             }
           }
@@ -4501,22 +4501,22 @@
     },
     "babel-preset-react": {
       "version": "6.5.0",
-      "from": "babel-preset-react@>=6.3.13 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.5.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.5.0.tgz",
       "dependencies": {
         "babel-plugin-syntax-flow": {
           "version": "6.5.0",
-          "from": "babel-plugin-syntax-flow@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.5.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.5.0.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "5.8.38",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -4525,17 +4525,17 @@
         },
         "babel-plugin-syntax-jsx": {
           "version": "6.5.0",
-          "from": "babel-plugin-syntax-jsx@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.5.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.5.0.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "5.8.38",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -4544,17 +4544,17 @@
         },
         "babel-plugin-transform-flow-strip-types": {
           "version": "6.7.0",
-          "from": "babel-plugin-transform-flow-strip-types@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.7.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.7.0.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "5.8.38",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -4563,17 +4563,17 @@
         },
         "babel-plugin-transform-react-display-name": {
           "version": "6.5.0",
-          "from": "babel-plugin-transform-react-display-name@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.5.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.5.0.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "5.8.38",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -4582,134 +4582,134 @@
         },
         "babel-plugin-transform-react-jsx": {
           "version": "6.7.5",
-          "from": "babel-plugin-transform-react-jsx@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.7.5.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.7.5.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "5.8.38",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
             },
             "babel-helper-builder-react-jsx": {
               "version": "6.7.5",
-              "from": "babel-helper-builder-react-jsx@>=6.7.5 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.7.5.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.7.5.tgz",
               "dependencies": {
                 "babel-types": {
                   "version": "6.7.7",
-                  "from": "babel-types@>=6.6.5 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.7.tgz",
                   "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.7.7.tgz",
                   "dependencies": {
                     "babel-traverse": {
                       "version": "6.7.6",
-                      "from": "babel-traverse@>=6.7.2 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
                       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
                       "dependencies": {
                         "babel-code-frame": {
                           "version": "6.7.7",
-                          "from": "babel-code-frame@>=6.7.5 <7.0.0",
+                          "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.7.tgz",
                           "dependencies": {
                             "chalk": {
                               "version": "1.1.3",
-                              "from": "chalk@>=1.1.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                               "dependencies": {
                                 "ansi-styles": {
                                   "version": "2.2.1",
-                                  "from": "ansi-styles@>=2.2.1 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                                 },
                                 "escape-string-regexp": {
                                   "version": "1.0.5",
-                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                                 },
                                 "has-ansi": {
                                   "version": "2.0.0",
-                                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                     }
                                   }
                                 },
                                 "strip-ansi": {
                                   "version": "3.0.1",
-                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                     }
                                   }
                                 },
                                 "supports-color": {
                                   "version": "2.0.0",
-                                  "from": "supports-color@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                                 }
                               }
                             },
                             "js-tokens": {
                               "version": "1.0.3",
-                              "from": "js-tokens@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                             }
                           }
                         },
                         "babel-messages": {
                           "version": "6.7.2",
-                          "from": "babel-messages@>=6.7.2 <7.0.0",
+                          "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz",
                           "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.7.2.tgz"
                         },
                         "babylon": {
                           "version": "6.7.0",
-                          "from": "babylon@>=6.7.0 <7.0.0",
+                          "from": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz",
                           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.7.0.tgz"
                         },
                         "debug": {
                           "version": "2.2.0",
-                          "from": "debug@>=2.2.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                           "dependencies": {
                             "ms": {
                               "version": "0.7.1",
-                              "from": "ms@0.7.1",
+                              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                             }
                           }
                         },
                         "globals": {
                           "version": "8.18.0",
-                          "from": "globals@>=8.3.0 <9.0.0",
+                          "from": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
                           "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
                         },
                         "invariant": {
                           "version": "2.2.1",
-                          "from": "invariant@>=2.2.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                           "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
                           "dependencies": {
                             "loose-envify": {
                               "version": "1.1.0",
-                              "from": "loose-envify@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                               "dependencies": {
                                 "js-tokens": {
                                   "version": "1.0.3",
-                                  "from": "js-tokens@>=1.0.1 <2.0.0",
+                                  "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
                                   "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
                                 }
                               }
@@ -4718,17 +4718,17 @@
                         },
                         "repeating": {
                           "version": "1.1.3",
-                          "from": "repeating@>=1.1.3 <2.0.0",
+                          "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                 }
                               }
@@ -4739,19 +4739,19 @@
                     },
                     "to-fast-properties": {
                       "version": "1.0.2",
-                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
                     }
                   }
                 },
                 "esutils": {
                   "version": "2.0.2",
-                  "from": "esutils@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                 },
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@>=3.10.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 }
               }
@@ -4760,17 +4760,17 @@
         },
         "babel-plugin-transform-react-jsx-source": {
           "version": "6.5.0",
-          "from": "babel-plugin-transform-react-jsx-source@>=6.3.13 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.5.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.5.0.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "5.8.38",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
                 }
               }
@@ -4812,9 +4812,9 @@
               "resolved": "https://registry.npmjs.org/bourbon/-/bourbon-4.2.7.tgz"
             },
             "bourbon-neat": {
-              "version": "1.7.4",
+              "version": "1.8.0",
               "from": "bourbon-neat@>=1.7.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/bourbon-neat/-/bourbon-neat-1.7.4.tgz"
+              "resolved": "https://registry.npmjs.org/bourbon-neat/-/bourbon-neat-1.8.0.tgz"
             },
             "cross-spawn": {
               "version": "2.2.3",
@@ -4936,42 +4936,42 @@
     },
     "codecov.io": {
       "version": "0.1.6",
-      "from": "codecov.io@>=0.1.5 <0.2.0",
+      "from": "https://registry.npmjs.org/codecov.io/-/codecov.io-0.1.6.tgz",
       "resolved": "https://registry.npmjs.org/codecov.io/-/codecov.io-0.1.6.tgz",
       "dependencies": {
         "request": {
           "version": "2.42.0",
-          "from": "request@2.42.0",
+          "from": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
           "resolved": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
           "dependencies": {
             "bl": {
               "version": "0.9.5",
-              "from": "bl@>=0.9.0 <0.10.0",
+              "from": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
               "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.34",
-                  "from": "readable-stream@>=1.0.26 <1.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -4980,194 +4980,194 @@
             },
             "caseless": {
               "version": "0.6.0",
-              "from": "caseless@>=0.6.0 <0.7.0",
+              "from": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz"
             },
             "forever-agent": {
               "version": "0.5.2",
-              "from": "forever-agent@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
             },
             "qs": {
               "version": "1.2.2",
-              "from": "qs@>=1.2.0 <1.3.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
               "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
               "version": "1.0.2",
-              "from": "mime-types@>=1.0.1 <1.1.0",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
             },
             "node-uuid": {
               "version": "1.4.7",
-              "from": "node-uuid@>=1.4.0 <1.5.0",
+              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.2",
-              "from": "tunnel-agent@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
             },
             "tough-cookie": {
               "version": "2.2.2",
-              "from": "tough-cookie@>=0.12.0",
+              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
             },
             "form-data": {
               "version": "0.1.4",
-              "from": "form-data@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
               "dependencies": {
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "combined-stream@>=0.0.4 <0.1.0",
+                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "0.0.5",
-                      "from": "delayed-stream@0.0.5",
+                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                     }
                   }
                 },
                 "mime": {
                   "version": "1.2.11",
-                  "from": "mime@>=1.2.11 <1.3.0",
+                  "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
                 },
                 "async": {
                   "version": "0.9.2",
-                  "from": "async@>=0.9.0 <0.10.0",
+                  "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                 }
               }
             },
             "http-signature": {
               "version": "0.10.1",
-              "from": "http-signature@>=0.10.0 <0.11.0",
+              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.5",
-                  "from": "assert-plus@>=0.1.5 <0.2.0",
+                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                 },
                 "asn1": {
                   "version": "0.1.11",
-                  "from": "asn1@0.1.11",
+                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                 },
                 "ctype": {
                   "version": "0.5.3",
-                  "from": "ctype@0.5.3",
+                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
                   "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                 }
               }
             },
             "oauth-sign": {
               "version": "0.4.0",
-              "from": "oauth-sign@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz"
             },
             "hawk": {
               "version": "1.1.1",
-              "from": "hawk@1.1.1",
+              "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
               "dependencies": {
                 "hoek": {
                   "version": "0.9.1",
-                  "from": "hoek@>=0.9.0 <0.10.0",
+                  "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                 },
                 "boom": {
                   "version": "0.4.2",
-                  "from": "boom@>=0.4.0 <0.5.0",
+                  "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                 },
                 "cryptiles": {
                   "version": "0.2.2",
-                  "from": "cryptiles@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                 },
                 "sntp": {
                   "version": "0.2.4",
-                  "from": "sntp@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                 }
               }
             },
             "aws-sign2": {
               "version": "0.5.0",
-              "from": "aws-sign2@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
             },
             "stringstream": {
               "version": "0.0.5",
-              "from": "stringstream@>=0.0.4 <0.1.0",
+              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
             }
           }
         },
         "urlgrey": {
           "version": "0.4.0",
-          "from": "urlgrey@0.4.0",
+          "from": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.0.tgz",
           "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.0.tgz",
           "dependencies": {
             "tape": {
               "version": "2.3.0",
-              "from": "tape@2.3.0",
+              "from": "https://registry.npmjs.org/tape/-/tape-2.3.0.tgz",
               "resolved": "https://registry.npmjs.org/tape/-/tape-2.3.0.tgz",
               "dependencies": {
                 "jsonify": {
                   "version": "0.0.0",
-                  "from": "jsonify@>=0.0.0 <0.1.0",
+                  "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
                 },
                 "deep-equal": {
                   "version": "0.1.2",
-                  "from": "deep-equal@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.1.2.tgz"
                 },
                 "defined": {
                   "version": "0.0.0",
-                  "from": "defined@>=0.0.0 <0.1.0",
+                  "from": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
                 },
                 "through": {
                   "version": "2.3.8",
-                  "from": "through@>=2.3.4 <2.4.0",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 },
                 "resumer": {
                   "version": "0.0.0",
-                  "from": "resumer@>=0.0.0 <0.1.0",
+                  "from": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz"
                 },
                 "stream-combiner": {
                   "version": "0.0.4",
-                  "from": "stream-combiner@>=0.0.2 <0.1.0",
+                  "from": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
                   "dependencies": {
                     "duplexer": {
                       "version": "0.1.1",
-                      "from": "duplexer@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
                     }
                   }
                 },
                 "split": {
                   "version": "0.2.10",
-                  "from": "split@>=0.2.10 <0.3.0",
+                  "from": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
                   "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -5178,96 +5178,96 @@
     },
     "css-loader": {
       "version": "0.23.1",
-      "from": "css-loader@>=0.23.0 <0.24.0",
+      "from": "https://registry.npmjs.org/css-loader/-/css-loader-0.23.1.tgz",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.23.1.tgz",
       "dependencies": {
         "css-selector-tokenizer": {
           "version": "0.5.4",
-          "from": "css-selector-tokenizer@>=0.5.1 <0.6.0",
+          "from": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.5.4.tgz",
           "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.5.4.tgz",
           "dependencies": {
             "cssesc": {
               "version": "0.1.0",
-              "from": "cssesc@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz"
             },
             "fastparse": {
               "version": "1.1.1",
-              "from": "fastparse@>=1.1.1 <2.0.0",
+              "from": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz"
             }
           }
         },
         "cssnano": {
           "version": "3.5.2",
-          "from": "cssnano@>=2.6.1 <4.0.0",
+          "from": "https://registry.npmjs.org/cssnano/-/cssnano-3.5.2.tgz",
           "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.5.2.tgz",
           "dependencies": {
             "autoprefixer": {
               "version": "6.3.6",
-              "from": "autoprefixer@>=6.3.1 <7.0.0",
+              "from": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.3.6.tgz",
               "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.3.6.tgz",
               "dependencies": {
                 "normalize-range": {
                   "version": "0.1.2",
-                  "from": "normalize-range@>=0.1.2 <0.2.0",
+                  "from": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz"
                 },
                 "num2fraction": {
                   "version": "1.2.2",
-                  "from": "num2fraction@>=1.2.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
                 },
                 "browserslist": {
                   "version": "1.3.1",
-                  "from": "browserslist@>=1.3.1 <1.4.0",
+                  "from": "https://registry.npmjs.org/browserslist/-/browserslist-1.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.3.1.tgz"
                 },
                 "caniuse-db": {
                   "version": "1.0.30000460",
-                  "from": "caniuse-db@>=1.0.30000444 <2.0.0",
+                  "from": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000460.tgz",
                   "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000460.tgz"
                 }
               }
             },
             "decamelize": {
               "version": "1.2.0",
-              "from": "decamelize@>=1.1.2 <2.0.0",
+              "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
             },
             "defined": {
               "version": "1.0.0",
-              "from": "defined@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
             },
             "indexes-of": {
               "version": "1.0.1",
-              "from": "indexes-of@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz"
             },
             "postcss-calc": {
               "version": "5.2.1",
-              "from": "postcss-calc@>=5.2.0 <6.0.0",
+              "from": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.2.1.tgz",
               "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.2.1.tgz",
               "dependencies": {
                 "postcss-message-helpers": {
                   "version": "2.0.0",
-                  "from": "postcss-message-helpers@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz"
                 },
                 "reduce-css-calc": {
                   "version": "1.2.3",
-                  "from": "reduce-css-calc@>=1.2.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.2.3.tgz",
                   "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.2.3.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.1.0",
-                      "from": "balanced-match@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz"
                     },
                     "reduce-function-call": {
                       "version": "1.0.1",
-                      "from": "reduce-function-call@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz"
                     }
                   }
@@ -5276,32 +5276,32 @@
             },
             "postcss-colormin": {
               "version": "2.2.0",
-              "from": "postcss-colormin@>=2.1.8 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.0.tgz",
               "dependencies": {
                 "colormin": {
                   "version": "1.1.0",
-                  "from": "colormin@>=1.0.5 <2.0.0",
+                  "from": "https://registry.npmjs.org/colormin/-/colormin-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.0.tgz",
                   "dependencies": {
                     "color": {
                       "version": "0.11.1",
-                      "from": "color@>=0.11.0 <0.12.0",
+                      "from": "https://registry.npmjs.org/color/-/color-0.11.1.tgz",
                       "resolved": "https://registry.npmjs.org/color/-/color-0.11.1.tgz",
                       "dependencies": {
                         "color-convert": {
                           "version": "0.5.3",
-                          "from": "color-convert@>=0.5.3 <0.6.0",
+                          "from": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
                           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz"
                         },
                         "color-string": {
                           "version": "0.3.0",
-                          "from": "color-string@>=0.3.0 <0.4.0",
+                          "from": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
                           "dependencies": {
                             "color-name": {
                               "version": "1.1.1",
-                              "from": "color-name@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
                               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz"
                             }
                           }
@@ -5310,7 +5310,7 @@
                     },
                     "css-color-names": {
                       "version": "0.0.3",
-                      "from": "css-color-names@0.0.3",
+                      "from": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.3.tgz"
                     }
                   }
@@ -5319,132 +5319,132 @@
             },
             "postcss-convert-values": {
               "version": "2.3.4",
-              "from": "postcss-convert-values@>=2.3.4 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.3.4.tgz",
               "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.3.4.tgz"
             },
             "postcss-discard-comments": {
               "version": "2.0.4",
-              "from": "postcss-discard-comments@>=2.0.4 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
               "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz"
             },
             "postcss-discard-duplicates": {
               "version": "2.0.1",
-              "from": "postcss-discard-duplicates@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.0.1.tgz"
             },
             "postcss-discard-empty": {
               "version": "2.1.0",
-              "from": "postcss-discard-empty@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz"
             },
             "postcss-discard-unused": {
               "version": "2.2.1",
-              "from": "postcss-discard-unused@>=2.2.1 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.1.tgz",
               "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.1.tgz",
               "dependencies": {
                 "flatten": {
                   "version": "1.0.2",
-                  "from": "flatten@1.0.2",
+                  "from": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz"
                 },
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
                 }
               }
             },
             "postcss-filter-plugins": {
               "version": "2.0.0",
-              "from": "postcss-filter-plugins@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.0.tgz",
               "dependencies": {
                 "uniqid": {
                   "version": "1.0.0",
-                  "from": "uniqid@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/uniqid/-/uniqid-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-1.0.0.tgz"
                 }
               }
             },
             "postcss-merge-idents": {
               "version": "2.1.5",
-              "from": "postcss-merge-idents@>=2.1.5 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.5.tgz",
               "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.5.tgz",
               "dependencies": {
                 "has-own": {
                   "version": "1.0.0",
-                  "from": "has-own@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/has-own/-/has-own-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-own/-/has-own-1.0.0.tgz"
                 }
               }
             },
             "postcss-merge-longhand": {
               "version": "2.0.1",
-              "from": "postcss-merge-longhand@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.1.tgz"
             },
             "postcss-merge-rules": {
               "version": "2.0.7",
-              "from": "postcss-merge-rules@>=2.0.3 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.0.7.tgz",
               "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.0.7.tgz"
             },
             "postcss-minify-font-values": {
               "version": "1.0.3",
-              "from": "postcss-minify-font-values@>=1.0.2 <2.0.0",
+              "from": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.3.tgz",
               "dependencies": {
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
                 }
               }
             },
             "postcss-minify-gradients": {
               "version": "1.0.1",
-              "from": "postcss-minify-gradients@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.1.tgz"
             },
             "postcss-minify-params": {
               "version": "1.0.4",
-              "from": "postcss-minify-params@>=1.0.4 <2.0.0",
+              "from": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.0.4.tgz",
               "dependencies": {
                 "alphanum-sort": {
                   "version": "1.0.2",
-                  "from": "alphanum-sort@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
                 },
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
                 }
               }
             },
             "postcss-minify-selectors": {
               "version": "2.0.4",
-              "from": "postcss-minify-selectors@>=2.0.4 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.0.4.tgz",
               "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.0.4.tgz",
               "dependencies": {
                 "alphanum-sort": {
                   "version": "1.0.2",
-                  "from": "alphanum-sort@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
                 },
                 "postcss-selector-parser": {
                   "version": "1.3.3",
-                  "from": "postcss-selector-parser@>=1.3.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-1.3.3.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-1.3.3.tgz",
                   "dependencies": {
                     "flatten": {
                       "version": "1.0.2",
-                      "from": "flatten@>=1.0.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz"
                     },
                     "uniq": {
                       "version": "1.0.1",
-                      "from": "uniq@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
                     }
                   }
@@ -5453,49 +5453,49 @@
             },
             "postcss-normalize-charset": {
               "version": "1.1.0",
-              "from": "postcss-normalize-charset@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.0.tgz"
             },
             "postcss-normalize-url": {
               "version": "3.0.7",
-              "from": "postcss-normalize-url@>=3.0.7 <4.0.0",
+              "from": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.7.tgz",
               "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.7.tgz",
               "dependencies": {
                 "is-absolute-url": {
                   "version": "2.0.0",
-                  "from": "is-absolute-url@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.0.0.tgz"
                 },
                 "normalize-url": {
                   "version": "1.4.1",
-                  "from": "normalize-url@>=1.4.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.4.1.tgz",
                   "dependencies": {
                     "prepend-http": {
                       "version": "1.0.3",
-                      "from": "prepend-http@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz"
                     },
                     "query-string": {
                       "version": "3.0.3",
-                      "from": "query-string@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/query-string/-/query-string-3.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/query-string/-/query-string-3.0.3.tgz",
                       "dependencies": {
                         "strict-uri-encode": {
                           "version": "1.1.0",
-                          "from": "strict-uri-encode@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz"
                         }
                       }
                     },
                     "sort-keys": {
                       "version": "1.1.1",
-                      "from": "sort-keys@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.1.tgz",
                       "dependencies": {
                         "is-plain-obj": {
                           "version": "1.1.0",
-                          "from": "is-plain-obj@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
                         }
                       }
@@ -5506,156 +5506,156 @@
             },
             "postcss-ordered-values": {
               "version": "2.1.0",
-              "from": "postcss-ordered-values@>=2.1.0 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.1.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.1.0.tgz"
             },
             "postcss-reduce-idents": {
               "version": "2.3.0",
-              "from": "postcss-reduce-idents@>=2.2.2 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.3.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.3.0.tgz"
             },
             "postcss-reduce-transforms": {
               "version": "1.0.3",
-              "from": "postcss-reduce-transforms@>=1.0.3 <2.0.0",
+              "from": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.3.tgz"
             },
             "postcss-svgo": {
               "version": "2.1.3",
-              "from": "postcss-svgo@>=2.1.1 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.3.tgz",
               "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.3.tgz",
               "dependencies": {
                 "is-svg": {
                   "version": "2.0.0",
-                  "from": "is-svg@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/is-svg/-/is-svg-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.0.0.tgz",
                   "dependencies": {
                     "html-comment-regex": {
                       "version": "1.1.0",
-                      "from": "html-comment-regex@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.0.tgz"
                     }
                   }
                 },
                 "svgo": {
                   "version": "0.6.6",
-                  "from": "svgo@>=0.6.1 <0.7.0",
+                  "from": "https://registry.npmjs.org/svgo/-/svgo-0.6.6.tgz",
                   "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.6.6.tgz",
                   "dependencies": {
                     "sax": {
                       "version": "1.2.1",
-                      "from": "sax@>=1.2.1 <1.3.0",
+                      "from": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz"
                     },
                     "coa": {
                       "version": "1.0.1",
-                      "from": "coa@>=1.0.1 <1.1.0",
+                      "from": "https://registry.npmjs.org/coa/-/coa-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.1.tgz",
                       "dependencies": {
                         "q": {
                           "version": "1.4.1",
-                          "from": "q@>=1.1.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
                           "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
                         }
                       }
                     },
                     "js-yaml": {
                       "version": "3.6.0",
-                      "from": "js-yaml@>=3.6.0 <3.7.0",
+                      "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.0.tgz",
                       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.0.tgz",
                       "dependencies": {
                         "argparse": {
                           "version": "1.0.7",
-                          "from": "argparse@>=1.0.7 <2.0.0",
+                          "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
                           "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
                           "dependencies": {
                             "sprintf-js": {
                               "version": "1.0.3",
-                              "from": "sprintf-js@>=1.0.2 <1.1.0",
+                              "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                             }
                           }
                         },
                         "esprima": {
                           "version": "2.7.2",
-                          "from": "esprima@>=2.6.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
                           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
                         }
                       }
                     },
                     "colors": {
                       "version": "1.1.2",
-                      "from": "colors@>=1.1.2 <1.2.0",
+                      "from": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
                     },
                     "whet.extend": {
                       "version": "0.9.9",
-                      "from": "whet.extend@>=0.9.9 <0.10.0",
+                      "from": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
                       "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
                     },
                     "mkdirp": {
                       "version": "0.5.1",
-                      "from": "mkdirp@>=0.5.1 <0.6.0",
+                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "dependencies": {
                         "minimist": {
                           "version": "0.0.8",
-                          "from": "minimist@0.0.8",
+                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                         }
                       }
                     },
                     "csso": {
                       "version": "2.0.0",
-                      "from": "csso@>=2.0.0 <2.1.0",
+                      "from": "https://registry.npmjs.org/csso/-/csso-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/csso/-/csso-2.0.0.tgz",
                       "dependencies": {
                         "clap": {
                           "version": "1.1.0",
-                          "from": "clap@>=1.0.9 <2.0.0",
+                          "from": "https://registry.npmjs.org/clap/-/clap-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/clap/-/clap-1.1.0.tgz",
                           "dependencies": {
                             "chalk": {
                               "version": "1.1.1",
-                              "from": "chalk@1.1.1",
+                              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                               "dependencies": {
                                 "ansi-styles": {
                                   "version": "2.2.1",
-                                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                                 },
                                 "escape-string-regexp": {
                                   "version": "1.0.5",
-                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                                 },
                                 "has-ansi": {
                                   "version": "2.0.0",
-                                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                     }
                                   }
                                 },
                                 "strip-ansi": {
                                   "version": "3.0.1",
-                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                     }
                                   }
                                 },
                                 "supports-color": {
                                   "version": "2.0.0",
-                                  "from": "supports-color@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                                 }
                               }
@@ -5664,7 +5664,7 @@
                         },
                         "source-map": {
                           "version": "0.5.5",
-                          "from": "source-map@>=0.5.3 <0.6.0",
+                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.5.tgz",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.5.tgz"
                         }
                       }
@@ -5675,34 +5675,34 @@
             },
             "postcss-unique-selectors": {
               "version": "2.0.2",
-              "from": "postcss-unique-selectors@>=2.0.2 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
               "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
               "dependencies": {
                 "alphanum-sort": {
                   "version": "1.0.2",
-                  "from": "alphanum-sort@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
                 },
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
                 }
               }
             },
             "postcss-value-parser": {
               "version": "3.3.0",
-              "from": "postcss-value-parser@>=3.2.3 <4.0.0",
+              "from": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
             },
             "postcss-zindex": {
               "version": "2.1.1",
-              "from": "postcss-zindex@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.1.1.tgz",
               "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.1.1.tgz",
               "dependencies": {
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
                 }
               }
@@ -5711,61 +5711,61 @@
         },
         "loader-utils": {
           "version": "0.2.14",
-          "from": "loader-utils@>=0.2.2 <0.3.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.14.tgz",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.14.tgz",
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.1.3 <4.0.0",
+              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "emojis-list": {
               "version": "1.0.1",
-              "from": "emojis-list@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.1.tgz"
             },
             "json5": {
               "version": "0.5.0",
-              "from": "json5@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz"
             }
           }
         },
         "object-assign": {
           "version": "4.0.1",
-          "from": "object-assign@>=4.0.1 <5.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
         },
         "lodash.camelcase": {
           "version": "3.0.1",
-          "from": "lodash.camelcase@>=3.0.1 <4.0.0",
+          "from": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-3.0.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-3.0.1.tgz",
           "dependencies": {
             "lodash._createcompounder": {
               "version": "3.0.0",
-              "from": "lodash._createcompounder@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._createcompounder/-/lodash._createcompounder-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash._createcompounder/-/lodash._createcompounder-3.0.0.tgz",
               "dependencies": {
                 "lodash.deburr": {
                   "version": "3.2.0",
-                  "from": "lodash.deburr@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-3.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-3.2.0.tgz",
                   "dependencies": {
                     "lodash._root": {
                       "version": "3.0.1",
-                      "from": "lodash._root@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
                     }
                   }
                 },
                 "lodash.words": {
                   "version": "3.2.0",
-                  "from": "lodash.words@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.words/-/lodash.words-3.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.words/-/lodash.words-3.2.0.tgz",
                   "dependencies": {
                     "lodash._root": {
                       "version": "3.0.1",
-                      "from": "lodash._root@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
                     }
                   }
@@ -5776,159 +5776,159 @@
         },
         "postcss": {
           "version": "5.0.19",
-          "from": "postcss@>=5.0.19 <6.0.0",
+          "from": "https://registry.npmjs.org/postcss/-/postcss-5.0.19.tgz",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.19.tgz",
           "dependencies": {
             "supports-color": {
               "version": "3.1.2",
-              "from": "supports-color@>=3.1.2 <4.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
               "dependencies": {
                 "has-flag": {
                   "version": "1.0.0",
-                  "from": "has-flag@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
                 }
               }
             },
             "source-map": {
               "version": "0.5.5",
-              "from": "source-map@>=0.5.1 <0.6.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.5.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.5.tgz"
             },
             "js-base64": {
               "version": "2.1.9",
-              "from": "js-base64@>=2.1.9 <3.0.0",
+              "from": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
               "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
             }
           }
         },
         "postcss-modules-extract-imports": {
           "version": "1.0.0",
-          "from": "postcss-modules-extract-imports@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.0.0.tgz"
         },
         "postcss-modules-local-by-default": {
           "version": "1.0.1",
-          "from": "postcss-modules-local-by-default@>=1.0.1 <2.0.0",
+          "from": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.0.1.tgz"
         },
         "postcss-modules-scope": {
           "version": "1.0.0",
-          "from": "postcss-modules-scope@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.0.0.tgz"
         },
         "postcss-modules-values": {
           "version": "1.1.2",
-          "from": "postcss-modules-values@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.1.2.tgz",
           "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.1.2.tgz",
           "dependencies": {
             "icss-replace-symbols": {
               "version": "1.0.2",
-              "from": "icss-replace-symbols@>=1.0.2 <2.0.0",
+              "from": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.0.2.tgz"
             }
           }
         },
         "source-list-map": {
           "version": "0.1.6",
-          "from": "source-list-map@>=0.1.4 <0.2.0",
+          "from": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.6.tgz",
           "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.6.tgz"
         }
       }
     },
     "cssnext-loader": {
       "version": "1.0.1",
-      "from": "cssnext-loader@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/cssnext-loader/-/cssnext-loader-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/cssnext-loader/-/cssnext-loader-1.0.1.tgz",
       "dependencies": {
         "cssnext": {
           "version": "1.8.4",
-          "from": "cssnext@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/cssnext/-/cssnext-1.8.4.tgz",
           "resolved": "https://registry.npmjs.org/cssnext/-/cssnext-1.8.4.tgz",
           "dependencies": {
             "autoprefixer-core": {
               "version": "5.2.1",
-              "from": "autoprefixer-core@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.2.1.tgz",
               "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.2.1.tgz",
               "dependencies": {
                 "browserslist": {
                   "version": "0.4.0",
-                  "from": "browserslist@>=0.4.0 <0.5.0",
+                  "from": "https://registry.npmjs.org/browserslist/-/browserslist-0.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.4.0.tgz"
                 },
                 "num2fraction": {
                   "version": "1.2.2",
-                  "from": "num2fraction@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
                 },
                 "caniuse-db": {
                   "version": "1.0.30000460",
-                  "from": "caniuse-db@>=1.0.30000214 <2.0.0",
+                  "from": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000460.tgz",
                   "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000460.tgz"
                 }
               }
             },
             "caniuse-api": {
               "version": "1.4.1",
-              "from": "caniuse-api@>=1.3.1 <2.0.0",
+              "from": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.4.1.tgz",
               "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.4.1.tgz",
               "dependencies": {
                 "browserslist": {
                   "version": "1.3.1",
-                  "from": "browserslist@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/browserslist/-/browserslist-1.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.3.1.tgz"
                 },
                 "caniuse-db": {
                   "version": "1.0.30000460",
-                  "from": "caniuse-db@>=1.0.30000346 <2.0.0",
+                  "from": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000460.tgz",
                   "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000460.tgz"
                 },
                 "lodash.memoize": {
                   "version": "2.4.1",
-                  "from": "lodash.memoize@>=2.4.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-2.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-2.4.1.tgz",
                   "dependencies": {
                     "lodash.isfunction": {
                       "version": "2.4.1",
-                      "from": "lodash.isfunction@>=2.4.1 <2.5.0",
+                      "from": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz"
                     },
                     "lodash._keyprefix": {
                       "version": "2.4.2",
-                      "from": "lodash._keyprefix@>=2.4.1 <2.5.0",
+                      "from": "https://registry.npmjs.org/lodash._keyprefix/-/lodash._keyprefix-2.4.2.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._keyprefix/-/lodash._keyprefix-2.4.2.tgz"
                     }
                   }
                 },
                 "lodash.uniq": {
                   "version": "3.2.2",
-                  "from": "lodash.uniq@>=3.1.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-3.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-3.2.2.tgz",
                   "dependencies": {
                     "lodash._basecallback": {
                       "version": "3.3.1",
-                      "from": "lodash._basecallback@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash._basecallback/-/lodash._basecallback-3.3.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._basecallback/-/lodash._basecallback-3.3.1.tgz",
                       "dependencies": {
                         "lodash._baseisequal": {
                           "version": "3.0.7",
-                          "from": "lodash._baseisequal@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
                           "resolved": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
                           "dependencies": {
                             "lodash.istypedarray": {
                               "version": "3.0.6",
-                              "from": "lodash.istypedarray@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
                               "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz"
                             },
                             "lodash.keys": {
                               "version": "3.1.2",
-                              "from": "lodash.keys@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                               "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                               "dependencies": {
                                 "lodash.isarguments": {
                                   "version": "3.0.8",
-                                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                                  "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz",
                                   "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
                                 }
                               }
@@ -5937,22 +5937,22 @@
                         },
                         "lodash._bindcallback": {
                           "version": "3.0.1",
-                          "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
                         },
                         "lodash.pairs": {
                           "version": "3.0.1",
-                          "from": "lodash.pairs@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/lodash.pairs/-/lodash.pairs-3.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/lodash.pairs/-/lodash.pairs-3.0.1.tgz",
                           "dependencies": {
                             "lodash.keys": {
                               "version": "3.1.2",
-                              "from": "lodash.keys@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                               "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                               "dependencies": {
                                 "lodash.isarguments": {
                                   "version": "3.0.8",
-                                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                                  "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz",
                                   "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
                                 }
                               }
@@ -5963,173 +5963,173 @@
                     },
                     "lodash._baseuniq": {
                       "version": "3.0.3",
-                      "from": "lodash._baseuniq@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-3.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-3.0.3.tgz",
                       "dependencies": {
                         "lodash._baseindexof": {
                           "version": "3.1.0",
-                          "from": "lodash._baseindexof@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz"
                         },
                         "lodash._cacheindexof": {
                           "version": "3.0.2",
-                          "from": "lodash._cacheindexof@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz"
                         },
                         "lodash._createcache": {
                           "version": "3.1.2",
-                          "from": "lodash._createcache@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz"
                         }
                       }
                     },
                     "lodash._getnative": {
                       "version": "3.9.1",
-                      "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                     },
                     "lodash._isiterateecall": {
                       "version": "3.0.9",
-                      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
                     },
                     "lodash.isarray": {
                       "version": "3.0.4",
-                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                     }
                   }
                 },
                 "shelljs": {
                   "version": "0.5.3",
-                  "from": "shelljs@>=0.5.3 <0.6.0",
+                  "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
                   "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz"
                 }
               }
             },
             "chalk": {
               "version": "1.1.3",
-              "from": "chalk@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.2.1",
-                  "from": "ansi-styles@>=2.2.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "chokidar": {
               "version": "1.4.3",
-              "from": "chokidar@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.3.tgz",
               "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.3.tgz",
               "dependencies": {
                 "anymatch": {
                   "version": "1.3.0",
-                  "from": "anymatch@>=1.3.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
                   "dependencies": {
                     "arrify": {
                       "version": "1.0.1",
-                      "from": "arrify@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
                     },
                     "micromatch": {
                       "version": "2.3.8",
-                      "from": "micromatch@>=2.1.5 <3.0.0",
+                      "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.8.tgz",
                       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.8.tgz",
                       "dependencies": {
                         "arr-diff": {
                           "version": "2.0.0",
-                          "from": "arr-diff@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
                           "dependencies": {
                             "arr-flatten": {
                               "version": "1.0.1",
-                              "from": "arr-flatten@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
                             }
                           }
                         },
                         "array-unique": {
                           "version": "0.2.1",
-                          "from": "array-unique@>=0.2.1 <0.3.0",
+                          "from": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
                           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
                         },
                         "braces": {
                           "version": "1.8.4",
-                          "from": "braces@>=1.8.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/braces/-/braces-1.8.4.tgz",
                           "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.4.tgz",
                           "dependencies": {
                             "expand-range": {
                               "version": "1.8.1",
-                              "from": "expand-range@>=1.8.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                               "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                               "dependencies": {
                                 "fill-range": {
                                   "version": "2.2.3",
-                                  "from": "fill-range@>=2.1.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
                                   "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
                                   "dependencies": {
                                     "is-number": {
                                       "version": "2.1.0",
-                                      "from": "is-number@>=2.1.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
                                       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
                                     },
                                     "isobject": {
                                       "version": "2.1.0",
-                                      "from": "isobject@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                                       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                                       "dependencies": {
                                         "isarray": {
                                           "version": "1.0.0",
-                                          "from": "isarray@1.0.0",
+                                          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                                         }
                                       }
                                     },
                                     "randomatic": {
                                       "version": "1.1.5",
-                                      "from": "randomatic@>=1.1.3 <2.0.0",
+                                      "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
                                       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
                                     },
                                     "repeat-string": {
                                       "version": "1.5.4",
-                                      "from": "repeat-string@>=1.5.2 <2.0.0",
+                                      "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
                                       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                     }
                                   }
@@ -6138,114 +6138,114 @@
                             },
                             "preserve": {
                               "version": "0.2.0",
-                              "from": "preserve@>=0.2.0 <0.3.0",
+                              "from": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
                               "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
                             },
                             "repeat-element": {
                               "version": "1.1.2",
-                              "from": "repeat-element@>=1.1.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
                               "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
                             }
                           }
                         },
                         "expand-brackets": {
                           "version": "0.1.5",
-                          "from": "expand-brackets@>=0.1.4 <0.2.0",
+                          "from": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
                           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
                           "dependencies": {
                             "is-posix-bracket": {
                               "version": "0.1.1",
-                              "from": "is-posix-bracket@>=0.1.0 <0.2.0",
+                              "from": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
                               "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
                             }
                           }
                         },
                         "extglob": {
                           "version": "0.3.2",
-                          "from": "extglob@>=0.3.1 <0.4.0",
+                          "from": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
                           "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
                         },
                         "filename-regex": {
                           "version": "2.0.0",
-                          "from": "filename-regex@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
                         },
                         "is-extglob": {
                           "version": "1.0.0",
-                          "from": "is-extglob@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                         },
                         "kind-of": {
                           "version": "3.0.2",
-                          "from": "kind-of@>=3.0.2 <4.0.0",
+                          "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                           "dependencies": {
                             "is-buffer": {
                               "version": "1.1.3",
-                              "from": "is-buffer@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
                               "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                             }
                           }
                         },
                         "normalize-path": {
                           "version": "2.0.1",
-                          "from": "normalize-path@>=2.0.1 <3.0.0",
+                          "from": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
                         },
                         "object.omit": {
                           "version": "2.0.0",
-                          "from": "object.omit@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
                           "dependencies": {
                             "for-own": {
                               "version": "0.1.4",
-                              "from": "for-own@>=0.1.3 <0.2.0",
+                              "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
                               "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
                               "dependencies": {
                                 "for-in": {
                                   "version": "0.1.5",
-                                  "from": "for-in@>=0.1.5 <0.2.0",
+                                  "from": "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz",
                                   "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz"
                                 }
                               }
                             },
                             "is-extendable": {
                               "version": "0.1.1",
-                              "from": "is-extendable@>=0.1.1 <0.2.0",
+                              "from": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
                               "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
                             }
                           }
                         },
                         "parse-glob": {
                           "version": "3.0.4",
-                          "from": "parse-glob@>=3.0.4 <4.0.0",
+                          "from": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
                           "dependencies": {
                             "glob-base": {
                               "version": "0.3.0",
-                              "from": "glob-base@>=0.3.0 <0.4.0",
+                              "from": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
                               "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
                             },
                             "is-dotfile": {
                               "version": "1.0.2",
-                              "from": "is-dotfile@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
                             }
                           }
                         },
                         "regex-cache": {
                           "version": "0.4.3",
-                          "from": "regex-cache@>=0.4.2 <0.5.0",
+                          "from": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
                           "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
                           "dependencies": {
                             "is-equal-shallow": {
                               "version": "0.1.3",
-                              "from": "is-equal-shallow@>=0.1.3 <0.2.0",
+                              "from": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
                               "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
                             },
                             "is-primitive": {
                               "version": "2.0.0",
-                              "from": "is-primitive@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
                             }
                           }
@@ -6256,76 +6256,76 @@
                 },
                 "async-each": {
                   "version": "1.0.0",
-                  "from": "async-each@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/async-each/-/async-each-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.0.tgz"
                 },
                 "glob-parent": {
                   "version": "2.0.0",
-                  "from": "glob-parent@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "is-binary-path": {
                   "version": "1.0.1",
-                  "from": "is-binary-path@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
                   "dependencies": {
                     "binary-extensions": {
                       "version": "1.4.0",
-                      "from": "binary-extensions@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz",
                       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz"
                     }
                   }
                 },
                 "is-glob": {
                   "version": "2.0.1",
-                  "from": "is-glob@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                   "dependencies": {
                     "is-extglob": {
                       "version": "1.0.0",
-                      "from": "is-extglob@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                 },
                 "readdirp": {
                   "version": "2.0.0",
-                  "from": "readdirp@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
                   "dependencies": {
                     "graceful-fs": {
                       "version": "4.1.3",
-                      "from": "graceful-fs@>=4.1.2 <5.0.0",
+                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                     },
                     "minimatch": {
                       "version": "2.0.10",
-                      "from": "minimatch@>=2.0.10 <3.0.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.3",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.3.0",
-                              "from": "balanced-match@>=0.3.0 <0.4.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
@@ -6334,66 +6334,66 @@
                     },
                     "readable-stream": {
                       "version": "2.1.0",
-                      "from": "readable-stream@>=2.0.2 <3.0.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.0.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "inline-process-browser": {
                           "version": "2.0.1",
-                          "from": "inline-process-browser@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inline-process-browser/-/inline-process-browser-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inline-process-browser/-/inline-process-browser-2.0.1.tgz",
                           "dependencies": {
                             "falafel": {
                               "version": "1.2.0",
-                              "from": "falafel@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
                               "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
                               "dependencies": {
                                 "acorn": {
                                   "version": "1.2.2",
-                                  "from": "acorn@>=1.0.3 <2.0.0",
+                                  "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
                                   "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
                                 },
                                 "foreach": {
                                   "version": "2.0.5",
-                                  "from": "foreach@>=2.0.5 <3.0.0",
+                                  "from": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
                                   "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
                                 },
                                 "isarray": {
                                   "version": "0.0.1",
-                                  "from": "isarray@0.0.1",
+                                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                                 },
                                 "object-keys": {
                                   "version": "1.0.9",
-                                  "from": "object-keys@>=1.0.6 <2.0.0",
+                                  "from": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz",
                                   "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz"
                                 }
                               }
                             },
                             "through2": {
                               "version": "0.6.5",
-                              "from": "through2@>=0.6.5 <0.7.0",
+                              "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                               "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                               "dependencies": {
                                 "readable-stream": {
                                   "version": "1.0.34",
-                                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                                   "dependencies": {
                                     "isarray": {
                                       "version": "0.0.1",
-                                      "from": "isarray@0.0.1",
+                                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                                     }
                                   }
                                 },
                                 "xtend": {
                                   "version": "4.0.1",
-                                  "from": "xtend@>=4.0.0 <4.1.0-0",
+                                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                                 }
                               }
@@ -6402,52 +6402,52 @@
                         },
                         "isarray": {
                           "version": "1.0.0",
-                          "from": "isarray@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                         },
                         "process-nextick-args": {
                           "version": "1.0.6",
-                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                          "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "unreachable-branch-transform": {
                           "version": "0.5.1",
-                          "from": "unreachable-branch-transform@>=0.5.0 <0.6.0",
+                          "from": "https://registry.npmjs.org/unreachable-branch-transform/-/unreachable-branch-transform-0.5.1.tgz",
                           "resolved": "https://registry.npmjs.org/unreachable-branch-transform/-/unreachable-branch-transform-0.5.1.tgz",
                           "dependencies": {
                             "esmangle-evaluator": {
                               "version": "1.0.0",
-                              "from": "esmangle-evaluator@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.0.tgz"
                             },
                             "recast": {
                               "version": "0.11.5",
-                              "from": "recast@>=0.11.4 <0.12.0",
+                              "from": "https://registry.npmjs.org/recast/-/recast-0.11.5.tgz",
                               "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.5.tgz",
                               "dependencies": {
                                 "ast-types": {
                                   "version": "0.8.16",
-                                  "from": "ast-types@0.8.16",
+                                  "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.16.tgz",
                                   "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.16.tgz"
                                 },
                                 "esprima": {
                                   "version": "2.7.2",
-                                  "from": "esprima@>=2.7.1 <2.8.0",
+                                  "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
                                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
                                 },
                                 "private": {
                                   "version": "0.1.6",
-                                  "from": "private@>=0.1.6 <0.2.0",
+                                  "from": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
                                   "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
                                 },
                                 "source-map": {
                                   "version": "0.5.5",
-                                  "from": "source-map@>=0.5.0 <0.6.0",
+                                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.5.tgz",
                                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.5.tgz"
                                 }
                               }
@@ -6456,7 +6456,7 @@
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                         }
                       }
@@ -6465,12 +6465,12 @@
                 },
                 "fsevents": {
                   "version": "1.0.11",
-                  "from": "fsevents@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.11.tgz",
                   "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.11.tgz",
                   "dependencies": {
                     "nan": {
                       "version": "2.3.2",
-                      "from": "nan@>=2.1.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/nan/-/nan-2.3.2.tgz",
                       "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.2.tgz"
                     },
                     "node-pre-gyp": {
@@ -6497,25 +6497,25 @@
                       "from": "ansi@~0.3.1",
                       "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz"
                     },
-                    "ansi-styles": {
-                      "version": "2.2.1",
-                      "from": "ansi-styles@^2.2.1",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                    },
                     "ansi-regex": {
                       "version": "2.0.0",
                       "from": "ansi-regex@^2.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     },
-                    "are-we-there-yet": {
-                      "version": "1.1.2",
-                      "from": "are-we-there-yet@~1.1.2",
-                      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz"
+                    "ansi-styles": {
+                      "version": "2.2.1",
+                      "from": "ansi-styles@^2.2.1",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                     },
                     "asn1": {
                       "version": "0.2.3",
                       "from": "asn1@>=0.2.3 <0.3.0",
                       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                    },
+                    "are-we-there-yet": {
+                      "version": "1.1.2",
+                      "from": "are-we-there-yet@~1.1.2",
+                      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz"
                     },
                     "assert-plus": {
                       "version": "0.2.0",
@@ -6527,6 +6527,11 @@
                       "from": "async@^1.5.2",
                       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
                     },
+                    "block-stream": {
+                      "version": "0.0.8",
+                      "from": "block-stream@*",
+                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
+                    },
                     "aws-sign2": {
                       "version": "0.6.0",
                       "from": "aws-sign2@~0.6.0",
@@ -6537,30 +6542,20 @@
                       "from": "bl@~1.0.0",
                       "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz"
                     },
-                    "block-stream": {
-                      "version": "0.0.8",
-                      "from": "block-stream@*",
-                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
-                    },
                     "boom": {
                       "version": "2.10.1",
                       "from": "boom@2.x.x",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                     },
-                    "caseless": {
-                      "version": "0.11.0",
-                      "from": "caseless@~0.11.0",
-                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
-                    },
-                    "commander": {
-                      "version": "2.9.0",
-                      "from": "commander@^2.9.0",
-                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
-                    },
                     "chalk": {
                       "version": "1.1.3",
                       "from": "chalk@^1.1.1",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+                    },
+                    "caseless": {
+                      "version": "0.11.0",
+                      "from": "caseless@~0.11.0",
+                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
                     },
                     "combined-stream": {
                       "version": "1.0.5",
@@ -6572,15 +6567,15 @@
                       "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
+                    "commander": {
+                      "version": "2.9.0",
+                      "from": "commander@^2.9.0",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+                    },
                     "cryptiles": {
                       "version": "2.0.5",
                       "from": "cryptiles@2.x.x",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                    },
-                    "deep-extend": {
-                      "version": "0.4.1",
-                      "from": "deep-extend@~0.4.0",
-                      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
                     },
                     "debug": {
                       "version": "2.2.0",
@@ -6592,10 +6587,10 @@
                       "from": "delayed-stream@~1.0.0",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                     },
-                    "ecc-jsbn": {
-                      "version": "0.1.1",
-                      "from": "ecc-jsbn@>=0.0.1 <1.0.0",
-                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                    "deep-extend": {
+                      "version": "0.4.1",
+                      "from": "deep-extend@~0.4.0",
+                      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
                     },
                     "delegates": {
                       "version": "1.0.0",
@@ -6612,15 +6607,20 @@
                       "from": "extend@~3.0.0",
                       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
                     },
-                    "forever-agent": {
-                      "version": "0.6.1",
-                      "from": "forever-agent@~0.6.1",
-                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "from": "ecc-jsbn@>=0.0.1 <1.0.0",
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                     },
                     "extsprintf": {
                       "version": "1.0.2",
                       "from": "extsprintf@1.0.2",
                       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                    },
+                    "forever-agent": {
+                      "version": "0.6.1",
+                      "from": "forever-agent@~0.6.1",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                     },
                     "form-data": {
                       "version": "1.0.0-rc4",
@@ -6632,6 +6632,11 @@
                       "from": "fstream@^1.0.2",
                       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
                     },
+                    "generate-object-property": {
+                      "version": "1.2.0",
+                      "from": "generate-object-property@^1.1.0",
+                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+                    },
                     "gauge": {
                       "version": "1.2.7",
                       "from": "gauge@~1.2.5",
@@ -6642,25 +6647,25 @@
                       "from": "generate-function@^2.0.0",
                       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
-                    "generate-object-property": {
-                      "version": "1.2.0",
-                      "from": "generate-object-property@^1.1.0",
-                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
-                    },
-                    "har-validator": {
-                      "version": "2.0.6",
-                      "from": "har-validator@~2.0.6",
-                      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
+                    "graceful-readlink": {
+                      "version": "1.0.1",
+                      "from": "graceful-readlink@>= 1.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     },
                     "graceful-fs": {
                       "version": "4.1.3",
                       "from": "graceful-fs@^4.1.2",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                     },
-                    "graceful-readlink": {
-                      "version": "1.0.1",
-                      "from": "graceful-readlink@>= 1.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                    "hawk": {
+                      "version": "3.1.3",
+                      "from": "hawk@~3.1.0",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
+                    },
+                    "har-validator": {
+                      "version": "2.0.6",
+                      "from": "har-validator@~2.0.6",
+                      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
                     },
                     "has-ansi": {
                       "version": "2.0.0",
@@ -6672,30 +6677,25 @@
                       "from": "has-unicode@^2.0.0",
                       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz"
                     },
-                    "hoek": {
-                      "version": "2.16.3",
-                      "from": "hoek@2.x.x",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                    },
-                    "hawk": {
-                      "version": "3.1.3",
-                      "from": "hawk@~3.1.0",
-                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
-                    },
                     "http-signature": {
                       "version": "1.1.1",
                       "from": "http-signature@~1.1.0",
                       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
                     },
-                    "ini": {
-                      "version": "1.3.4",
-                      "from": "ini@~1.3.0",
-                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                    "hoek": {
+                      "version": "2.16.3",
+                      "from": "hoek@2.x.x",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
                       "from": "inherits@*",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "ini": {
+                      "version": "1.3.4",
+                      "from": "ini@~1.3.0",
+                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                     },
                     "is-property": {
                       "version": "1.0.2",
@@ -6712,55 +6712,50 @@
                       "from": "is-typedarray@~1.0.0",
                       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
                     },
-                    "isstream": {
-                      "version": "0.1.2",
-                      "from": "isstream@~0.1.2",
-                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-                    },
                     "isarray": {
                       "version": "1.0.0",
                       "from": "isarray@~1.0.0",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                     },
-                    "jsbn": {
-                      "version": "0.1.0",
-                      "from": "jsbn@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
-                    },
-                    "jodid25519": {
-                      "version": "1.0.2",
-                      "from": "jodid25519@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
-                    },
-                    "json-stringify-safe": {
-                      "version": "5.0.1",
-                      "from": "json-stringify-safe@~5.0.1",
-                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                    "isstream": {
+                      "version": "0.1.2",
+                      "from": "isstream@~0.1.2",
+                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                     },
                     "json-schema": {
                       "version": "0.2.2",
                       "from": "json-schema@0.2.2",
                       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
                     },
+                    "jodid25519": {
+                      "version": "1.0.2",
+                      "from": "jodid25519@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                    },
+                    "jsbn": {
+                      "version": "0.1.0",
+                      "from": "jsbn@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                    },
                     "jsonpointer": {
                       "version": "2.0.0",
                       "from": "jsonpointer@2.0.0",
                       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                     },
-                    "jsprim": {
-                      "version": "1.2.2",
-                      "from": "jsprim@^1.2.2",
-                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
+                    "json-stringify-safe": {
+                      "version": "5.0.1",
+                      "from": "json-stringify-safe@~5.0.1",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                     },
                     "lodash.pad": {
                       "version": "4.1.0",
                       "from": "lodash.pad@^4.1.0",
                       "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.1.0.tgz"
                     },
-                    "lodash.repeat": {
-                      "version": "4.0.0",
-                      "from": "lodash.repeat@^4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.0.0.tgz"
+                    "jsprim": {
+                      "version": "1.2.2",
+                      "from": "jsprim@^1.2.2",
+                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
                     },
                     "lodash.padend": {
                       "version": "4.2.0",
@@ -6777,15 +6772,15 @@
                       "from": "lodash.tostring@^4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.2.tgz"
                     },
-                    "mkdirp": {
-                      "version": "0.5.1",
-                      "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
-                    },
                     "mime-db": {
                       "version": "1.22.0",
                       "from": "mime-db@~1.22.0",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
+                    },
+                    "lodash.repeat": {
+                      "version": "4.0.0",
+                      "from": "lodash.repeat@^4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.0.0.tgz"
                     },
                     "minimist": {
                       "version": "0.0.8",
@@ -6802,25 +6797,25 @@
                       "from": "ms@0.7.1",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     },
-                    "node-uuid": {
-                      "version": "1.4.7",
-                      "from": "node-uuid@~1.4.7",
-                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
                     },
                     "npmlog": {
                       "version": "2.0.3",
                       "from": "npmlog@~2.0.0",
                       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.3.tgz"
                     },
+                    "node-uuid": {
+                      "version": "1.4.7",
+                      "from": "node-uuid@~1.4.7",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+                    },
                     "oauth-sign": {
                       "version": "0.8.1",
                       "from": "oauth-sign@~0.8.0",
                       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.6",
-                      "from": "process-nextick-args@~1.0.6",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                     },
                     "once": {
                       "version": "1.3.3",
@@ -6837,6 +6832,11 @@
                       "from": "pinkie-promise@^2.0.0",
                       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
                     },
+                    "process-nextick-args": {
+                      "version": "1.0.6",
+                      "from": "process-nextick-args@~1.0.6",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                    },
                     "qs": {
                       "version": "6.0.2",
                       "from": "qs@~6.0.2",
@@ -6852,15 +6852,20 @@
                       "from": "request@2.x",
                       "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz"
                     },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "from": "sntp@1.x.x",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                    },
                     "semver": {
                       "version": "5.1.0",
                       "from": "semver@~5.1.0",
                       "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
                     },
-                    "sntp": {
-                      "version": "1.0.9",
-                      "from": "sntp@1.x.x",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                    "sshpk": {
+                      "version": "1.7.4",
+                      "from": "sshpk@^1.7.0",
+                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
@@ -6872,16 +6877,6 @@
                       "from": "stringstream@~0.0.4",
                       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                     },
-                    "sshpk": {
-                      "version": "1.7.4",
-                      "from": "sshpk@^1.7.0",
-                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz"
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "from": "strip-ansi@^3.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-                    },
                     "strip-json-comments": {
                       "version": "1.0.4",
                       "from": "strip-json-comments@~1.0.4",
@@ -6892,15 +6887,15 @@
                       "from": "tar@~2.2.0",
                       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
                     },
-                    "tar-pack": {
-                      "version": "3.1.3",
-                      "from": "tar-pack@~3.1.0",
-                      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.3.tgz"
-                    },
                     "supports-color": {
                       "version": "2.0.0",
                       "from": "supports-color@^2.0.0",
                       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                    },
+                    "tar-pack": {
+                      "version": "3.1.3",
+                      "from": "tar-pack@~3.1.0",
+                      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.3.tgz"
                     },
                     "tough-cookie": {
                       "version": "2.2.2",
@@ -6912,30 +6907,35 @@
                       "from": "tunnel-agent@~0.4.1",
                       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
                     },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "util-deprecate@~1.0.1",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                    },
-                    "uid-number": {
-                      "version": "0.0.6",
-                      "from": "uid-number@~0.0.6",
-                      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "from": "strip-ansi@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
                     },
                     "tweetnacl": {
                       "version": "0.14.3",
                       "from": "tweetnacl@>=0.13.0 <1.0.0",
                       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
                     },
-                    "verror": {
-                      "version": "1.3.6",
-                      "from": "verror@1.3.6",
-                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                    "uid-number": {
+                      "version": "0.0.6",
+                      "from": "uid-number@~0.0.6",
+                      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
                     },
                     "wrappy": {
                       "version": "1.0.1",
                       "from": "wrappy@1",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    },
+                    "verror": {
+                      "version": "1.3.6",
+                      "from": "verror@1.3.6",
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "util-deprecate@~1.0.1",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     },
                     "xtend": {
                       "version": "4.0.1",
@@ -7099,74 +7099,74 @@
             },
             "commander": {
               "version": "2.9.0",
-              "from": "commander@>=2.3.0 <3.0.0",
+              "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
               "dependencies": {
                 "graceful-readlink": {
                   "version": "1.0.1",
-                  "from": "graceful-readlink@>=1.0.0",
+                  "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                 }
               }
             },
             "cssnano": {
               "version": "2.6.1",
-              "from": "cssnano@>=2.6.1 <3.0.0",
+              "from": "https://registry.npmjs.org/cssnano/-/cssnano-2.6.1.tgz",
               "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-2.6.1.tgz",
               "dependencies": {
                 "balanced-match": {
                   "version": "0.2.1",
-                  "from": "balanced-match@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
                 },
                 "css-list": {
                   "version": "0.1.3",
-                  "from": "css-list@>=0.1.2 <0.2.0",
+                  "from": "https://registry.npmjs.org/css-list/-/css-list-0.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/css-list/-/css-list-0.1.3.tgz"
                 },
                 "decamelize": {
                   "version": "1.2.0",
-                  "from": "decamelize@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                 },
                 "defined": {
                   "version": "1.0.0",
-                  "from": "defined@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
                 },
                 "indexes-of": {
                   "version": "1.0.1",
-                  "from": "indexes-of@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz"
                 },
                 "minimist": {
                   "version": "1.2.0",
-                  "from": "minimist@>=1.1.3 <2.0.0",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                 },
                 "postcss-colormin": {
                   "version": "1.2.7",
-                  "from": "postcss-colormin@>=1.2.5 <2.0.0",
+                  "from": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-1.2.7.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-1.2.7.tgz",
                   "dependencies": {
                     "color": {
                       "version": "0.10.1",
-                      "from": "color@>=0.10.1 <0.11.0",
+                      "from": "https://registry.npmjs.org/color/-/color-0.10.1.tgz",
                       "resolved": "https://registry.npmjs.org/color/-/color-0.10.1.tgz",
                       "dependencies": {
                         "color-convert": {
                           "version": "0.5.3",
-                          "from": "color-convert@>=0.5.3 <0.6.0",
+                          "from": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
                           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz"
                         },
                         "color-string": {
                           "version": "0.3.0",
-                          "from": "color-string@>=0.3.0 <0.4.0",
+                          "from": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
                           "dependencies": {
                             "color-name": {
                               "version": "1.1.1",
-                              "from": "color-name@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
                               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz"
                             }
                           }
@@ -7175,27 +7175,27 @@
                     },
                     "colormin": {
                       "version": "1.1.0",
-                      "from": "colormin@>=1.0.3 <2.0.0",
+                      "from": "https://registry.npmjs.org/colormin/-/colormin-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.0.tgz",
                       "dependencies": {
                         "color": {
                           "version": "0.11.1",
-                          "from": "color@>=0.11.0 <0.12.0",
+                          "from": "https://registry.npmjs.org/color/-/color-0.11.1.tgz",
                           "resolved": "https://registry.npmjs.org/color/-/color-0.11.1.tgz",
                           "dependencies": {
                             "color-convert": {
                               "version": "0.5.3",
-                              "from": "color-convert@>=0.5.3 <0.6.0",
+                              "from": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
                               "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz"
                             },
                             "color-string": {
                               "version": "0.3.0",
-                              "from": "color-string@>=0.3.0 <0.4.0",
+                              "from": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
                               "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
                               "dependencies": {
                                 "color-name": {
                                   "version": "1.1.1",
-                                  "from": "color-name@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
                                   "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz"
                                 }
                               }
@@ -7204,19 +7204,19 @@
                         },
                         "css-color-names": {
                           "version": "0.0.3",
-                          "from": "css-color-names@0.0.3",
+                          "from": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.3.tgz"
                         }
                       }
                     },
                     "reduce-function-call": {
                       "version": "1.0.1",
-                      "from": "reduce-function-call@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.1.0",
-                          "from": "balanced-match@>=0.1.0 <0.2.0",
+                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz"
                         }
                       }
@@ -7225,183 +7225,183 @@
                 },
                 "postcss-convert-values": {
                   "version": "1.3.1",
-                  "from": "postcss-convert-values@>=1.2.4 <2.0.0",
+                  "from": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-1.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-1.3.1.tgz",
                   "dependencies": {
                     "postcss-value-parser": {
                       "version": "1.4.2",
-                      "from": "postcss-value-parser@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-1.4.2.tgz",
                       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-1.4.2.tgz"
                     }
                   }
                 },
                 "postcss-discard-comments": {
                   "version": "1.2.1",
-                  "from": "postcss-discard-comments@>=1.2.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-1.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-1.2.1.tgz",
                   "dependencies": {
                     "node-balanced": {
                       "version": "0.0.14",
-                      "from": "node-balanced@0.0.14",
+                      "from": "https://registry.npmjs.org/node-balanced/-/node-balanced-0.0.14.tgz",
                       "resolved": "https://registry.npmjs.org/node-balanced/-/node-balanced-0.0.14.tgz"
                     }
                   }
                 },
                 "postcss-discard-duplicates": {
                   "version": "1.2.1",
-                  "from": "postcss-discard-duplicates@>=1.1.5 <2.0.0",
+                  "from": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-1.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-1.2.1.tgz"
                 },
                 "postcss-discard-empty": {
                   "version": "1.1.2",
-                  "from": "postcss-discard-empty@>=1.1.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-1.1.2.tgz"
                 },
                 "postcss-discard-unused": {
                   "version": "1.0.3",
-                  "from": "postcss-discard-unused@>=1.0.3 <2.0.0",
+                  "from": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-1.0.3.tgz",
                   "dependencies": {
                     "flatten": {
                       "version": "0.0.1",
-                      "from": "flatten@0.0.1",
+                      "from": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz"
                     },
                     "uniqs": {
                       "version": "2.0.0",
-                      "from": "uniqs@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
                     }
                   }
                 },
                 "postcss-filter-plugins": {
                   "version": "1.0.1",
-                  "from": "postcss-filter-plugins@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-1.0.1.tgz",
                   "dependencies": {
                     "uniqid": {
                       "version": "1.0.0",
-                      "from": "uniqid@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/uniqid/-/uniqid-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-1.0.0.tgz"
                     }
                   }
                 },
                 "postcss-font-family": {
                   "version": "1.2.1",
-                  "from": "postcss-font-family@>=1.2.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/postcss-font-family/-/postcss-font-family-1.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-font-family/-/postcss-font-family-1.2.1.tgz",
                   "dependencies": {
                     "object-assign": {
                       "version": "3.0.0",
-                      "from": "object-assign@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                     },
                     "uniqs": {
                       "version": "2.0.0",
-                      "from": "uniqs@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
                     }
                   }
                 },
                 "postcss-merge-idents": {
                   "version": "1.0.2",
-                  "from": "postcss-merge-idents@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-1.0.2.tgz"
                 },
                 "postcss-merge-longhand": {
                   "version": "1.0.2",
-                  "from": "postcss-merge-longhand@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-1.0.2.tgz"
                 },
                 "postcss-merge-rules": {
                   "version": "1.3.6",
-                  "from": "postcss-merge-rules@>=1.3.5 <2.0.0",
+                  "from": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-1.3.6.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-1.3.6.tgz"
                 },
                 "postcss-minify-font-weight": {
                   "version": "1.0.1",
-                  "from": "postcss-minify-font-weight@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/postcss-minify-font-weight/-/postcss-minify-font-weight-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-minify-font-weight/-/postcss-minify-font-weight-1.0.1.tgz"
                 },
                 "postcss-minify-selectors": {
                   "version": "1.5.0",
-                  "from": "postcss-minify-selectors@>=1.5.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-1.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-1.5.0.tgz",
                   "dependencies": {
                     "javascript-natural-sort": {
                       "version": "0.7.1",
-                      "from": "javascript-natural-sort@>=0.7.1 <0.8.0",
+                      "from": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
                       "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz"
                     },
                     "normalize-selector": {
                       "version": "0.2.0",
-                      "from": "normalize-selector@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz"
                     },
                     "postcss-selector-parser": {
                       "version": "1.3.3",
-                      "from": "postcss-selector-parser@>=1.1.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-1.3.3.tgz",
                       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-1.3.3.tgz",
                       "dependencies": {
                         "flatten": {
                           "version": "1.0.2",
-                          "from": "flatten@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz"
                         },
                         "uniq": {
                           "version": "1.0.1",
-                          "from": "uniq@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
                         }
                       }
                     },
                     "uniqs": {
                       "version": "2.0.0",
-                      "from": "uniqs@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
                     }
                   }
                 },
                 "postcss-normalize-url": {
                   "version": "2.1.3",
-                  "from": "postcss-normalize-url@>=2.1.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-2.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-2.1.3.tgz",
                   "dependencies": {
                     "is-absolute-url": {
                       "version": "2.0.0",
-                      "from": "is-absolute-url@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.0.0.tgz"
                     },
                     "normalize-url": {
                       "version": "1.4.1",
-                      "from": "normalize-url@>=1.3.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.4.1.tgz",
                       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.4.1.tgz",
                       "dependencies": {
                         "prepend-http": {
                           "version": "1.0.3",
-                          "from": "prepend-http@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz"
                         },
                         "query-string": {
                           "version": "3.0.3",
-                          "from": "query-string@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/query-string/-/query-string-3.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/query-string/-/query-string-3.0.3.tgz",
                           "dependencies": {
                             "strict-uri-encode": {
                               "version": "1.1.0",
-                              "from": "strict-uri-encode@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz"
                             }
                           }
                         },
                         "sort-keys": {
                           "version": "1.1.1",
-                          "from": "sort-keys@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.1.tgz",
                           "dependencies": {
                             "is-plain-obj": {
                               "version": "1.1.0",
-                              "from": "is-plain-obj@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
                             }
                           }
@@ -7410,41 +7410,41 @@
                     },
                     "object-assign": {
                       "version": "4.0.1",
-                      "from": "object-assign@>=4.0.1 <5.0.0",
+                      "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
                     },
                     "postcss-value-parser": {
                       "version": "1.4.2",
-                      "from": "postcss-value-parser@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-1.4.2.tgz",
                       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-1.4.2.tgz"
                     }
                   }
                 },
                 "postcss-ordered-values": {
                   "version": "1.1.1",
-                  "from": "postcss-ordered-values@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-1.1.1.tgz",
                   "dependencies": {
                     "postcss-value-parser": {
                       "version": "1.4.2",
-                      "from": "postcss-value-parser@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-1.4.2.tgz",
                       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-1.4.2.tgz"
                     }
                   }
                 },
                 "postcss-reduce-idents": {
                   "version": "1.0.3",
-                  "from": "postcss-reduce-idents@>=1.0.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-1.0.3.tgz",
                   "dependencies": {
                     "reduce-function-call": {
                       "version": "1.0.1",
-                      "from": "reduce-function-call@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.1.0",
-                          "from": "balanced-match@>=0.1.0 <0.2.0",
+                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz"
                         }
                       }
@@ -7453,69 +7453,69 @@
                 },
                 "postcss-single-charset": {
                   "version": "0.3.0",
-                  "from": "postcss-single-charset@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/postcss-single-charset/-/postcss-single-charset-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-single-charset/-/postcss-single-charset-0.3.0.tgz",
                   "dependencies": {
                     "fs-extra": {
                       "version": "0.14.0",
-                      "from": "fs-extra@>=0.14.0 <0.15.0",
+                      "from": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.14.0.tgz",
                       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.14.0.tgz",
                       "dependencies": {
                         "ncp": {
                           "version": "1.0.1",
-                          "from": "ncp@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz"
                         },
                         "jsonfile": {
                           "version": "2.3.0",
-                          "from": "jsonfile@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.3.0.tgz"
                         },
                         "rimraf": {
                           "version": "2.5.2",
-                          "from": "rimraf@>=2.2.8 <3.0.0",
+                          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
                           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
                           "dependencies": {
                             "glob": {
                               "version": "7.0.3",
-                              "from": "glob@>=7.0.0 <8.0.0",
+                              "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
                               "dependencies": {
                                 "inflight": {
                                   "version": "1.0.4",
-                                  "from": "inflight@>=1.0.4 <2.0.0",
+                                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                                   "dependencies": {
                                     "wrappy": {
                                       "version": "1.0.1",
-                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                                     }
                                   }
                                 },
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "inherits@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 },
                                 "minimatch": {
                                   "version": "3.0.0",
-                                  "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                                   "dependencies": {
                                     "brace-expansion": {
                                       "version": "1.1.3",
-                                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                                       "dependencies": {
                                         "balanced-match": {
                                           "version": "0.3.0",
-                                          "from": "balanced-match@>=0.3.0 <0.4.0",
+                                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                                         },
                                         "concat-map": {
                                           "version": "0.0.1",
-                                          "from": "concat-map@0.0.1",
+                                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                                         }
                                       }
@@ -7524,19 +7524,19 @@
                                 },
                                 "once": {
                                   "version": "1.3.3",
-                                  "from": "once@>=1.3.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                                   "dependencies": {
                                     "wrappy": {
                                       "version": "1.0.1",
-                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                                     }
                                   }
                                 },
                                 "path-is-absolute": {
                                   "version": "1.0.0",
-                                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                                 }
                               }
@@ -7549,75 +7549,75 @@
                 },
                 "postcss-unique-selectors": {
                   "version": "1.0.1",
-                  "from": "postcss-unique-selectors@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-1.0.1.tgz",
                   "dependencies": {
                     "javascript-natural-sort": {
                       "version": "0.7.1",
-                      "from": "javascript-natural-sort@>=0.7.1 <0.8.0",
+                      "from": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
                       "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz"
                     },
                     "uniqs": {
                       "version": "2.0.0",
-                      "from": "uniqs@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
                     }
                   }
                 },
                 "postcss-zindex": {
                   "version": "1.1.3",
-                  "from": "postcss-zindex@>=1.1.3 <2.0.0",
+                  "from": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-1.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-1.1.3.tgz"
                 }
               }
             },
             "exit": {
               "version": "0.1.2",
-              "from": "exit@>=0.1.2 <0.2.0",
+              "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             },
             "mkdirp": {
               "version": "0.5.1",
-              "from": "mkdirp@>=0.5.1 <0.6.0",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "minimist@0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "pixrem": {
               "version": "1.3.1",
-              "from": "pixrem@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/pixrem/-/pixrem-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/pixrem/-/pixrem-1.3.1.tgz",
               "dependencies": {
                 "browserslist": {
                   "version": "0.5.0",
-                  "from": "browserslist@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/browserslist/-/browserslist-0.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.5.0.tgz",
                   "dependencies": {
                     "caniuse-db": {
                       "version": "1.0.30000460",
-                      "from": "caniuse-db@>=1.0.30000214 <2.0.0",
+                      "from": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000460.tgz",
                       "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000460.tgz"
                     }
                   }
                 },
                 "reduce-css-calc": {
                   "version": "1.2.3",
-                  "from": "reduce-css-calc@>=1.2.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.2.3.tgz",
                   "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.2.3.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.1.0",
-                      "from": "balanced-match@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz"
                     },
                     "reduce-function-call": {
                       "version": "1.0.1",
-                      "from": "reduce-function-call@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz"
                     }
                   }
@@ -7626,68 +7626,68 @@
             },
             "pleeease-filters": {
               "version": "1.0.1",
-              "from": "pleeease-filters@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/pleeease-filters/-/pleeease-filters-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/pleeease-filters/-/pleeease-filters-1.0.1.tgz",
               "dependencies": {
                 "onecolor": {
                   "version": "2.4.2",
-                  "from": "onecolor@>=2.4.0 <2.5.0",
+                  "from": "https://registry.npmjs.org/onecolor/-/onecolor-2.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/onecolor/-/onecolor-2.4.2.tgz"
                 }
               }
             },
             "postcss": {
               "version": "4.1.16",
-              "from": "postcss@>=4.0.2 <5.0.0",
+              "from": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
               "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
               "dependencies": {
                 "es6-promise": {
                   "version": "2.3.0",
-                  "from": "es6-promise@>=2.3.0 <2.4.0",
+                  "from": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz"
                 },
                 "source-map": {
                   "version": "0.4.4",
-                  "from": "source-map@>=0.4.2 <0.5.0",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "1.0.0",
-                      "from": "amdefine@>=0.0.4",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                     }
                   }
                 },
                 "js-base64": {
                   "version": "2.1.9",
-                  "from": "js-base64@>=2.1.8 <2.2.0",
+                  "from": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
                   "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
                 }
               }
             },
             "postcss-calc": {
               "version": "4.1.0",
-              "from": "postcss-calc@>=4.0.0 <5.0.0",
+              "from": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-4.1.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-4.1.0.tgz",
               "dependencies": {
                 "postcss-message-helpers": {
                   "version": "2.0.0",
-                  "from": "postcss-message-helpers@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz"
                 },
                 "reduce-css-calc": {
                   "version": "1.2.3",
-                  "from": "reduce-css-calc@>=1.2.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.2.3.tgz",
                   "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.2.3.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.1.0",
-                      "from": "balanced-match@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz"
                     },
                     "reduce-function-call": {
                       "version": "1.0.1",
-                      "from": "reduce-function-call@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz"
                     }
                   }
@@ -7696,37 +7696,37 @@
             },
             "postcss-color-function": {
               "version": "1.3.2",
-              "from": "postcss-color-function@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/postcss-color-function/-/postcss-color-function-1.3.2.tgz",
               "resolved": "https://registry.npmjs.org/postcss-color-function/-/postcss-color-function-1.3.2.tgz",
               "dependencies": {
                 "balanced-match": {
                   "version": "0.1.0",
-                  "from": "balanced-match@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz"
                 },
                 "css-color-function": {
                   "version": "1.3.0",
-                  "from": "css-color-function@>=1.2.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/css-color-function/-/css-color-function-1.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/css-color-function/-/css-color-function-1.3.0.tgz",
                   "dependencies": {
                     "color": {
                       "version": "0.11.1",
-                      "from": "color@>=0.11.0 <0.12.0",
+                      "from": "https://registry.npmjs.org/color/-/color-0.11.1.tgz",
                       "resolved": "https://registry.npmjs.org/color/-/color-0.11.1.tgz",
                       "dependencies": {
                         "color-convert": {
                           "version": "0.5.3",
-                          "from": "color-convert@>=0.5.3 <0.6.0",
+                          "from": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
                           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz"
                         },
                         "color-string": {
                           "version": "0.3.0",
-                          "from": "color-string@>=0.3.0 <0.4.0",
+                          "from": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
                           "dependencies": {
                             "color-name": {
                               "version": "1.1.1",
-                              "from": "color-name@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
                               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz"
                             }
                           }
@@ -7735,46 +7735,46 @@
                     },
                     "debug": {
                       "version": "0.7.4",
-                      "from": "debug@>=0.7.4 <0.8.0",
+                      "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
                     },
                     "rgb": {
                       "version": "0.1.0",
-                      "from": "rgb@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/rgb/-/rgb-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/rgb/-/rgb-0.1.0.tgz"
                     }
                   }
                 },
                 "postcss-message-helpers": {
                   "version": "1.1.1",
-                  "from": "postcss-message-helpers@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-1.1.1.tgz"
                 }
               }
             },
             "postcss-color-gray": {
               "version": "2.0.0",
-              "from": "postcss-color-gray@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-color-gray/-/postcss-color-gray-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-color-gray/-/postcss-color-gray-2.0.0.tgz",
               "dependencies": {
                 "color": {
                   "version": "0.7.3",
-                  "from": "color@>=0.7.3 <0.8.0",
+                  "from": "https://registry.npmjs.org/color/-/color-0.7.3.tgz",
                   "resolved": "https://registry.npmjs.org/color/-/color-0.7.3.tgz",
                   "dependencies": {
                     "color-convert": {
                       "version": "0.5.3",
-                      "from": "color-convert@>=0.5.0 <0.6.0",
+                      "from": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
                       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz"
                     },
                     "color-string": {
                       "version": "0.2.4",
-                      "from": "color-string@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/color-string/-/color-string-0.2.4.tgz",
                       "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.2.4.tgz",
                       "dependencies": {
                         "color-name": {
                           "version": "1.0.1",
-                          "from": "color-name@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/color-name/-/color-name-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.0.1.tgz"
                         }
                       }
@@ -7783,17 +7783,17 @@
                 },
                 "postcss-message-helpers": {
                   "version": "2.0.0",
-                  "from": "postcss-message-helpers@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz"
                 },
                 "reduce-function-call": {
                   "version": "1.0.1",
-                  "from": "reduce-function-call@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.1.0",
-                      "from": "balanced-match@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz"
                     }
                   }
@@ -7802,27 +7802,27 @@
             },
             "postcss-color-hex-alpha": {
               "version": "1.3.0",
-              "from": "postcss-color-hex-alpha@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-1.3.0.tgz",
               "dependencies": {
                 "color": {
                   "version": "0.10.1",
-                  "from": "color@>=0.10.1 <0.11.0",
+                  "from": "https://registry.npmjs.org/color/-/color-0.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/color/-/color-0.10.1.tgz",
                   "dependencies": {
                     "color-convert": {
                       "version": "0.5.3",
-                      "from": "color-convert@>=0.5.3 <0.6.0",
+                      "from": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
                       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz"
                     },
                     "color-string": {
                       "version": "0.3.0",
-                      "from": "color-string@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
                       "dependencies": {
                         "color-name": {
                           "version": "1.1.1",
-                          "from": "color-name@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz"
                         }
                       }
@@ -7831,34 +7831,34 @@
                 },
                 "postcss-message-helpers": {
                   "version": "2.0.0",
-                  "from": "postcss-message-helpers@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz"
                 }
               }
             },
             "postcss-color-hwb": {
               "version": "1.2.0",
-              "from": "postcss-color-hwb@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/postcss-color-hwb/-/postcss-color-hwb-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-color-hwb/-/postcss-color-hwb-1.2.0.tgz",
               "dependencies": {
                 "color": {
                   "version": "0.10.1",
-                  "from": "color@>=0.10.1 <0.11.0",
+                  "from": "https://registry.npmjs.org/color/-/color-0.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/color/-/color-0.10.1.tgz",
                   "dependencies": {
                     "color-convert": {
                       "version": "0.5.3",
-                      "from": "color-convert@>=0.5.3 <0.6.0",
+                      "from": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
                       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz"
                     },
                     "color-string": {
                       "version": "0.3.0",
-                      "from": "color-string@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
                       "dependencies": {
                         "color-name": {
                           "version": "1.1.1",
-                          "from": "color-name@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz"
                         }
                       }
@@ -7867,17 +7867,17 @@
                 },
                 "postcss-message-helpers": {
                   "version": "2.0.0",
-                  "from": "postcss-message-helpers@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz"
                 },
                 "reduce-function-call": {
                   "version": "1.0.1",
-                  "from": "reduce-function-call@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.1.0",
-                      "from": "balanced-match@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz"
                     }
                   }
@@ -7886,27 +7886,27 @@
             },
             "postcss-color-rebeccapurple": {
               "version": "1.2.0",
-              "from": "postcss-color-rebeccapurple@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-1.2.0.tgz",
               "dependencies": {
                 "color": {
                   "version": "0.9.0",
-                  "from": "color@>=0.9.0 <0.10.0",
+                  "from": "https://registry.npmjs.org/color/-/color-0.9.0.tgz",
                   "resolved": "https://registry.npmjs.org/color/-/color-0.9.0.tgz",
                   "dependencies": {
                     "color-convert": {
                       "version": "0.5.3",
-                      "from": "color-convert@>=0.5.3 <0.6.0",
+                      "from": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
                       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz"
                     },
                     "color-string": {
                       "version": "0.3.0",
-                      "from": "color-string@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
                       "dependencies": {
                         "color-name": {
                           "version": "1.1.1",
-                          "from": "color-name@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz"
                         }
                       }
@@ -7917,17 +7917,17 @@
             },
             "postcss-color-rgba-fallback": {
               "version": "1.3.1",
-              "from": "postcss-color-rgba-fallback@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/postcss-color-rgba-fallback/-/postcss-color-rgba-fallback-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/postcss-color-rgba-fallback/-/postcss-color-rgba-fallback-1.3.1.tgz",
               "dependencies": {
                 "color-string": {
                   "version": "0.3.0",
-                  "from": "color-string@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
                   "dependencies": {
                     "color-name": {
                       "version": "1.1.1",
-                      "from": "color-name@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz"
                     }
                   }
@@ -7936,93 +7936,93 @@
             },
             "postcss-custom-media": {
               "version": "4.1.0",
-              "from": "postcss-custom-media@>=4.0.0 <5.0.0",
+              "from": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-4.1.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-4.1.0.tgz"
             },
             "postcss-custom-properties": {
               "version": "4.2.0",
-              "from": "postcss-custom-properties@>=4.0.0 <5.0.0",
+              "from": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-4.2.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-4.2.0.tgz",
               "dependencies": {
                 "balanced-match": {
                   "version": "0.1.0",
-                  "from": "balanced-match@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz"
                 }
               }
             },
             "postcss-custom-selectors": {
               "version": "2.3.0",
-              "from": "postcss-custom-selectors@>=2.3.0 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-2.3.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-2.3.0.tgz",
               "dependencies": {
                 "balanced-match": {
                   "version": "0.2.1",
-                  "from": "balanced-match@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
                 }
               }
             },
             "postcss-font-variant": {
               "version": "1.2.0",
-              "from": "postcss-font-variant@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-1.2.0.tgz"
             },
             "postcss-import": {
               "version": "6.2.0",
-              "from": "postcss-import@>=6.0.0 <7.0.0",
+              "from": "https://registry.npmjs.org/postcss-import/-/postcss-import-6.2.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-6.2.0.tgz",
               "dependencies": {
                 "clone": {
                   "version": "0.1.19",
-                  "from": "clone@>=0.1.17 <0.2.0",
+                  "from": "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz",
                   "resolved": "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz"
                 },
                 "es6-promise": {
                   "version": "2.3.0",
-                  "from": "es6-promise@>=2.3.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz"
                 },
                 "glob": {
                   "version": "5.0.15",
-                  "from": "glob@>=5.0.1 <6.0.0",
+                  "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "3.0.0",
-                      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.3",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.3.0",
-                              "from": "balanced-match@>=0.3.0 <0.4.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
@@ -8031,73 +8031,73 @@
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "path-is-absolute": {
                       "version": "1.0.0",
-                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                     }
                   }
                 },
                 "object-assign": {
                   "version": "3.0.0",
-                  "from": "object-assign@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                 },
                 "postcss-message-helpers": {
                   "version": "2.0.0",
-                  "from": "postcss-message-helpers@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz"
                 },
                 "resolve": {
                   "version": "1.1.7",
-                  "from": "resolve@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
                   "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
                 }
               }
             },
             "postcss-media-minmax": {
               "version": "1.2.0",
-              "from": "postcss-media-minmax@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-1.2.0.tgz"
             },
             "postcss-messages": {
               "version": "0.2.2",
-              "from": "postcss-messages@>=0.2.2 <0.3.0",
+              "from": "https://registry.npmjs.org/postcss-messages/-/postcss-messages-0.2.2.tgz",
               "resolved": "https://registry.npmjs.org/postcss-messages/-/postcss-messages-0.2.2.tgz"
             },
             "postcss-pseudo-class-any-link": {
               "version": "0.2.1",
-              "from": "postcss-pseudo-class-any-link@>=0.2.1 <0.3.0",
+              "from": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-0.2.1.tgz",
               "resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-0.2.1.tgz",
               "dependencies": {
                 "postcss-selector-parser": {
                   "version": "1.3.3",
-                  "from": "postcss-selector-parser@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-1.3.3.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-1.3.3.tgz",
                   "dependencies": {
                     "flatten": {
                       "version": "1.0.2",
-                      "from": "flatten@>=1.0.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz"
                     },
                     "indexes-of": {
                       "version": "1.0.1",
-                      "from": "indexes-of@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz"
                     },
                     "uniq": {
                       "version": "1.0.1",
-                      "from": "uniq@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
                     }
                   }
@@ -8106,42 +8106,42 @@
             },
             "postcss-pseudoelements": {
               "version": "2.2.0",
-              "from": "postcss-pseudoelements@>=2.1.1 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-pseudoelements/-/postcss-pseudoelements-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-pseudoelements/-/postcss-pseudoelements-2.2.0.tgz"
             },
             "postcss-reporter": {
               "version": "0.1.0",
-              "from": "postcss-reporter@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-0.1.0.tgz",
               "dependencies": {
                 "lodash.difference": {
                   "version": "3.2.2",
-                  "from": "lodash.difference@>=3.2.1 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-3.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-3.2.2.tgz",
                   "dependencies": {
                     "lodash._basedifference": {
                       "version": "3.0.3",
-                      "from": "lodash._basedifference@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
                       "dependencies": {
                         "lodash._baseindexof": {
                           "version": "3.1.0",
-                          "from": "lodash._baseindexof@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz"
                         },
                         "lodash._cacheindexof": {
                           "version": "3.0.2",
-                          "from": "lodash._cacheindexof@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz"
                         },
                         "lodash._createcache": {
                           "version": "3.1.2",
-                          "from": "lodash._createcache@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
                           "dependencies": {
                             "lodash._getnative": {
                               "version": "3.9.1",
-                              "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
                               "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                             }
                           }
@@ -8150,24 +8150,24 @@
                     },
                     "lodash._baseflatten": {
                       "version": "3.1.4",
-                      "from": "lodash._baseflatten@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
                       "dependencies": {
                         "lodash.isarguments": {
                           "version": "3.0.8",
-                          "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz",
                           "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
                         },
                         "lodash.isarray": {
                           "version": "3.0.4",
-                          "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                         }
                       }
                     },
                     "lodash.restparam": {
                       "version": "3.6.1",
-                      "from": "lodash.restparam@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
                     }
                   }
@@ -8176,100 +8176,100 @@
             },
             "postcss-selector-matches": {
               "version": "1.2.1",
-              "from": "postcss-selector-matches@>=1.2.1 <2.0.0",
+              "from": "https://registry.npmjs.org/postcss-selector-matches/-/postcss-selector-matches-1.2.1.tgz",
               "resolved": "https://registry.npmjs.org/postcss-selector-matches/-/postcss-selector-matches-1.2.1.tgz",
               "dependencies": {
                 "balanced-match": {
                   "version": "0.2.1",
-                  "from": "balanced-match@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
                 }
               }
             },
             "postcss-selector-not": {
               "version": "1.2.1",
-              "from": "postcss-selector-not@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-1.2.1.tgz",
               "resolved": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-1.2.1.tgz",
               "dependencies": {
                 "balanced-match": {
                   "version": "0.2.1",
-                  "from": "balanced-match@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
                 }
               }
             },
             "postcss-url": {
               "version": "4.0.1",
-              "from": "postcss-url@>=4.0.1 <5.0.0",
+              "from": "https://registry.npmjs.org/postcss-url/-/postcss-url-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/postcss-url/-/postcss-url-4.0.1.tgz",
               "dependencies": {
                 "directory-encoder": {
                   "version": "0.6.1",
-                  "from": "directory-encoder@>=0.6.1 <0.7.0",
+                  "from": "https://registry.npmjs.org/directory-encoder/-/directory-encoder-0.6.1.tgz",
                   "resolved": "https://registry.npmjs.org/directory-encoder/-/directory-encoder-0.6.1.tgz",
                   "dependencies": {
                     "fs-extra": {
                       "version": "0.8.1",
-                      "from": "fs-extra@0.8.1",
+                      "from": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.8.1.tgz",
                       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.8.1.tgz",
                       "dependencies": {
                         "ncp": {
                           "version": "0.4.2",
-                          "from": "ncp@>=0.4.2 <0.5.0",
+                          "from": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
                           "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
                         },
                         "mkdirp": {
                           "version": "0.3.5",
-                          "from": "mkdirp@>=0.3.0 <0.4.0",
+                          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
                           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
                         },
                         "jsonfile": {
                           "version": "1.1.1",
-                          "from": "jsonfile@>=1.1.0 <1.2.0",
+                          "from": "https://registry.npmjs.org/jsonfile/-/jsonfile-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-1.1.1.tgz"
                         },
                         "rimraf": {
                           "version": "2.2.8",
-                          "from": "rimraf@>=2.2.0 <2.3.0",
+                          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
                           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                         }
                       }
                     },
                     "handlebars": {
                       "version": "1.1.2",
-                      "from": "handlebars@1.1.2",
+                      "from": "https://registry.npmjs.org/handlebars/-/handlebars-1.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.1.2.tgz",
                       "dependencies": {
                         "optimist": {
                           "version": "0.3.7",
-                          "from": "optimist@>=0.3.0 <0.4.0",
+                          "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                           "dependencies": {
                             "wordwrap": {
                               "version": "0.0.3",
-                              "from": "wordwrap@>=0.0.2 <0.1.0",
+                              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                             }
                           }
                         },
                         "uglify-js": {
                           "version": "2.3.6",
-                          "from": "uglify-js@>=2.3.0 <2.4.0",
+                          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
                           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
                           "dependencies": {
                             "async": {
                               "version": "0.2.10",
-                              "from": "async@>=0.2.6 <0.3.0",
+                              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
                               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                             },
                             "source-map": {
                               "version": "0.1.43",
-                              "from": "source-map@>=0.1.7 <0.2.0",
+                              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                               "dependencies": {
                                 "amdefine": {
                                   "version": "1.0.0",
-                                  "from": "amdefine@>=0.0.4",
+                                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                                 }
                               }
@@ -8280,17 +8280,17 @@
                     },
                     "lodash": {
                       "version": "2.4.0",
-                      "from": "lodash@2.4.0",
+                      "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.0.tgz",
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.0.tgz"
                     },
                     "img-stats": {
                       "version": "0.4.2",
-                      "from": "img-stats@0.4.2",
+                      "from": "https://registry.npmjs.org/img-stats/-/img-stats-0.4.2.tgz",
                       "resolved": "https://registry.npmjs.org/img-stats/-/img-stats-0.4.2.tgz",
                       "dependencies": {
                         "xmldom": {
                           "version": "0.1.16",
-                          "from": "xmldom@0.1.16",
+                          "from": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.16.tgz",
                           "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.16.tgz"
                         }
                       }
@@ -8299,27 +8299,27 @@
                 },
                 "js-base64": {
                   "version": "2.1.9",
-                  "from": "js-base64@>=2.1.5 <3.0.0",
+                  "from": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
                   "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
                 },
                 "mime": {
                   "version": "1.3.4",
-                  "from": "mime@>=1.2.11 <2.0.0",
+                  "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                 },
                 "reduce-function-call": {
                   "version": "1.0.1",
-                  "from": "reduce-function-call@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.1.0",
-                      "from": "balanced-match@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz"
                     }
                   }
@@ -8328,29 +8328,29 @@
             },
             "read-file-stdin": {
               "version": "0.2.1",
-              "from": "read-file-stdin@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/read-file-stdin/-/read-file-stdin-0.2.1.tgz",
               "resolved": "https://registry.npmjs.org/read-file-stdin/-/read-file-stdin-0.2.1.tgz",
               "dependencies": {
                 "gather-stream": {
                   "version": "1.0.0",
-                  "from": "gather-stream@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/gather-stream/-/gather-stream-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/gather-stream/-/gather-stream-1.0.0.tgz"
                 }
               }
             },
             "to-slug-case": {
               "version": "0.1.2",
-              "from": "to-slug-case@>=0.1.2 <0.2.0",
+              "from": "https://registry.npmjs.org/to-slug-case/-/to-slug-case-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/to-slug-case/-/to-slug-case-0.1.2.tgz",
               "dependencies": {
                 "to-space-case": {
                   "version": "0.1.2",
-                  "from": "to-space-case@0.1.2",
+                  "from": "https://registry.npmjs.org/to-space-case/-/to-space-case-0.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/to-space-case/-/to-space-case-0.1.2.tgz",
                   "dependencies": {
                     "to-no-case": {
                       "version": "0.1.1",
-                      "from": "to-no-case@0.1.1",
+                      "from": "https://registry.npmjs.org/to-no-case/-/to-no-case-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-0.1.1.tgz"
                     }
                   }
@@ -8359,60 +8359,60 @@
             },
             "to-space-case": {
               "version": "0.1.3",
-              "from": "to-space-case@>=0.1.3 <0.2.0",
+              "from": "https://registry.npmjs.org/to-space-case/-/to-space-case-0.1.3.tgz",
               "resolved": "https://registry.npmjs.org/to-space-case/-/to-space-case-0.1.3.tgz",
               "dependencies": {
                 "to-no-case": {
                   "version": "0.1.2",
-                  "from": "to-no-case@0.1.2",
+                  "from": "https://registry.npmjs.org/to-no-case/-/to-no-case-0.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-0.1.2.tgz"
                 }
               }
             },
             "write-file-stdout": {
               "version": "0.0.2",
-              "from": "write-file-stdout@0.0.2",
+              "from": "https://registry.npmjs.org/write-file-stdout/-/write-file-stdout-0.0.2.tgz",
               "resolved": "https://registry.npmjs.org/write-file-stdout/-/write-file-stdout-0.0.2.tgz"
             }
           }
         },
         "loader-utils": {
           "version": "0.2.14",
-          "from": "loader-utils@>=0.2.5 <0.3.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.14.tgz",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.14.tgz",
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.1.3 <4.0.0",
+              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "emojis-list": {
               "version": "1.0.1",
-              "from": "emojis-list@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.1.tgz"
             },
             "json5": {
               "version": "0.5.0",
-              "from": "json5@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz"
             },
             "object-assign": {
               "version": "4.0.1",
-              "from": "object-assign@>=4.0.1 <5.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
             }
           }
         },
         "object-assign": {
           "version": "2.1.1",
-          "from": "object-assign@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
         }
       }
     },
     "dedent": {
       "version": "0.6.0",
-      "from": "dedent@*",
+      "from": "https://registry.npmjs.org/dedent/-/dedent-0.6.0.tgz",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.6.0.tgz"
     },
     "director": {
@@ -8422,98 +8422,98 @@
     },
     "eslint": {
       "version": "2.8.0",
-      "from": "eslint@>=2.7.0 <3.0.0",
+      "from": "https://registry.npmjs.org/eslint/-/eslint-2.8.0.tgz",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.8.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.1.3 <2.0.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.2.1",
-              "from": "ansi-styles@>=2.2.1 <3.0.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "concat-stream": {
           "version": "1.5.1",
-          "from": "concat-stream@>=1.4.6 <2.0.0",
+          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "typedarray": {
               "version": "0.0.6",
-              "from": "typedarray@>=0.0.5 <0.1.0",
+              "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             },
             "readable-stream": {
               "version": "2.0.6",
-              "from": "readable-stream@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "isarray": {
                   "version": "1.0.0",
-                  "from": "isarray@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
@@ -8522,115 +8522,115 @@
         },
         "debug": {
           "version": "2.2.0",
-          "from": "debug@>=2.1.1 <3.0.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
-              "from": "ms@0.7.1",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "doctrine": {
           "version": "1.2.1",
-          "from": "doctrine@>=1.2.1 <2.0.0",
+          "from": "https://registry.npmjs.org/doctrine/-/doctrine-1.2.1.tgz",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.2.1.tgz",
           "dependencies": {
             "esutils": {
               "version": "1.1.6",
-              "from": "esutils@>=1.1.6 <2.0.0",
+              "from": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
               "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
             },
             "isarray": {
               "version": "1.0.0",
-              "from": "isarray@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
             }
           }
         },
         "es6-map": {
           "version": "0.1.3",
-          "from": "es6-map@>=0.1.3 <0.2.0",
+          "from": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.3.tgz",
           "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.3.tgz",
           "dependencies": {
             "d": {
               "version": "0.1.1",
-              "from": "d@>=0.1.1 <0.2.0",
+              "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
             },
             "es5-ext": {
               "version": "0.10.11",
-              "from": "es5-ext@>=0.10.8 <0.11.0",
+              "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
               "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
             },
             "es6-iterator": {
               "version": "2.0.0",
-              "from": "es6-iterator@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
             },
             "es6-set": {
               "version": "0.1.4",
-              "from": "es6-set@>=0.1.3 <0.2.0",
+              "from": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz",
               "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz"
             },
             "es6-symbol": {
               "version": "3.0.2",
-              "from": "es6-symbol@>=3.0.1 <3.1.0",
+              "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz",
               "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
             },
             "event-emitter": {
               "version": "0.3.4",
-              "from": "event-emitter@>=0.3.4 <0.4.0",
+              "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz",
               "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
             }
           }
         },
         "escope": {
           "version": "3.6.0",
-          "from": "escope@>=3.6.0 <4.0.0",
+          "from": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
           "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
           "dependencies": {
             "es6-weak-map": {
               "version": "2.0.1",
-              "from": "es6-weak-map@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
               "dependencies": {
                 "d": {
                   "version": "0.1.1",
-                  "from": "d@>=0.1.1 <0.2.0",
+                  "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                 },
                 "es5-ext": {
                   "version": "0.10.11",
-                  "from": "es5-ext@>=0.10.8 <0.11.0",
+                  "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
                   "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
                 },
                 "es6-iterator": {
                   "version": "2.0.0",
-                  "from": "es6-iterator@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
                 },
                 "es6-symbol": {
                   "version": "3.0.2",
-                  "from": "es6-symbol@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
                 }
               }
             },
             "esrecurse": {
               "version": "4.1.0",
-              "from": "esrecurse@>=4.1.0 <5.0.0",
+              "from": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
               "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
               "dependencies": {
                 "estraverse": {
                   "version": "4.1.1",
-                  "from": "estraverse@>=4.1.0 <4.2.0",
+                  "from": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
                 },
                 "object-assign": {
                   "version": "4.0.1",
-                  "from": "object-assign@>=4.0.1 <5.0.0",
+                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
                 }
               }
@@ -8639,22 +8639,22 @@
         },
         "espree": {
           "version": "3.1.3",
-          "from": "espree@3.1.3",
+          "from": "https://registry.npmjs.org/espree/-/espree-3.1.3.tgz",
           "resolved": "https://registry.npmjs.org/espree/-/espree-3.1.3.tgz",
           "dependencies": {
             "acorn": {
               "version": "3.1.0",
-              "from": "acorn@>=3.0.4 <4.0.0",
+              "from": "https://registry.npmjs.org/acorn/-/acorn-3.1.0.tgz",
               "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.1.0.tgz"
             },
             "acorn-jsx": {
               "version": "2.0.1",
-              "from": "acorn-jsx@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-2.0.1.tgz",
               "dependencies": {
                 "acorn": {
                   "version": "2.7.0",
-                  "from": "acorn@>=2.0.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
                   "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
                 }
               }
@@ -8663,91 +8663,91 @@
         },
         "estraverse": {
           "version": "4.2.0",
-          "from": "estraverse@>=4.2.0 <5.0.0",
+          "from": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
         },
         "esutils": {
           "version": "2.0.2",
-          "from": "esutils@>=2.0.2 <3.0.0",
+          "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
           "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
         },
         "file-entry-cache": {
           "version": "1.2.4",
-          "from": "file-entry-cache@>=1.1.1 <2.0.0",
+          "from": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.2.4.tgz",
           "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.2.4.tgz",
           "dependencies": {
             "flat-cache": {
               "version": "1.0.10",
-              "from": "flat-cache@>=1.0.9 <2.0.0",
+              "from": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.0.10.tgz",
               "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.0.10.tgz",
               "dependencies": {
                 "del": {
                   "version": "2.2.0",
-                  "from": "del@>=2.0.2 <3.0.0",
+                  "from": "https://registry.npmjs.org/del/-/del-2.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/del/-/del-2.2.0.tgz",
                   "dependencies": {
                     "globby": {
                       "version": "4.0.0",
-                      "from": "globby@>=4.0.0 <5.0.0",
+                      "from": "https://registry.npmjs.org/globby/-/globby-4.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/globby/-/globby-4.0.0.tgz",
                       "dependencies": {
                         "array-union": {
                           "version": "1.0.1",
-                          "from": "array-union@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
                           "dependencies": {
                             "array-uniq": {
                               "version": "1.0.2",
-                              "from": "array-uniq@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
                             }
                           }
                         },
                         "arrify": {
                           "version": "1.0.1",
-                          "from": "arrify@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
                         },
                         "glob": {
                           "version": "6.0.4",
-                          "from": "glob@>=6.0.1 <7.0.0",
+                          "from": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
                           "dependencies": {
                             "inflight": {
                               "version": "1.0.4",
-                              "from": "inflight@>=1.0.4 <2.0.0",
+                              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                               "dependencies": {
                                 "wrappy": {
                                   "version": "1.0.1",
-                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                                 }
                               }
                             },
                             "inherits": {
                               "version": "2.0.1",
-                              "from": "inherits@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             },
                             "minimatch": {
                               "version": "3.0.0",
-                              "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                               "dependencies": {
                                 "brace-expansion": {
                                   "version": "1.1.3",
-                                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                                   "dependencies": {
                                     "balanced-match": {
                                       "version": "0.3.0",
-                                      "from": "balanced-match@>=0.3.0 <0.4.0",
+                                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                                     },
                                     "concat-map": {
                                       "version": "0.0.1",
-                                      "from": "concat-map@0.0.1",
+                                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                                     }
                                   }
@@ -8756,12 +8756,12 @@
                             },
                             "once": {
                               "version": "1.3.3",
-                              "from": "once@>=1.3.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                               "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                               "dependencies": {
                                 "wrappy": {
                                   "version": "1.0.1",
-                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                                 }
                               }
@@ -8772,109 +8772,109 @@
                     },
                     "is-path-cwd": {
                       "version": "1.0.0",
-                      "from": "is-path-cwd@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
                     },
                     "is-path-in-cwd": {
                       "version": "1.0.0",
-                      "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
                       "dependencies": {
                         "is-path-inside": {
                           "version": "1.0.0",
-                          "from": "is-path-inside@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
                         }
                       }
                     },
                     "pify": {
                       "version": "2.3.0",
-                      "from": "pify@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                     },
                     "pinkie-promise": {
                       "version": "2.0.1",
-                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                       "dependencies": {
                         "pinkie": {
                           "version": "2.0.4",
-                          "from": "pinkie@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                         }
                       }
                     },
                     "rimraf": {
                       "version": "2.5.2",
-                      "from": "rimraf@>=2.2.8 <3.0.0",
+                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
                       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz"
                     }
                   }
                 },
                 "graceful-fs": {
                   "version": "4.1.3",
-                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                 },
                 "read-json-sync": {
                   "version": "1.1.1",
-                  "from": "read-json-sync@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/read-json-sync/-/read-json-sync-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/read-json-sync/-/read-json-sync-1.1.1.tgz"
                 },
                 "write": {
                   "version": "0.2.1",
-                  "from": "write@>=0.2.1 <0.3.0",
+                  "from": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
                 }
               }
             },
             "object-assign": {
               "version": "4.0.1",
-              "from": "object-assign@>=4.0.1 <5.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
             }
           }
         },
         "glob": {
           "version": "7.0.3",
-          "from": "glob@>=7.0.3 <8.0.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "inflight@>=1.0.4 <2.0.0",
+              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "3.0.0",
-              "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.3",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.3.0",
-                      "from": "balanced-match@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -8883,12 +8883,12 @@
             },
             "once": {
               "version": "1.3.3",
-              "from": "once@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
@@ -8897,52 +8897,52 @@
         },
         "globals": {
           "version": "9.5.0",
-          "from": "globals@>=9.2.0 <10.0.0",
+          "from": "https://registry.npmjs.org/globals/-/globals-9.5.0.tgz",
           "resolved": "https://registry.npmjs.org/globals/-/globals-9.5.0.tgz"
         },
         "ignore": {
           "version": "3.1.2",
-          "from": "ignore@>=3.0.10 <4.0.0",
+          "from": "https://registry.npmjs.org/ignore/-/ignore-3.1.2.tgz",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.1.2.tgz"
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "from": "imurmurhash@>=0.1.4 <0.2.0",
+          "from": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
           "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
         },
         "inquirer": {
           "version": "0.12.0",
-          "from": "inquirer@>=0.12.0 <0.13.0",
+          "from": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
           "dependencies": {
             "ansi-escapes": {
               "version": "1.4.0",
-              "from": "ansi-escapes@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz"
             },
             "ansi-regex": {
               "version": "2.0.0",
-              "from": "ansi-regex@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
             },
             "cli-cursor": {
               "version": "1.0.2",
-              "from": "cli-cursor@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
               "dependencies": {
                 "restore-cursor": {
                   "version": "1.0.1",
-                  "from": "restore-cursor@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
                   "dependencies": {
                     "exit-hook": {
                       "version": "1.1.1",
-                      "from": "exit-hook@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
                     },
                     "onetime": {
                       "version": "1.1.0",
-                      "from": "onetime@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
                     }
                   }
@@ -8951,63 +8951,63 @@
             },
             "cli-width": {
               "version": "2.1.0",
-              "from": "cli-width@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
               "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz"
             },
             "figures": {
               "version": "1.5.0",
-              "from": "figures@>=1.3.5 <2.0.0",
+              "from": "https://registry.npmjs.org/figures/-/figures-1.5.0.tgz",
               "resolved": "https://registry.npmjs.org/figures/-/figures-1.5.0.tgz"
             },
             "readline2": {
               "version": "1.0.1",
-              "from": "readline2@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
               "dependencies": {
                 "code-point-at": {
                   "version": "1.0.0",
-                  "from": "code-point-at@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     }
                   }
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
-                  "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     }
                   }
                 },
                 "mute-stream": {
                   "version": "0.0.5",
-                  "from": "mute-stream@0.0.5",
+                  "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
                 }
               }
             },
             "run-async": {
               "version": "0.1.0",
-              "from": "run-async@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
               "dependencies": {
                 "once": {
                   "version": "1.3.3",
-                  "from": "once@>=1.3.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -9016,34 +9016,34 @@
             },
             "rx-lite": {
               "version": "3.1.2",
-              "from": "rx-lite@>=3.1.2 <4.0.0",
+              "from": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
               "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz"
             },
             "string-width": {
               "version": "1.0.1",
-              "from": "string-width@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
               "dependencies": {
                 "code-point-at": {
                   "version": "1.0.0",
-                  "from": "code-point-at@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     }
                   }
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
-                  "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     }
                   }
@@ -9052,106 +9052,106 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
             },
             "through": {
               "version": "2.3.8",
-              "from": "through@>=2.3.6 <3.0.0",
+              "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
               "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
             }
           }
         },
         "is-my-json-valid": {
           "version": "2.13.1",
-          "from": "is-my-json-valid@>=2.10.0 <3.0.0",
+          "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
           "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
           "dependencies": {
             "generate-function": {
               "version": "2.0.0",
-              "from": "generate-function@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
             },
             "generate-object-property": {
               "version": "1.2.0",
-              "from": "generate-object-property@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
               "dependencies": {
                 "is-property": {
                   "version": "1.0.2",
-                  "from": "is-property@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                 }
               }
             },
             "jsonpointer": {
               "version": "2.0.0",
-              "from": "jsonpointer@2.0.0",
+              "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <5.0.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
         },
         "is-resolvable": {
           "version": "1.0.0",
-          "from": "is-resolvable@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
           "dependencies": {
             "tryit": {
               "version": "1.0.2",
-              "from": "tryit@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/tryit/-/tryit-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.2.tgz"
             }
           }
         },
         "js-yaml": {
           "version": "3.6.0",
-          "from": "js-yaml@>=3.5.1 <4.0.0",
+          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.0.tgz",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.0.tgz",
           "dependencies": {
             "argparse": {
               "version": "1.0.7",
-              "from": "argparse@>=1.0.7 <2.0.0",
+              "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
               "dependencies": {
                 "sprintf-js": {
                   "version": "1.0.3",
-                  "from": "sprintf-js@>=1.0.2 <1.1.0",
+                  "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                 }
               }
             },
             "esprima": {
               "version": "2.7.2",
-              "from": "esprima@>=2.6.0 <3.0.0",
+              "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
             }
           }
         },
         "json-stable-stringify": {
           "version": "1.0.1",
-          "from": "json-stable-stringify@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
           "dependencies": {
             "jsonify": {
               "version": "0.0.0",
-              "from": "jsonify@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
               "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
             }
           }
         },
         "lodash": {
           "version": "4.11.1",
-          "from": "lodash@>=4.0.0 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.11.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.11.1.tgz"
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
@@ -9163,135 +9163,135 @@
         },
         "optionator": {
           "version": "0.8.1",
-          "from": "optionator@>=0.8.1 <0.9.0",
+          "from": "https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz",
           "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz",
           "dependencies": {
             "prelude-ls": {
               "version": "1.1.2",
-              "from": "prelude-ls@>=1.1.2 <1.2.0",
+              "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
             },
             "deep-is": {
               "version": "0.1.3",
-              "from": "deep-is@>=0.1.3 <0.2.0",
+              "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
               "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
             },
             "wordwrap": {
               "version": "1.0.0",
-              "from": "wordwrap@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
             },
             "type-check": {
               "version": "0.3.2",
-              "from": "type-check@>=0.3.2 <0.4.0",
+              "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
               "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
             },
             "levn": {
               "version": "0.3.0",
-              "from": "levn@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
             },
             "fast-levenshtein": {
               "version": "1.1.3",
-              "from": "fast-levenshtein@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.3.tgz"
             }
           }
         },
         "path-is-absolute": {
           "version": "1.0.0",
-          "from": "path-is-absolute@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
         },
         "path-is-inside": {
           "version": "1.0.1",
-          "from": "path-is-inside@>=1.0.1 <2.0.0",
+          "from": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
         },
         "pluralize": {
           "version": "1.2.1",
-          "from": "pluralize@>=1.2.1 <2.0.0",
+          "from": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
           "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz"
         },
         "progress": {
           "version": "1.1.8",
-          "from": "progress@>=1.1.8 <2.0.0",
+          "from": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
           "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
         },
         "require-uncached": {
           "version": "1.0.2",
-          "from": "require-uncached@>=1.0.2 <2.0.0",
+          "from": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.2.tgz",
           "dependencies": {
             "caller-path": {
               "version": "0.1.0",
-              "from": "caller-path@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
               "dependencies": {
                 "callsites": {
                   "version": "0.2.0",
-                  "from": "callsites@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz"
                 }
               }
             },
             "resolve-from": {
               "version": "1.0.1",
-              "from": "resolve-from@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz"
             }
           }
         },
         "shelljs": {
           "version": "0.6.0",
-          "from": "shelljs@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.0.tgz",
           "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.0.tgz"
         },
         "strip-json-comments": {
           "version": "1.0.4",
-          "from": "strip-json-comments@>=1.0.1 <1.1.0",
+          "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
         },
         "table": {
           "version": "3.7.8",
-          "from": "table@>=3.7.8 <4.0.0",
+          "from": "https://registry.npmjs.org/table/-/table-3.7.8.tgz",
           "resolved": "https://registry.npmjs.org/table/-/table-3.7.8.tgz",
           "dependencies": {
             "bluebird": {
               "version": "3.3.5",
-              "from": "bluebird@>=3.1.1 <4.0.0",
+              "from": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.5.tgz",
               "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.5.tgz"
             },
             "slice-ansi": {
               "version": "0.0.4",
-              "from": "slice-ansi@0.0.4",
+              "from": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
               "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz"
             },
             "string-width": {
               "version": "1.0.1",
-              "from": "string-width@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
               "dependencies": {
                 "code-point-at": {
                   "version": "1.0.0",
-                  "from": "code-point-at@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     }
                   }
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
-                  "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     }
                   }
@@ -9300,41 +9300,41 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "tv4": {
               "version": "1.2.7",
-              "from": "tv4@>=1.2.7 <2.0.0",
+              "from": "https://registry.npmjs.org/tv4/-/tv4-1.2.7.tgz",
               "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.2.7.tgz"
             },
             "xregexp": {
               "version": "3.1.0",
-              "from": "xregexp@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/xregexp/-/xregexp-3.1.0.tgz",
               "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-3.1.0.tgz"
             }
           }
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "text-table@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         },
         "user-home": {
           "version": "2.0.0",
-          "from": "user-home@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
           "dependencies": {
             "os-homedir": {
               "version": "1.0.1",
-              "from": "os-homedir@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
             }
           }
@@ -9343,46 +9343,46 @@
     },
     "eslint-config-airbnb": {
       "version": "6.2.0",
-      "from": "eslint-config-airbnb@>=6.2.0 <7.0.0",
+      "from": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-6.2.0.tgz",
       "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-6.2.0.tgz"
     },
     "eslint-loader": {
       "version": "1.3.0",
-      "from": "eslint-loader@>=1.3.0 <2.0.0",
+      "from": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-1.3.0.tgz",
       "dependencies": {
         "loader-utils": {
           "version": "0.2.14",
-          "from": "loader-utils@>=0.2.7 <0.3.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.14.tgz",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.14.tgz",
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.1.3 <4.0.0",
+              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "emojis-list": {
               "version": "1.0.1",
-              "from": "emojis-list@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.1.tgz"
             },
             "json5": {
               "version": "0.5.0",
-              "from": "json5@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz"
             }
           }
         },
         "object-assign": {
           "version": "4.0.1",
-          "from": "object-assign@>=4.0.1 <5.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
         }
       }
     },
     "eslint-plugin-react": {
       "version": "4.3.0",
-      "from": "eslint-plugin-react@>=4.2.3 <5.0.0",
+      "from": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-4.3.0.tgz",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-4.3.0.tgz"
     },
     "events": {
@@ -9392,37 +9392,37 @@
     },
     "extract-text-webpack-plugin": {
       "version": "0.8.2",
-      "from": "extract-text-webpack-plugin@>=0.8.1 <0.9.0",
+      "from": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-0.8.2.tgz",
       "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-0.8.2.tgz",
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "from": "async@>=1.2.1 <2.0.0",
+          "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         },
         "loader-utils": {
           "version": "0.2.14",
-          "from": "loader-utils@>=0.2.11 <0.3.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.14.tgz",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.14.tgz",
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.1.3 <4.0.0",
+              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "emojis-list": {
               "version": "1.0.1",
-              "from": "emojis-list@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.1.tgz"
             },
             "json5": {
               "version": "0.5.0",
-              "from": "json5@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz"
             },
             "object-assign": {
               "version": "4.0.1",
-              "from": "object-assign@>=4.0.1 <5.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
             }
           }
@@ -9431,32 +9431,32 @@
     },
     "file-loader": {
       "version": "0.8.5",
-      "from": "file-loader@>=0.8.5 <0.9.0",
+      "from": "https://registry.npmjs.org/file-loader/-/file-loader-0.8.5.tgz",
       "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.8.5.tgz",
       "dependencies": {
         "loader-utils": {
           "version": "0.2.14",
-          "from": "loader-utils@>=0.2.7 <0.3.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.14.tgz",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.14.tgz",
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.1.3 <4.0.0",
+              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "emojis-list": {
               "version": "1.0.1",
-              "from": "emojis-list@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.1.tgz"
             },
             "json5": {
               "version": "0.5.0",
-              "from": "json5@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz"
             },
             "object-assign": {
               "version": "4.0.1",
-              "from": "object-assign@>=4.0.1 <5.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
             }
           }
@@ -9595,44 +9595,44 @@
     },
     "imports-loader": {
       "version": "0.6.5",
-      "from": "imports-loader@>=0.6.4 <0.7.0",
+      "from": "https://registry.npmjs.org/imports-loader/-/imports-loader-0.6.5.tgz",
       "resolved": "https://registry.npmjs.org/imports-loader/-/imports-loader-0.6.5.tgz",
       "dependencies": {
         "loader-utils": {
           "version": "0.2.14",
-          "from": "loader-utils@>=0.2.7 <0.3.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.14.tgz",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.14.tgz",
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.1.3 <4.0.0",
+              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "emojis-list": {
               "version": "1.0.1",
-              "from": "emojis-list@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.1.tgz"
             },
             "json5": {
               "version": "0.5.0",
-              "from": "json5@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz"
             },
             "object-assign": {
               "version": "4.0.1",
-              "from": "object-assign@>=4.0.1 <5.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
             }
           }
         },
         "source-map": {
           "version": "0.1.43",
-          "from": "source-map@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "dependencies": {
             "amdefine": {
               "version": "1.0.0",
-              "from": "amdefine@>=0.0.4",
+              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
             }
           }
@@ -9641,84 +9641,84 @@
     },
     "istanbul": {
       "version": "0.3.22",
-      "from": "istanbul@>=0.3.5 <0.4.0",
+      "from": "https://registry.npmjs.org/istanbul/-/istanbul-0.3.22.tgz",
       "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.3.22.tgz",
       "dependencies": {
         "abbrev": {
           "version": "1.0.7",
-          "from": "abbrev@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
           "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
         },
         "async": {
           "version": "1.5.2",
-          "from": "async@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         },
         "escodegen": {
           "version": "1.7.1",
-          "from": "escodegen@>=1.7.0 <1.8.0",
+          "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.7.1.tgz",
           "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.7.1.tgz",
           "dependencies": {
             "estraverse": {
               "version": "1.9.3",
-              "from": "estraverse@>=1.9.1 <2.0.0",
+              "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
               "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
             },
             "esutils": {
               "version": "2.0.2",
-              "from": "esutils@>=2.0.2 <3.0.0",
+              "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
               "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
             },
             "esprima": {
               "version": "1.2.5",
-              "from": "esprima@>=1.2.2 <2.0.0",
+              "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
             },
             "optionator": {
               "version": "0.5.0",
-              "from": "optionator@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
               "dependencies": {
                 "prelude-ls": {
                   "version": "1.1.2",
-                  "from": "prelude-ls@>=1.1.1 <1.2.0",
+                  "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
                 },
                 "deep-is": {
                   "version": "0.1.3",
-                  "from": "deep-is@>=0.1.2 <0.2.0",
+                  "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                 },
                 "wordwrap": {
                   "version": "0.0.3",
-                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                 },
                 "type-check": {
                   "version": "0.3.2",
-                  "from": "type-check@>=0.3.1 <0.4.0",
+                  "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
                   "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
                 },
                 "levn": {
                   "version": "0.2.5",
-                  "from": "levn@>=0.2.5 <0.3.0",
+                  "from": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
                   "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
                 },
                 "fast-levenshtein": {
                   "version": "1.0.7",
-                  "from": "fast-levenshtein@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
                 }
               }
             },
             "source-map": {
               "version": "0.2.0",
-              "from": "source-map@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "1.0.0",
-                  "from": "amdefine@>=0.0.4",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                 }
               }
@@ -9727,32 +9727,32 @@
         },
         "esprima": {
           "version": "2.5.0",
-          "from": "esprima@>=2.5.0 <2.6.0",
+          "from": "https://registry.npmjs.org/esprima/-/esprima-2.5.0.tgz",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.5.0.tgz"
         },
         "fileset": {
           "version": "0.2.1",
-          "from": "fileset@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
           "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
           "dependencies": {
             "minimatch": {
               "version": "2.0.10",
-              "from": "minimatch@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.3",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.3.0",
-                      "from": "balanced-match@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -9761,29 +9761,29 @@
             },
             "glob": {
               "version": "5.0.15",
-              "from": "glob@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                 }
               }
@@ -9792,144 +9792,144 @@
         },
         "handlebars": {
           "version": "4.0.5",
-          "from": "handlebars@>=4.0.1 <5.0.0",
+          "from": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
           "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
           "dependencies": {
             "optimist": {
               "version": "0.6.1",
-              "from": "optimist@>=0.6.1 <0.7.0",
+              "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.3",
-                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                 },
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "minimist@>=0.0.1 <0.1.0",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 }
               }
             },
             "source-map": {
               "version": "0.4.4",
-              "from": "source-map@>=0.4.4 <0.5.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "1.0.0",
-                  "from": "amdefine@>=0.0.4",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                 }
               }
             },
             "uglify-js": {
               "version": "2.6.2",
-              "from": "uglify-js@>=2.6.0 <3.0.0",
+              "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "async@>=0.2.6 <0.3.0",
+                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "source-map": {
                   "version": "0.5.5",
-                  "from": "source-map@>=0.5.1 <0.6.0",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.5.tgz",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.5.tgz"
                 },
                 "uglify-to-browserify": {
                   "version": "1.0.2",
-                  "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
                 },
                 "yargs": {
                   "version": "3.10.0",
-                  "from": "yargs@>=3.10.0 <3.11.0",
+                  "from": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
                   "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "1.2.1",
-                      "from": "camelcase@>=1.0.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                     },
                     "cliui": {
                       "version": "2.1.0",
-                      "from": "cliui@>=2.1.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                       "dependencies": {
                         "center-align": {
                           "version": "0.1.3",
-                          "from": "center-align@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.4",
-                              "from": "align-text@>=0.1.3 <0.2.0",
+                              "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                               "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                               "dependencies": {
                                 "kind-of": {
                                   "version": "3.0.2",
-                                  "from": "kind-of@>=3.0.2 <4.0.0",
+                                  "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                                   "dependencies": {
                                     "is-buffer": {
                                       "version": "1.1.3",
-                                      "from": "is-buffer@>=1.0.2 <2.0.0",
+                                      "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
                                       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                     }
                                   }
                                 },
                                 "longest": {
                                   "version": "1.0.1",
-                                  "from": "longest@>=1.0.1 <2.0.0",
+                                  "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.4",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                 }
                               }
                             },
                             "lazy-cache": {
                               "version": "1.0.4",
-                              "from": "lazy-cache@>=1.0.3 <2.0.0",
+                              "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
                             }
                           }
                         },
                         "right-align": {
                           "version": "0.1.3",
-                          "from": "right-align@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.4",
-                              "from": "align-text@>=0.1.3 <0.2.0",
+                              "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                               "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                               "dependencies": {
                                 "kind-of": {
                                   "version": "3.0.2",
-                                  "from": "kind-of@>=3.0.2 <4.0.0",
+                                  "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                                   "dependencies": {
                                     "is-buffer": {
                                       "version": "1.1.3",
-                                      "from": "is-buffer@>=1.0.2 <2.0.0",
+                                      "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
                                       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                     }
                                   }
                                 },
                                 "longest": {
                                   "version": "1.0.1",
-                                  "from": "longest@>=1.0.1 <2.0.0",
+                                  "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.4",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                 }
                               }
@@ -9938,19 +9938,19 @@
                         },
                         "wordwrap": {
                           "version": "0.0.2",
-                          "from": "wordwrap@0.0.2",
+                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                         }
                       }
                     },
                     "decamelize": {
                       "version": "1.2.0",
-                      "from": "decamelize@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                     },
                     "window-size": {
                       "version": "0.1.0",
-                      "from": "window-size@0.1.0",
+                      "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
                     }
                   }
@@ -9961,113 +9961,113 @@
         },
         "js-yaml": {
           "version": "3.6.0",
-          "from": "js-yaml@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.0.tgz",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.0.tgz",
           "dependencies": {
             "argparse": {
               "version": "1.0.7",
-              "from": "argparse@>=1.0.7 <2.0.0",
+              "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
               "dependencies": {
                 "sprintf-js": {
                   "version": "1.0.3",
-                  "from": "sprintf-js@>=1.0.2 <1.1.0",
+                  "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                 }
               }
             },
             "esprima": {
               "version": "2.7.2",
-              "from": "esprima@>=2.6.0 <3.0.0",
+              "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
             }
           }
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "minimist@0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "nopt": {
           "version": "3.0.6",
-          "from": "nopt@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
         },
         "once": {
           "version": "1.3.3",
-          "from": "once@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "dependencies": {
             "wrappy": {
               "version": "1.0.1",
-              "from": "wrappy@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
             }
           }
         },
         "resolve": {
           "version": "1.1.7",
-          "from": "resolve@>=1.1.0 <1.2.0",
+          "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
         },
         "supports-color": {
           "version": "3.1.2",
-          "from": "supports-color@>=3.1.0 <4.0.0",
+          "from": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "dependencies": {
             "has-flag": {
               "version": "1.0.0",
-              "from": "has-flag@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
             }
           }
         },
         "which": {
           "version": "1.2.4",
-          "from": "which@>=1.1.1 <2.0.0",
+          "from": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
           "resolved": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
           "dependencies": {
             "is-absolute": {
               "version": "0.1.7",
-              "from": "is-absolute@>=0.1.7 <0.2.0",
+              "from": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
               "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
               "dependencies": {
                 "is-relative": {
                   "version": "0.1.3",
-                  "from": "is-relative@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
                 }
               }
             },
             "isexe": {
               "version": "1.1.2",
-              "from": "isexe@>=1.1.1 <2.0.0",
+              "from": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
             }
           }
         },
         "wordwrap": {
           "version": "1.0.0",
-          "from": "wordwrap@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
         }
       }
     },
     "jasmine-core": {
       "version": "2.4.1",
-      "from": "jasmine-core@>=2.3.4 <3.0.0",
+      "from": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.4.1.tgz",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.4.1.tgz"
     },
     "jasmine-sinon": {
       "version": "0.4.0",
-      "from": "jasmine-sinon@>=0.4.0 <0.5.0",
+      "from": "https://registry.npmjs.org/jasmine-sinon/-/jasmine-sinon-0.4.0.tgz",
       "resolved": "https://registry.npmjs.org/jasmine-sinon/-/jasmine-sinon-0.4.0.tgz"
     },
     "json-loader": {
@@ -10077,93 +10077,93 @@
     },
     "jsx-loader": {
       "version": "0.13.2",
-      "from": "jsx-loader@>=0.13.2 <0.14.0",
+      "from": "https://registry.npmjs.org/jsx-loader/-/jsx-loader-0.13.2.tgz",
       "resolved": "https://registry.npmjs.org/jsx-loader/-/jsx-loader-0.13.2.tgz",
       "dependencies": {
         "jstransform": {
           "version": "11.0.3",
-          "from": "jstransform@>=11.0.0 <12.0.0",
+          "from": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
           "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
           "dependencies": {
             "base62": {
               "version": "1.1.1",
-              "from": "base62@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/base62/-/base62-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/base62/-/base62-1.1.1.tgz"
             },
             "commoner": {
               "version": "0.10.4",
-              "from": "commoner@>=0.10.1 <0.11.0",
+              "from": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
               "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
               "dependencies": {
                 "commander": {
                   "version": "2.9.0",
-                  "from": "commander@>=2.5.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "from": "graceful-readlink@>=1.0.0",
+                      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     }
                   }
                 },
                 "detective": {
                   "version": "4.3.1",
-                  "from": "detective@>=4.3.1 <5.0.0",
+                  "from": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
                   "dependencies": {
                     "acorn": {
                       "version": "1.2.2",
-                      "from": "acorn@>=1.0.3 <2.0.0",
+                      "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
                     },
                     "defined": {
                       "version": "1.0.0",
-                      "from": "defined@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
                     }
                   }
                 },
                 "glob": {
                   "version": "5.0.15",
-                  "from": "glob@>=5.0.15 <6.0.0",
+                  "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "3.0.0",
-                      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.3",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.3.0",
-                              "from": "balanced-match@>=0.3.0 <0.4.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
@@ -10172,73 +10172,73 @@
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "path-is-absolute": {
                       "version": "1.0.0",
-                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                     }
                   }
                 },
                 "graceful-fs": {
                   "version": "4.1.3",
-                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                 },
                 "iconv-lite": {
                   "version": "0.4.13",
-                  "from": "iconv-lite@>=0.4.5 <0.5.0",
+                  "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
                   "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
                 },
                 "mkdirp": {
                   "version": "0.5.1",
-                  "from": "mkdirp@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "minimist@0.0.8",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
                 },
                 "private": {
                   "version": "0.1.6",
-                  "from": "private@>=0.1.5 <0.2.0",
+                  "from": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
                   "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
                 },
                 "q": {
                   "version": "1.4.1",
-                  "from": "q@>=1.1.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
                 },
                 "recast": {
                   "version": "0.10.43",
-                  "from": "recast@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
                   "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
                   "dependencies": {
                     "esprima-fb": {
                       "version": "15001.1001.0-dev-harmony-fb",
-                      "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
+                      "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
                       "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
                     },
                     "source-map": {
                       "version": "0.5.5",
-                      "from": "source-map@>=0.5.0 <0.6.0",
+                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.5.tgz",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.5.tgz"
                     },
                     "ast-types": {
                       "version": "0.8.15",
-                      "from": "ast-types@0.8.15",
+                      "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz",
                       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz"
                     }
                   }
@@ -10247,22 +10247,22 @@
             },
             "esprima-fb": {
               "version": "15001.1.0-dev-harmony-fb",
-              "from": "esprima-fb@>=15001.1.0-dev-harmony-fb <15002.0.0",
+              "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
               "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz"
             },
             "object-assign": {
               "version": "2.1.1",
-              "from": "object-assign@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
             },
             "source-map": {
               "version": "0.4.4",
-              "from": "source-map@>=0.4.2 <0.5.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "1.0.0",
-                  "from": "amdefine@>=0.0.4",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                 }
               }
@@ -10271,27 +10271,27 @@
         },
         "loader-utils": {
           "version": "0.2.14",
-          "from": "loader-utils@>=0.2.7 <0.3.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.14.tgz",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.14.tgz",
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.1.3 <4.0.0",
+              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "emojis-list": {
               "version": "1.0.1",
-              "from": "emojis-list@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.1.tgz"
             },
             "json5": {
               "version": "0.5.0",
-              "from": "json5@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz"
             },
             "object-assign": {
               "version": "4.0.1",
-              "from": "object-assign@>=4.0.1 <5.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
             }
           }
@@ -10300,125 +10300,125 @@
     },
     "karma": {
       "version": "0.13.22",
-      "from": "karma@>=0.13.19 <0.14.0",
+      "from": "https://registry.npmjs.org/karma/-/karma-0.13.22.tgz",
       "resolved": "https://registry.npmjs.org/karma/-/karma-0.13.22.tgz",
       "dependencies": {
         "batch": {
           "version": "0.5.3",
-          "from": "batch@>=0.5.3 <0.6.0",
+          "from": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
           "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz"
         },
         "bluebird": {
           "version": "2.10.2",
-          "from": "bluebird@>=2.9.27 <3.0.0",
+          "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
         },
         "body-parser": {
           "version": "1.15.0",
-          "from": "body-parser@>=1.12.4 <2.0.0",
+          "from": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.0.tgz",
           "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.0.tgz",
           "dependencies": {
             "bytes": {
               "version": "2.2.0",
-              "from": "bytes@2.2.0",
+              "from": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz"
             },
             "content-type": {
               "version": "1.0.1",
-              "from": "content-type@>=1.0.1 <1.1.0",
+              "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
             },
             "debug": {
               "version": "2.2.0",
-              "from": "debug@>=2.2.0 <2.3.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
-                  "from": "ms@0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
             },
             "depd": {
               "version": "1.1.0",
-              "from": "depd@>=1.1.0 <1.2.0",
+              "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
             },
             "http-errors": {
               "version": "1.4.0",
-              "from": "http-errors@>=1.4.0 <1.5.0",
+              "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz",
               "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "statuses": {
                   "version": "1.2.1",
-                  "from": "statuses@>=1.2.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
                 }
               }
             },
             "iconv-lite": {
               "version": "0.4.13",
-              "from": "iconv-lite@0.4.13",
+              "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
               "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
             },
             "on-finished": {
               "version": "2.3.0",
-              "from": "on-finished@>=2.3.0 <2.4.0",
+              "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "dependencies": {
                 "ee-first": {
                   "version": "1.1.1",
-                  "from": "ee-first@1.1.1",
+                  "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
                 }
               }
             },
             "qs": {
               "version": "6.1.0",
-              "from": "qs@6.1.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz",
               "resolved": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz"
             },
             "raw-body": {
               "version": "2.1.6",
-              "from": "raw-body@>=2.1.5 <2.2.0",
+              "from": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.6.tgz",
               "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.6.tgz",
               "dependencies": {
                 "bytes": {
                   "version": "2.3.0",
-                  "from": "bytes@2.3.0",
+                  "from": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz"
                 },
                 "unpipe": {
                   "version": "1.0.0",
-                  "from": "unpipe@1.0.0",
+                  "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
                 }
               }
             },
             "type-is": {
               "version": "1.6.12",
-              "from": "type-is@>=1.6.11 <1.7.0",
+              "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz",
               "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz",
               "dependencies": {
                 "media-typer": {
                   "version": "0.3.0",
-                  "from": "media-typer@0.3.0",
+                  "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
                 },
                 "mime-types": {
                   "version": "2.1.10",
-                  "from": "mime-types@>=2.1.10 <2.2.0",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.22.0",
-                      "from": "mime-db@>=1.22.0 <1.23.0",
+                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
                     }
                   }
@@ -10429,81 +10429,81 @@
         },
         "chokidar": {
           "version": "1.4.3",
-          "from": "chokidar@>=1.4.1 <2.0.0",
+          "from": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.3.tgz",
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.3.tgz",
           "dependencies": {
             "anymatch": {
               "version": "1.3.0",
-              "from": "anymatch@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
               "dependencies": {
                 "arrify": {
                   "version": "1.0.1",
-                  "from": "arrify@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
                 },
                 "micromatch": {
                   "version": "2.3.8",
-                  "from": "micromatch@>=2.1.5 <3.0.0",
+                  "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.8.tgz",
                   "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.8.tgz",
                   "dependencies": {
                     "arr-diff": {
                       "version": "2.0.0",
-                      "from": "arr-diff@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
                       "dependencies": {
                         "arr-flatten": {
                           "version": "1.0.1",
-                          "from": "arr-flatten@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
                         }
                       }
                     },
                     "array-unique": {
                       "version": "0.2.1",
-                      "from": "array-unique@>=0.2.1 <0.3.0",
+                      "from": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
                     },
                     "braces": {
                       "version": "1.8.4",
-                      "from": "braces@>=1.8.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/braces/-/braces-1.8.4.tgz",
                       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.4.tgz",
                       "dependencies": {
                         "expand-range": {
                           "version": "1.8.1",
-                          "from": "expand-range@>=1.8.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                           "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                           "dependencies": {
                             "fill-range": {
                               "version": "2.2.3",
-                              "from": "fill-range@>=2.1.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
                               "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
                               "dependencies": {
                                 "is-number": {
                                   "version": "2.1.0",
-                                  "from": "is-number@>=2.1.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
                                   "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
                                 },
                                 "isobject": {
                                   "version": "2.1.0",
-                                  "from": "isobject@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                                   "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                                   "dependencies": {
                                     "isarray": {
                                       "version": "1.0.0",
-                                      "from": "isarray@1.0.0",
+                                      "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                                     }
                                   }
                                 },
                                 "randomatic": {
                                   "version": "1.1.5",
-                                  "from": "randomatic@>=1.1.3 <2.0.0",
+                                  "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
                                   "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.4",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                 }
                               }
@@ -10512,114 +10512,114 @@
                         },
                         "preserve": {
                           "version": "0.2.0",
-                          "from": "preserve@>=0.2.0 <0.3.0",
+                          "from": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
                         },
                         "repeat-element": {
                           "version": "1.1.2",
-                          "from": "repeat-element@>=1.1.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
                         }
                       }
                     },
                     "expand-brackets": {
                       "version": "0.1.5",
-                      "from": "expand-brackets@>=0.1.4 <0.2.0",
+                      "from": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
                       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
                       "dependencies": {
                         "is-posix-bracket": {
                           "version": "0.1.1",
-                          "from": "is-posix-bracket@>=0.1.0 <0.2.0",
+                          "from": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
                         }
                       }
                     },
                     "extglob": {
                       "version": "0.3.2",
-                      "from": "extglob@>=0.3.1 <0.4.0",
+                      "from": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
                       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
                     },
                     "filename-regex": {
                       "version": "2.0.0",
-                      "from": "filename-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
                     },
                     "is-extglob": {
                       "version": "1.0.0",
-                      "from": "is-extglob@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                     },
                     "kind-of": {
                       "version": "3.0.2",
-                      "from": "kind-of@>=3.0.2 <4.0.0",
+                      "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                       "dependencies": {
                         "is-buffer": {
                           "version": "1.1.3",
-                          "from": "is-buffer@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                         }
                       }
                     },
                     "normalize-path": {
                       "version": "2.0.1",
-                      "from": "normalize-path@>=2.0.1 <3.0.0",
+                      "from": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
                     },
                     "object.omit": {
                       "version": "2.0.0",
-                      "from": "object.omit@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
                       "dependencies": {
                         "for-own": {
                           "version": "0.1.4",
-                          "from": "for-own@>=0.1.3 <0.2.0",
+                          "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
                           "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
                           "dependencies": {
                             "for-in": {
                               "version": "0.1.5",
-                              "from": "for-in@>=0.1.5 <0.2.0",
+                              "from": "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz",
                               "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz"
                             }
                           }
                         },
                         "is-extendable": {
                           "version": "0.1.1",
-                          "from": "is-extendable@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
                         }
                       }
                     },
                     "parse-glob": {
                       "version": "3.0.4",
-                      "from": "parse-glob@>=3.0.4 <4.0.0",
+                      "from": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
                       "dependencies": {
                         "glob-base": {
                           "version": "0.3.0",
-                          "from": "glob-base@>=0.3.0 <0.4.0",
+                          "from": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
                         },
                         "is-dotfile": {
                           "version": "1.0.2",
-                          "from": "is-dotfile@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
                         }
                       }
                     },
                     "regex-cache": {
                       "version": "0.4.3",
-                      "from": "regex-cache@>=0.4.2 <0.5.0",
+                      "from": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
                       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
                       "dependencies": {
                         "is-equal-shallow": {
                           "version": "0.1.3",
-                          "from": "is-equal-shallow@>=0.1.3 <0.2.0",
+                          "from": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
                         },
                         "is-primitive": {
                           "version": "2.0.0",
-                          "from": "is-primitive@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
                         }
                       }
@@ -10630,71 +10630,71 @@
             },
             "async-each": {
               "version": "1.0.0",
-              "from": "async-each@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/async-each/-/async-each-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.0.tgz"
             },
             "glob-parent": {
               "version": "2.0.0",
-              "from": "glob-parent@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "is-binary-path": {
               "version": "1.0.1",
-              "from": "is-binary-path@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
               "dependencies": {
                 "binary-extensions": {
                   "version": "1.4.0",
-                  "from": "binary-extensions@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz"
                 }
               }
             },
             "is-glob": {
               "version": "2.0.1",
-              "from": "is-glob@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
               "dependencies": {
                 "is-extglob": {
                   "version": "1.0.0",
-                  "from": "is-extglob@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                 }
               }
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             },
             "readdirp": {
               "version": "2.0.0",
-              "from": "readdirp@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
               "dependencies": {
                 "minimatch": {
                   "version": "2.0.10",
-                  "from": "minimatch@>=2.0.10 <3.0.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.3",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.3.0",
-                          "from": "balanced-match@>=0.3.0 <0.4.0",
+                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
+                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -10703,66 +10703,66 @@
                 },
                 "readable-stream": {
                   "version": "2.1.0",
-                  "from": "readable-stream@>=2.0.2 <3.0.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.0.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "inline-process-browser": {
                       "version": "2.0.1",
-                      "from": "inline-process-browser@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inline-process-browser/-/inline-process-browser-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inline-process-browser/-/inline-process-browser-2.0.1.tgz",
                       "dependencies": {
                         "falafel": {
                           "version": "1.2.0",
-                          "from": "falafel@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
                           "dependencies": {
                             "acorn": {
                               "version": "1.2.2",
-                              "from": "acorn@>=1.0.3 <2.0.0",
+                              "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
                               "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
                             },
                             "foreach": {
                               "version": "2.0.5",
-                              "from": "foreach@>=2.0.5 <3.0.0",
+                              "from": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
                               "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
                             },
                             "isarray": {
                               "version": "0.0.1",
-                              "from": "isarray@0.0.1",
+                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                             },
                             "object-keys": {
                               "version": "1.0.9",
-                              "from": "object-keys@>=1.0.6 <2.0.0",
+                              "from": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz",
                               "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz"
                             }
                           }
                         },
                         "through2": {
                           "version": "0.6.5",
-                          "from": "through2@>=0.6.5 <0.7.0",
+                          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                           "dependencies": {
                             "readable-stream": {
                               "version": "1.0.34",
-                              "from": "readable-stream@>=1.0.2 <1.1.0",
+                              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                               "dependencies": {
                                 "isarray": {
                                   "version": "0.0.1",
-                                  "from": "isarray@0.0.1",
+                                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                                 }
                               }
                             },
                             "xtend": {
                               "version": "4.0.1",
-                              "from": "xtend@>=4.0.0 <4.1.0-0",
+                              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                             }
                           }
@@ -10771,47 +10771,47 @@
                     },
                     "isarray": {
                       "version": "1.0.0",
-                      "from": "isarray@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.6",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "unreachable-branch-transform": {
                       "version": "0.5.1",
-                      "from": "unreachable-branch-transform@>=0.5.0 <0.6.0",
+                      "from": "https://registry.npmjs.org/unreachable-branch-transform/-/unreachable-branch-transform-0.5.1.tgz",
                       "resolved": "https://registry.npmjs.org/unreachable-branch-transform/-/unreachable-branch-transform-0.5.1.tgz",
                       "dependencies": {
                         "esmangle-evaluator": {
                           "version": "1.0.0",
-                          "from": "esmangle-evaluator@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.0.tgz"
                         },
                         "recast": {
                           "version": "0.11.5",
-                          "from": "recast@>=0.11.4 <0.12.0",
+                          "from": "https://registry.npmjs.org/recast/-/recast-0.11.5.tgz",
                           "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.5.tgz",
                           "dependencies": {
                             "ast-types": {
                               "version": "0.8.16",
-                              "from": "ast-types@0.8.16",
+                              "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.16.tgz",
                               "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.16.tgz"
                             },
                             "esprima": {
                               "version": "2.7.2",
-                              "from": "esprima@>=2.7.1 <2.8.0",
+                              "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
                               "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
                             },
                             "private": {
                               "version": "0.1.6",
-                              "from": "private@>=0.1.5 <0.2.0",
+                              "from": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
                               "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
                             }
                           }
@@ -10820,7 +10820,7 @@
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
@@ -10829,12 +10829,12 @@
             },
             "fsevents": {
               "version": "1.0.11",
-              "from": "fsevents@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.11.tgz",
               "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.11.tgz",
               "dependencies": {
                 "nan": {
                   "version": "2.3.2",
-                  "from": "nan@>=2.1.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/nan/-/nan-2.3.2.tgz",
                   "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.2.tgz"
                 },
                 "node-pre-gyp": {
@@ -10856,6 +10856,11 @@
                     }
                   }
                 },
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@^2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                },
                 "ansi": {
                   "version": "0.3.1",
                   "from": "ansi@~0.3.1",
@@ -10866,30 +10871,25 @@
                   "from": "ansi-styles@^2.2.1",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                 },
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "ansi-regex@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                "are-we-there-yet": {
+                  "version": "1.1.2",
+                  "from": "are-we-there-yet@~1.1.2",
+                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz"
                 },
                 "asn1": {
                   "version": "0.2.3",
                   "from": "asn1@>=0.2.3 <0.3.0",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                 },
-                "are-we-there-yet": {
-                  "version": "1.1.2",
-                  "from": "are-we-there-yet@~1.1.2",
-                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz"
+                "assert-plus": {
+                  "version": "0.2.0",
+                  "from": "assert-plus@^0.2.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
                 },
                 "async": {
                   "version": "1.5.2",
                   "from": "async@^1.5.2",
                   "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
-                },
-                "assert-plus": {
-                  "version": "0.2.0",
-                  "from": "assert-plus@^0.2.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
                 },
                 "aws-sign2": {
                   "version": "0.6.0",
@@ -10906,15 +10906,15 @@
                   "from": "bl@~1.0.0",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz"
                 },
-                "caseless": {
-                  "version": "0.11.0",
-                  "from": "caseless@~0.11.0",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
-                },
                 "boom": {
                   "version": "2.10.1",
                   "from": "boom@2.x.x",
                   "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                },
+                "caseless": {
+                  "version": "0.11.0",
+                  "from": "caseless@~0.11.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
                 },
                 "chalk": {
                   "version": "1.1.3",
@@ -10941,35 +10941,35 @@
                   "from": "cryptiles@2.x.x",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                 },
-                "debug": {
-                  "version": "2.2.0",
-                  "from": "debug@~2.2.0",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
-                },
                 "deep-extend": {
                   "version": "0.4.1",
                   "from": "deep-extend@~0.4.0",
                   "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
                 },
-                "delegates": {
-                  "version": "1.0.0",
-                  "from": "delegates@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
+                "debug": {
+                  "version": "2.2.0",
+                  "from": "debug@~2.2.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
                 },
                 "delayed-stream": {
                   "version": "1.0.0",
                   "from": "delayed-stream@~1.0.0",
                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                 },
-                "ecc-jsbn": {
-                  "version": "0.1.1",
-                  "from": "ecc-jsbn@>=0.0.1 <1.0.0",
-                  "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                "delegates": {
+                  "version": "1.0.0",
+                  "from": "delegates@^1.0.0",
+                  "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
                   "from": "escape-string-regexp@^1.0.2",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                },
+                "ecc-jsbn": {
+                  "version": "0.1.1",
+                  "from": "ecc-jsbn@>=0.0.1 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                 },
                 "extend": {
                   "version": "3.0.0",
@@ -10981,30 +10981,25 @@
                   "from": "extsprintf@1.0.2",
                   "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                 },
-                "form-data": {
-                  "version": "1.0.0-rc4",
-                  "from": "form-data@~1.0.0-rc3",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz"
-                },
                 "forever-agent": {
                   "version": "0.6.1",
                   "from": "forever-agent@~0.6.1",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                 },
-                "gauge": {
-                  "version": "1.2.7",
-                  "from": "gauge@~1.2.5",
-                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz"
+                "form-data": {
+                  "version": "1.0.0-rc4",
+                  "from": "form-data@~1.0.0-rc3",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz"
                 },
                 "fstream": {
                   "version": "1.0.8",
                   "from": "fstream@^1.0.2",
                   "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
                 },
-                "graceful-fs": {
-                  "version": "4.1.3",
-                  "from": "graceful-fs@^4.1.2",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                "gauge": {
+                  "version": "1.2.7",
+                  "from": "gauge@~1.2.5",
+                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz"
                 },
                 "generate-function": {
                   "version": "2.0.0",
@@ -11016,30 +11011,35 @@
                   "from": "generate-object-property@^1.1.0",
                   "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
                 },
+                "graceful-fs": {
+                  "version": "4.1.3",
+                  "from": "graceful-fs@^4.1.2",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                },
                 "graceful-readlink": {
                   "version": "1.0.1",
                   "from": "graceful-readlink@>= 1.0.0",
                   "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-                },
-                "has-ansi": {
-                  "version": "2.0.0",
-                  "from": "has-ansi@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
                 },
                 "har-validator": {
                   "version": "2.0.6",
                   "from": "har-validator@~2.0.6",
                   "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
                 },
-                "hawk": {
-                  "version": "3.1.3",
-                  "from": "hawk@~3.1.0",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "from": "has-ansi@^2.0.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
                 },
                 "has-unicode": {
                   "version": "2.0.0",
                   "from": "has-unicode@^2.0.0",
                   "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz"
+                },
+                "hawk": {
+                  "version": "3.1.3",
+                  "from": "hawk@~3.1.0",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
                 },
                 "hoek": {
                   "version": "2.16.3",
@@ -11051,25 +11051,20 @@
                   "from": "http-signature@~1.1.0",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
                 },
-                "ini": {
-                  "version": "1.3.4",
-                  "from": "ini@~1.3.0",
-                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-                },
                 "inherits": {
                   "version": "2.0.1",
                   "from": "inherits@*",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
-                "isarray": {
-                  "version": "1.0.0",
-                  "from": "isarray@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                },
                 "is-my-json-valid": {
                   "version": "2.13.1",
                   "from": "is-my-json-valid@^2.12.4",
                   "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz"
+                },
+                "ini": {
+                  "version": "1.3.4",
+                  "from": "ini@~1.3.0",
+                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                 },
                 "is-property": {
                   "version": "1.0.2",
@@ -11086,10 +11081,10 @@
                   "from": "isstream@~0.1.2",
                   "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                 },
-                "json-schema": {
-                  "version": "0.2.2",
-                  "from": "json-schema@0.2.2",
-                  "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+                "isarray": {
+                  "version": "1.0.0",
+                  "from": "isarray@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 },
                 "jodid25519": {
                   "version": "1.0.2",
@@ -11101,6 +11096,11 @@
                   "from": "jsbn@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                 },
+                "json-schema": {
+                  "version": "0.2.2",
+                  "from": "json-schema@0.2.2",
+                  "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+                },
                 "json-stringify-safe": {
                   "version": "5.0.1",
                   "from": "json-stringify-safe@~5.0.1",
@@ -11111,30 +11111,35 @@
                   "from": "jsonpointer@2.0.0",
                   "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                 },
-                "lodash.pad": {
-                  "version": "4.1.0",
-                  "from": "lodash.pad@^4.1.0",
-                  "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.1.0.tgz"
-                },
                 "jsprim": {
                   "version": "1.2.2",
                   "from": "jsprim@^1.2.2",
                   "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
                 },
-                "lodash.padstart": {
-                  "version": "4.2.0",
-                  "from": "lodash.padstart@^4.1.0",
-                  "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.2.0.tgz"
+                "lodash.pad": {
+                  "version": "4.1.0",
+                  "from": "lodash.pad@^4.1.0",
+                  "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.1.0.tgz"
                 },
                 "lodash.padend": {
                   "version": "4.2.0",
                   "from": "lodash.padend@^4.1.0",
                   "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.2.0.tgz"
                 },
+                "lodash.padstart": {
+                  "version": "4.2.0",
+                  "from": "lodash.padstart@^4.1.0",
+                  "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.2.0.tgz"
+                },
                 "lodash.repeat": {
                   "version": "4.0.0",
                   "from": "lodash.repeat@^4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.0.0.tgz"
+                },
+                "mime-db": {
+                  "version": "1.22.0",
+                  "from": "mime-db@~1.22.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
                 },
                 "lodash.tostring": {
                   "version": "4.1.2",
@@ -11145,11 +11150,6 @@
                   "version": "2.1.10",
                   "from": "mime-types@~2.1.7",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz"
-                },
-                "mime-db": {
-                  "version": "1.22.0",
-                  "from": "mime-db@~1.22.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
                 },
                 "minimist": {
                   "version": "0.0.8",
@@ -11176,60 +11176,65 @@
                   "from": "npmlog@~2.0.0",
                   "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.3.tgz"
                 },
-                "once": {
-                  "version": "1.3.3",
-                  "from": "once@~1.3.3",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+                "pinkie": {
+                  "version": "2.0.4",
+                  "from": "pinkie@^2.0.0",
+                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                 },
                 "oauth-sign": {
                   "version": "0.8.1",
                   "from": "oauth-sign@~0.8.0",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
                 },
-                "pinkie": {
-                  "version": "2.0.4",
-                  "from": "pinkie@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                },
-                "qs": {
-                  "version": "6.0.2",
-                  "from": "qs@~6.0.2",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz"
-                },
-                "pinkie-promise": {
-                  "version": "2.0.0",
-                  "from": "pinkie-promise@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
+                "once": {
+                  "version": "1.3.3",
+                  "from": "once@~1.3.3",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
                   "from": "process-nextick-args@~1.0.6",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
-                "request": {
-                  "version": "2.69.0",
-                  "from": "request@2.x",
-                  "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz"
+                "pinkie-promise": {
+                  "version": "2.0.0",
+                  "from": "pinkie-promise@^2.0.0",
+                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
+                },
+                "qs": {
+                  "version": "6.0.2",
+                  "from": "qs@~6.0.2",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz"
                 },
                 "readable-stream": {
                   "version": "2.0.6",
                   "from": "readable-stream@^2.0.0 || ^1.1.13",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
                 },
+                "request": {
+                  "version": "2.69.0",
+                  "from": "request@2.x",
+                  "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz"
+                },
                 "semver": {
                   "version": "5.1.0",
                   "from": "semver@~5.1.0",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+                },
+                "sshpk": {
+                  "version": "1.7.4",
+                  "from": "sshpk@^1.7.0",
+                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
                   "from": "sntp@1.x.x",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 },
-                "sshpk": {
-                  "version": "1.7.4",
-                  "from": "sshpk@^1.7.0",
-                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz"
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.5",
@@ -11241,20 +11246,15 @@
                   "from": "strip-ansi@^3.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
                 },
-                "supports-color": {
-                  "version": "2.0.0",
-                  "from": "supports-color@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@~0.10.x",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
                 "strip-json-comments": {
                   "version": "1.0.4",
                   "from": "strip-json-comments@~1.0.4",
                   "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "from": "supports-color@^2.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 },
                 "tar": {
                   "version": "2.2.1",
@@ -11266,45 +11266,45 @@
                   "from": "tar-pack@~3.1.0",
                   "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.3.tgz"
                 },
-                "tunnel-agent": {
-                  "version": "0.4.2",
-                  "from": "tunnel-agent@~0.4.1",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
-                },
-                "uid-number": {
-                  "version": "0.0.6",
-                  "from": "uid-number@~0.0.6",
-                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
-                },
                 "tough-cookie": {
                   "version": "2.2.2",
                   "from": "tough-cookie@~2.2.0",
                   "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.2",
+                  "from": "tunnel-agent@~0.4.1",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
                 },
                 "tweetnacl": {
                   "version": "0.14.3",
                   "from": "tweetnacl@>=0.13.0 <1.0.0",
                   "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
                 },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "from": "util-deprecate@~1.0.1",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                "uid-number": {
+                  "version": "0.0.6",
+                  "from": "uid-number@~0.0.6",
+                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
                 },
                 "verror": {
                   "version": "1.3.6",
                   "from": "verror@1.3.6",
                   "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                 },
-                "wrappy": {
-                  "version": "1.0.1",
-                  "from": "wrappy@1",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "from": "util-deprecate@~1.0.1",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 },
                 "xtend": {
                   "version": "4.0.1",
                   "from": "xtend@^4.0.0",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                },
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@1",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 },
                 "dashdash": {
                   "version": "1.13.0",
@@ -11463,137 +11463,137 @@
         },
         "colors": {
           "version": "1.1.2",
-          "from": "colors@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
           "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
         },
         "connect": {
           "version": "3.4.1",
-          "from": "connect@>=3.3.5 <4.0.0",
+          "from": "https://registry.npmjs.org/connect/-/connect-3.4.1.tgz",
           "resolved": "https://registry.npmjs.org/connect/-/connect-3.4.1.tgz",
           "dependencies": {
             "debug": {
               "version": "2.2.0",
-              "from": "debug@>=2.2.0 <3.0.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
-                  "from": "ms@0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
             },
             "finalhandler": {
               "version": "0.4.1",
-              "from": "finalhandler@0.4.1",
+              "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
               "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
               "dependencies": {
                 "escape-html": {
                   "version": "1.0.3",
-                  "from": "escape-html@>=1.0.3 <1.1.0",
+                  "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
                 },
                 "on-finished": {
                   "version": "2.3.0",
-                  "from": "on-finished@>=2.3.0 <2.4.0",
+                  "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
                   "dependencies": {
                     "ee-first": {
                       "version": "1.1.1",
-                      "from": "ee-first@1.1.1",
+                      "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
                     }
                   }
                 },
                 "unpipe": {
                   "version": "1.0.0",
-                  "from": "unpipe@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
                 }
               }
             },
             "parseurl": {
               "version": "1.3.1",
-              "from": "parseurl@>=1.3.1 <1.4.0",
+              "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
             },
             "utils-merge": {
               "version": "1.0.0",
-              "from": "utils-merge@1.0.0",
+              "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
             }
           }
         },
         "core-js": {
           "version": "2.3.0",
-          "from": "core-js@>=2.1.0 <3.0.0",
+          "from": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz"
         },
         "di": {
           "version": "0.0.1",
-          "from": "di@>=0.0.1 <0.0.2",
+          "from": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz"
         },
         "dom-serialize": {
           "version": "2.2.1",
-          "from": "dom-serialize@>=2.2.0 <3.0.0",
+          "from": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
           "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
           "dependencies": {
             "custom-event": {
               "version": "1.0.0",
-              "from": "custom-event@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.0.tgz"
             },
             "ent": {
               "version": "2.2.0",
-              "from": "ent@>=2.2.0 <2.3.0",
+              "from": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz"
             },
             "extend": {
               "version": "3.0.0",
-              "from": "extend@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
             },
             "void-elements": {
               "version": "2.0.1",
-              "from": "void-elements@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz"
             }
           }
         },
         "expand-braces": {
           "version": "0.1.2",
-          "from": "expand-braces@>=0.1.1 <0.2.0",
+          "from": "https://registry.npmjs.org/expand-braces/-/expand-braces-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/expand-braces/-/expand-braces-0.1.2.tgz",
           "dependencies": {
             "array-slice": {
               "version": "0.2.3",
-              "from": "array-slice@>=0.2.3 <0.3.0",
+              "from": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
               "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
             },
             "array-unique": {
               "version": "0.2.1",
-              "from": "array-unique@>=0.2.1 <0.3.0",
+              "from": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
               "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
             },
             "braces": {
               "version": "0.1.5",
-              "from": "braces@>=0.1.2 <0.2.0",
+              "from": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz",
               "resolved": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz",
               "dependencies": {
                 "expand-range": {
                   "version": "0.1.1",
-                  "from": "expand-range@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
                   "dependencies": {
                     "is-number": {
                       "version": "0.1.1",
-                      "from": "is-number@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/is-number/-/is-number-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/is-number/-/is-number-0.1.1.tgz"
                     },
                     "repeat-string": {
                       "version": "0.2.2",
-                      "from": "repeat-string@>=0.2.2 <0.3.0",
+                      "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-0.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-0.2.2.tgz"
                     }
                   }
@@ -11604,139 +11604,139 @@
         },
         "glob": {
           "version": "7.0.3",
-          "from": "glob@>=7.0.0 <8.0.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "inflight@>=1.0.4 <2.0.0",
+              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "once": {
               "version": "1.3.3",
-              "from": "once@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             }
           }
         },
         "graceful-fs": {
           "version": "4.1.3",
-          "from": "graceful-fs@>=4.1.2 <5.0.0",
+          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
         },
         "http-proxy": {
           "version": "1.13.2",
-          "from": "http-proxy@>=1.13.0 <2.0.0",
+          "from": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.13.2.tgz",
           "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.13.2.tgz",
           "dependencies": {
             "eventemitter3": {
               "version": "1.2.0",
-              "from": "eventemitter3@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz"
             },
             "requires-port": {
               "version": "1.0.0",
-              "from": "requires-port@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
             }
           }
         },
         "isbinaryfile": {
           "version": "3.0.0",
-          "from": "isbinaryfile@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.0.tgz"
         },
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.8.0 <4.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "log4js": {
           "version": "0.6.35",
-          "from": "log4js@>=0.6.31 <0.7.0",
+          "from": "https://registry.npmjs.org/log4js/-/log4js-0.6.35.tgz",
           "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.35.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.34",
-              "from": "readable-stream@>=1.0.2 <1.1.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "semver": {
               "version": "4.3.6",
-              "from": "semver@>=4.3.3 <4.4.0",
+              "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
               "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
             }
           }
         },
         "mime": {
           "version": "1.3.4",
-          "from": "mime@>=1.3.4 <2.0.0",
+          "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
         },
         "minimatch": {
           "version": "3.0.0",
-          "from": "minimatch@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.3",
-              "from": "brace-expansion@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
               "dependencies": {
                 "balanced-match": {
                   "version": "0.3.0",
-                  "from": "balanced-match@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                 },
                 "concat-map": {
                   "version": "0.0.1",
-                  "from": "concat-map@0.0.1",
+                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                 }
               }
@@ -11745,122 +11745,122 @@
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "optimist@>=0.6.1 <0.7.0",
+          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.3",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@>=0.0.1 <0.1.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         },
         "rimraf": {
           "version": "2.5.2",
-          "from": "rimraf@>=2.3.3 <3.0.0",
+          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz"
         },
         "socket.io": {
           "version": "1.4.5",
-          "from": "socket.io@>=1.4.5 <2.0.0",
+          "from": "https://registry.npmjs.org/socket.io/-/socket.io-1.4.5.tgz",
           "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.4.5.tgz",
           "dependencies": {
             "engine.io": {
               "version": "1.6.8",
-              "from": "engine.io@1.6.8",
+              "from": "https://registry.npmjs.org/engine.io/-/engine.io-1.6.8.tgz",
               "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.6.8.tgz",
               "dependencies": {
                 "base64id": {
                   "version": "0.1.0",
-                  "from": "base64id@0.1.0",
+                  "from": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
                 },
                 "ws": {
                   "version": "1.0.1",
-                  "from": "ws@1.0.1",
+                  "from": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz",
                   "dependencies": {
                     "options": {
                       "version": "0.0.6",
-                      "from": "options@>=0.0.5",
+                      "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
                     },
                     "ultron": {
                       "version": "1.0.2",
-                      "from": "ultron@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
                     }
                   }
                 },
                 "engine.io-parser": {
                   "version": "1.2.4",
-                  "from": "engine.io-parser@1.2.4",
+                  "from": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
                   "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
                   "dependencies": {
                     "after": {
                       "version": "0.8.1",
-                      "from": "after@0.8.1",
+                      "from": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
                       "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
                     },
                     "arraybuffer.slice": {
                       "version": "0.0.6",
-                      "from": "arraybuffer.slice@0.0.6",
+                      "from": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
                     },
                     "base64-arraybuffer": {
                       "version": "0.1.2",
-                      "from": "base64-arraybuffer@0.1.2",
+                      "from": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
                     },
                     "blob": {
                       "version": "0.0.4",
-                      "from": "blob@0.0.4",
+                      "from": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz"
                     },
                     "has-binary": {
                       "version": "0.1.6",
-                      "from": "has-binary@0.1.6",
+                      "from": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
                       "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
                       "dependencies": {
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         }
                       }
                     },
                     "utf8": {
                       "version": "2.1.0",
-                      "from": "utf8@2.1.0",
+                      "from": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz"
                     }
                   }
                 },
                 "accepts": {
                   "version": "1.1.4",
-                  "from": "accepts@1.1.4",
+                  "from": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
                   "dependencies": {
                     "mime-types": {
                       "version": "2.0.14",
-                      "from": "mime-types@>=2.0.4 <2.1.0",
+                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.12.0",
-                          "from": "mime-db@>=1.12.0 <1.13.0",
+                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                         }
                       }
                     },
                     "negotiator": {
                       "version": "0.4.9",
-                      "from": "negotiator@0.4.9",
+                      "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
                       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
                     }
                   }
@@ -11869,130 +11869,130 @@
             },
             "socket.io-parser": {
               "version": "2.2.6",
-              "from": "socket.io-parser@2.2.6",
+              "from": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.6.tgz",
               "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.6.tgz",
               "dependencies": {
                 "json3": {
                   "version": "3.3.2",
-                  "from": "json3@3.3.2",
+                  "from": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
                   "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
                 },
                 "component-emitter": {
                   "version": "1.1.2",
-                  "from": "component-emitter@1.1.2",
+                  "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "benchmark": {
                   "version": "1.0.0",
-                  "from": "benchmark@1.0.0",
+                  "from": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
                 }
               }
             },
             "socket.io-client": {
               "version": "1.4.5",
-              "from": "socket.io-client@1.4.5",
+              "from": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.4.5.tgz",
               "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.4.5.tgz",
               "dependencies": {
                 "engine.io-client": {
                   "version": "1.6.8",
-                  "from": "engine.io-client@1.6.8",
+                  "from": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.6.8.tgz",
                   "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.6.8.tgz",
                   "dependencies": {
                     "has-cors": {
                       "version": "1.1.0",
-                      "from": "has-cors@1.1.0",
+                      "from": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz"
                     },
                     "ws": {
                       "version": "1.0.1",
-                      "from": "ws@1.0.1",
+                      "from": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz",
                       "dependencies": {
                         "options": {
                           "version": "0.0.6",
-                          "from": "options@>=0.0.5",
+                          "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
                           "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
                         },
                         "ultron": {
                           "version": "1.0.2",
-                          "from": "ultron@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
                         }
                       }
                     },
                     "xmlhttprequest-ssl": {
                       "version": "1.5.1",
-                      "from": "xmlhttprequest-ssl@1.5.1",
+                      "from": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz",
                       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz"
                     },
                     "component-emitter": {
                       "version": "1.1.2",
-                      "from": "component-emitter@1.1.2",
+                      "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
                     },
                     "engine.io-parser": {
                       "version": "1.2.4",
-                      "from": "engine.io-parser@1.2.4",
+                      "from": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
                       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
                       "dependencies": {
                         "after": {
                           "version": "0.8.1",
-                          "from": "after@0.8.1",
+                          "from": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
                           "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
                         },
                         "arraybuffer.slice": {
                           "version": "0.0.6",
-                          "from": "arraybuffer.slice@0.0.6",
+                          "from": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
                           "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
                         },
                         "base64-arraybuffer": {
                           "version": "0.1.2",
-                          "from": "base64-arraybuffer@0.1.2",
+                          "from": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
                         },
                         "blob": {
                           "version": "0.0.4",
-                          "from": "blob@0.0.4",
+                          "from": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz"
                         },
                         "has-binary": {
                           "version": "0.1.6",
-                          "from": "has-binary@0.1.6",
+                          "from": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
                           "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
                           "dependencies": {
                             "isarray": {
                               "version": "0.0.1",
-                              "from": "isarray@0.0.1",
+                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                             }
                           }
                         },
                         "utf8": {
                           "version": "2.1.0",
-                          "from": "utf8@2.1.0",
+                          "from": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz"
                         }
                       }
                     },
                     "parsejson": {
                       "version": "0.0.1",
-                      "from": "parsejson@0.0.1",
+                      "from": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
                       "dependencies": {
                         "better-assert": {
                           "version": "1.0.2",
-                          "from": "better-assert@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                           "dependencies": {
                             "callsite": {
                               "version": "1.0.0",
-                              "from": "callsite@1.0.0",
+                              "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
                             }
                           }
@@ -12001,17 +12001,17 @@
                     },
                     "parseqs": {
                       "version": "0.0.2",
-                      "from": "parseqs@0.0.2",
+                      "from": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
                       "dependencies": {
                         "better-assert": {
                           "version": "1.0.2",
-                          "from": "better-assert@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                           "dependencies": {
                             "callsite": {
                               "version": "1.0.0",
-                              "from": "callsite@1.0.0",
+                              "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
                             }
                           }
@@ -12020,49 +12020,49 @@
                     },
                     "component-inherit": {
                       "version": "0.0.3",
-                      "from": "component-inherit@0.0.3",
+                      "from": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz"
                     },
                     "yeast": {
                       "version": "0.1.2",
-                      "from": "yeast@0.1.2",
+                      "from": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz"
                     }
                   }
                 },
                 "component-bind": {
                   "version": "1.0.0",
-                  "from": "component-bind@1.0.0",
+                  "from": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz"
                 },
                 "component-emitter": {
                   "version": "1.2.0",
-                  "from": "component-emitter@1.2.0",
+                  "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz"
                 },
                 "object-component": {
                   "version": "0.0.3",
-                  "from": "object-component@0.0.3",
+                  "from": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz"
                 },
                 "indexof": {
                   "version": "0.0.1",
-                  "from": "indexof@0.0.1",
+                  "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
                 },
                 "parseuri": {
                   "version": "0.0.4",
-                  "from": "parseuri@0.0.4",
+                  "from": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
                   "dependencies": {
                     "better-assert": {
                       "version": "1.0.2",
-                      "from": "better-assert@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                       "dependencies": {
                         "callsite": {
                           "version": "1.0.0",
-                          "from": "callsite@1.0.0",
+                          "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
                         }
                       }
@@ -12071,49 +12071,49 @@
                 },
                 "to-array": {
                   "version": "0.1.4",
-                  "from": "to-array@0.1.4",
+                  "from": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz"
                 },
                 "backo2": {
                   "version": "1.0.2",
-                  "from": "backo2@1.0.2",
+                  "from": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz"
                 }
               }
             },
             "socket.io-adapter": {
               "version": "0.4.0",
-              "from": "socket.io-adapter@0.4.0",
+              "from": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.4.0.tgz",
               "dependencies": {
                 "socket.io-parser": {
                   "version": "2.2.2",
-                  "from": "socket.io-parser@2.2.2",
+                  "from": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
                   "dependencies": {
                     "debug": {
                       "version": "0.7.4",
-                      "from": "debug@0.7.4",
+                      "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
                     },
                     "json3": {
                       "version": "3.2.6",
-                      "from": "json3@3.2.6",
+                      "from": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz",
                       "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
                     },
                     "component-emitter": {
                       "version": "1.1.2",
-                      "from": "component-emitter@1.1.2",
+                      "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "benchmark": {
                       "version": "1.0.0",
-                      "from": "benchmark@1.0.0",
+                      "from": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
                     }
                   }
@@ -12122,24 +12122,24 @@
             },
             "has-binary": {
               "version": "0.1.7",
-              "from": "has-binary@0.1.7",
+              "from": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
               "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
               "dependencies": {
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 }
               }
             },
             "debug": {
               "version": "2.2.0",
-              "from": "debug@2.2.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
-                  "from": "ms@0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
@@ -12148,17 +12148,17 @@
         },
         "source-map": {
           "version": "0.5.5",
-          "from": "source-map@>=0.5.3 <0.6.0",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.5.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.5.tgz"
         },
         "useragent": {
           "version": "2.1.9",
-          "from": "useragent@>=2.1.6 <3.0.0",
+          "from": "https://registry.npmjs.org/useragent/-/useragent-2.1.9.tgz",
           "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.9.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.2.4",
-              "from": "lru-cache@>=2.2.0 <2.3.0",
+              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz"
             }
           }
@@ -12167,41 +12167,41 @@
     },
     "karma-chrome-launcher": {
       "version": "0.2.3",
-      "from": "karma-chrome-launcher@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-0.2.3.tgz",
       "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-0.2.3.tgz",
       "dependencies": {
         "fs-access": {
           "version": "1.0.0",
-          "from": "fs-access@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.0.tgz",
           "dependencies": {
             "null-check": {
               "version": "1.0.0",
-              "from": "null-check@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz"
             }
           }
         },
         "which": {
           "version": "1.2.4",
-          "from": "which@>=1.2.1 <2.0.0",
+          "from": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
           "resolved": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
           "dependencies": {
             "is-absolute": {
               "version": "0.1.7",
-              "from": "is-absolute@>=0.1.7 <0.2.0",
+              "from": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
               "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
               "dependencies": {
                 "is-relative": {
                   "version": "0.1.3",
-                  "from": "is-relative@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
                 }
               }
             },
             "isexe": {
               "version": "1.1.2",
-              "from": "isexe@>=1.1.1 <2.0.0",
+              "from": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
             }
           }
@@ -12210,186 +12210,186 @@
     },
     "karma-jasmine": {
       "version": "0.2.3",
-      "from": "karma-jasmine@>=0.2.2 <0.3.0",
+      "from": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.2.3.tgz",
       "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.2.3.tgz"
     },
     "karma-jasmine-matchers": {
       "version": "0.1.3",
-      "from": "karma-jasmine-matchers@>=0.1.3 <0.2.0",
+      "from": "https://registry.npmjs.org/karma-jasmine-matchers/-/karma-jasmine-matchers-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/karma-jasmine-matchers/-/karma-jasmine-matchers-0.1.3.tgz",
       "dependencies": {
         "jasmine-expect": {
           "version": "1.22.3",
-          "from": "jasmine-expect@>=1.21.0 <2.0.0",
+          "from": "https://registry.npmjs.org/jasmine-expect/-/jasmine-expect-1.22.3.tgz",
           "resolved": "https://registry.npmjs.org/jasmine-expect/-/jasmine-expect-1.22.3.tgz"
         }
       }
     },
     "karma-phantomjs-shim": {
       "version": "1.3.0",
-      "from": "karma-phantomjs-shim@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/karma-phantomjs-shim/-/karma-phantomjs-shim-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/karma-phantomjs-shim/-/karma-phantomjs-shim-1.3.0.tgz"
     },
     "karma-phantomjs2-launcher": {
       "version": "0.3.2",
-      "from": "karma-phantomjs2-launcher@>=0.3.2 <0.4.0",
+      "from": "https://registry.npmjs.org/karma-phantomjs2-launcher/-/karma-phantomjs2-launcher-0.3.2.tgz",
       "resolved": "https://registry.npmjs.org/karma-phantomjs2-launcher/-/karma-phantomjs2-launcher-0.3.2.tgz",
       "dependencies": {
         "lodash": {
           "version": "3.9.3",
-          "from": "lodash@>=3.9.3 <3.10.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
         },
         "phantomjs2-ext": {
           "version": "0.1.0",
-          "from": "phantomjs2-ext@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/phantomjs2-ext/-/phantomjs2-ext-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/phantomjs2-ext/-/phantomjs2-ext-0.1.0.tgz",
           "dependencies": {
             "adm-zip": {
               "version": "0.4.7",
-              "from": "adm-zip@0.4.7",
+              "from": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
               "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz"
             },
             "kew": {
               "version": "0.5.0",
-              "from": "kew@0.5.0",
+              "from": "https://registry.npmjs.org/kew/-/kew-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/kew/-/kew-0.5.0.tgz"
             },
             "ncp": {
               "version": "2.0.0",
-              "from": "ncp@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz"
             },
             "npmconf": {
               "version": "2.1.1",
-              "from": "npmconf@2.1.1",
+              "from": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.1.tgz",
               "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.1.tgz",
               "dependencies": {
                 "config-chain": {
                   "version": "1.1.10",
-                  "from": "config-chain@>=1.1.8 <1.2.0",
+                  "from": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz",
                   "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz",
                   "dependencies": {
                     "proto-list": {
                       "version": "1.2.4",
-                      "from": "proto-list@>=1.2.1 <1.3.0",
+                      "from": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
                       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "ini": {
                   "version": "1.3.4",
-                  "from": "ini@>=1.2.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
                   "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                 },
                 "nopt": {
                   "version": "3.0.6",
-                  "from": "nopt@>=3.0.1 <3.1.0",
+                  "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
                   "dependencies": {
                     "abbrev": {
                       "version": "1.0.7",
-                      "from": "abbrev@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                     }
                   }
                 },
                 "once": {
                   "version": "1.3.3",
-                  "from": "once@>=1.3.0 <1.4.0",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "osenv": {
                   "version": "0.1.3",
-                  "from": "osenv@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
                   "dependencies": {
                     "os-homedir": {
                       "version": "1.0.1",
-                      "from": "os-homedir@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                     },
                     "os-tmpdir": {
                       "version": "1.0.1",
-                      "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                     }
                   }
                 },
                 "semver": {
                   "version": "4.3.6",
-                  "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
+                  "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
                 },
                 "uid-number": {
                   "version": "0.0.5",
-                  "from": "uid-number@0.0.5",
+                  "from": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
                 }
               }
             },
             "mkdirp": {
               "version": "0.5.0",
-              "from": "mkdirp@0.5.0",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "minimist@0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "progress": {
               "version": "1.1.8",
-              "from": "progress@1.1.8",
+              "from": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
               "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
             },
             "request": {
               "version": "2.55.0",
-              "from": "request@2.55.0",
+              "from": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
               "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
               "dependencies": {
                 "bl": {
                   "version": "0.9.5",
-                  "from": "bl@>=0.9.0 <0.10.0",
+                  "from": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.34",
-                      "from": "readable-stream@>=1.0.26 <1.1.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -12398,242 +12398,242 @@
                 },
                 "caseless": {
                   "version": "0.9.0",
-                  "from": "caseless@>=0.9.0 <0.10.0",
+                  "from": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.6.1",
-                  "from": "forever-agent@>=0.6.0 <0.7.0",
+                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                 },
                 "form-data": {
                   "version": "0.2.0",
-                  "from": "form-data@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.9.2",
-                      "from": "async@>=0.9.0 <0.10.0",
+                      "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                     }
                   }
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "mime-types": {
                   "version": "2.0.14",
-                  "from": "mime-types@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.12.0",
-                      "from": "mime-db@>=1.12.0 <1.13.0",
+                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                     }
                   }
                 },
                 "node-uuid": {
                   "version": "1.4.7",
-                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
                 },
                 "qs": {
                   "version": "2.4.2",
-                  "from": "qs@>=2.4.0 <2.5.0",
+                  "from": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.2",
-                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
                 },
                 "tough-cookie": {
                   "version": "2.2.2",
-                  "from": "tough-cookie@>=0.12.0",
+                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
                 },
                 "http-signature": {
                   "version": "0.10.1",
-                  "from": "http-signature@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.1.5",
-                      "from": "assert-plus@>=0.1.5 <0.2.0",
+                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                     },
                     "asn1": {
                       "version": "0.1.11",
-                      "from": "asn1@0.1.11",
+                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
                       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                     },
                     "ctype": {
                       "version": "0.5.3",
-                      "from": "ctype@0.5.3",
+                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
                       "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                     }
                   }
                 },
                 "oauth-sign": {
                   "version": "0.6.0",
-                  "from": "oauth-sign@>=0.6.0 <0.7.0",
+                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
                 },
                 "hawk": {
                   "version": "2.3.1",
-                  "from": "hawk@>=2.3.0 <2.4.0",
+                  "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "2.16.3",
-                      "from": "hoek@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                     },
                     "boom": {
                       "version": "2.10.1",
-                      "from": "boom@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                     },
                     "cryptiles": {
                       "version": "2.0.5",
-                      "from": "cryptiles@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                     },
                     "sntp": {
                       "version": "1.0.9",
-                      "from": "sntp@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                     }
                   }
                 },
                 "aws-sign2": {
                   "version": "0.5.0",
-                  "from": "aws-sign2@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.5",
-                  "from": "stringstream@>=0.0.4 <0.1.0",
+                  "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                 },
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "combined-stream@>=0.0.5 <0.1.0",
+                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "0.0.5",
-                      "from": "delayed-stream@0.0.5",
+                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                     }
                   }
                 },
                 "isstream": {
                   "version": "0.1.2",
-                  "from": "isstream@>=0.1.1 <0.2.0",
+                  "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                 },
                 "har-validator": {
                   "version": "1.8.0",
-                  "from": "har-validator@>=1.4.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
                   "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
                   "dependencies": {
                     "bluebird": {
                       "version": "2.10.2",
-                      "from": "bluebird@>=2.9.30 <3.0.0",
+                      "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
                       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
                     },
                     "chalk": {
                       "version": "1.1.3",
-                      "from": "chalk@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                       "dependencies": {
                         "ansi-styles": {
                           "version": "2.2.1",
-                          "from": "ansi-styles@>=2.2.1 <3.0.0",
+                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                         },
                         "escape-string-regexp": {
                           "version": "1.0.5",
-                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                         },
                         "has-ansi": {
                           "version": "2.0.0",
-                          "from": "has-ansi@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                             }
                           }
                         },
                         "strip-ansi": {
                           "version": "3.0.1",
-                          "from": "strip-ansi@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                             }
                           }
                         },
                         "supports-color": {
                           "version": "2.0.0",
-                          "from": "supports-color@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                         }
                       }
                     },
                     "commander": {
                       "version": "2.9.0",
-                      "from": "commander@>=2.8.1 <3.0.0",
+                      "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                       "dependencies": {
                         "graceful-readlink": {
                           "version": "1.0.1",
-                          "from": "graceful-readlink@>=1.0.0",
+                          "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                         }
                       }
                     },
                     "is-my-json-valid": {
                       "version": "2.13.1",
-                      "from": "is-my-json-valid@>=2.12.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
                       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
                       "dependencies": {
                         "generate-function": {
                           "version": "2.0.0",
-                          "from": "generate-function@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                         },
                         "generate-object-property": {
                           "version": "1.2.0",
-                          "from": "generate-object-property@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                           "dependencies": {
                             "is-property": {
                               "version": "1.0.2",
-                              "from": "is-property@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                             }
                           }
                         },
                         "jsonpointer": {
                           "version": "2.0.0",
-                          "from": "jsonpointer@2.0.0",
+                          "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                         },
                         "xtend": {
                           "version": "4.0.1",
-                          "from": "xtend@>=4.0.0 <5.0.0",
+                          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                         }
                       }
@@ -12644,61 +12644,61 @@
             },
             "request-progress": {
               "version": "0.3.1",
-              "from": "request-progress@0.3.1",
+              "from": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
               "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
               "dependencies": {
                 "throttleit": {
                   "version": "0.0.2",
-                  "from": "throttleit@>=0.0.2 <0.1.0",
+                  "from": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
                 }
               }
             },
             "rimraf": {
               "version": "2.3.4",
-              "from": "rimraf@>=2.3.2 <2.4.0",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.4.tgz",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.4.tgz",
               "dependencies": {
                 "glob": {
                   "version": "4.5.3",
-                  "from": "glob@>=4.4.2 <5.0.0",
+                  "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "2.0.10",
-                      "from": "minimatch@>=2.0.1 <3.0.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.3",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.3.0",
-                              "from": "balanced-match@>=0.3.0 <0.4.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
@@ -12707,12 +12707,12 @@
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -12723,7 +12723,7 @@
             },
             "which": {
               "version": "1.0.9",
-              "from": "which@>=1.0.9 <1.1.0",
+              "from": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
               "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
             }
           }
@@ -12732,80 +12732,287 @@
     },
     "karma-sinon": {
       "version": "1.0.4",
-      "from": "karma-sinon@>=1.0.4 <2.0.0",
+      "from": "https://registry.npmjs.org/karma-sinon/-/karma-sinon-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/karma-sinon/-/karma-sinon-1.0.4.tgz"
     },
     "karma-sourcemap-loader": {
       "version": "0.3.7",
-      "from": "karma-sourcemap-loader@>=0.3.5 <0.4.0",
+      "from": "https://registry.npmjs.org/karma-sourcemap-loader/-/karma-sourcemap-loader-0.3.7.tgz",
       "resolved": "https://registry.npmjs.org/karma-sourcemap-loader/-/karma-sourcemap-loader-0.3.7.tgz",
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.3",
-          "from": "graceful-fs@>=4.1.2 <5.0.0",
+          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
         }
       }
     },
     "karma-webpack": {
       "version": "1.7.0",
-      "from": "karma-webpack@>=1.7.0 <2.0.0",
+      "from": "https://registry.npmjs.org/karma-webpack/-/karma-webpack-1.7.0.tgz",
       "resolved": "https://registry.npmjs.org/karma-webpack/-/karma-webpack-1.7.0.tgz",
       "dependencies": {
         "async": {
           "version": "0.9.2",
-          "from": "async@>=0.9.0 <0.10.0",
+          "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
         },
         "loader-utils": {
           "version": "0.2.14",
-          "from": "loader-utils@>=0.2.7 <0.3.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.14.tgz",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.14.tgz",
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.1.3 <4.0.0",
+              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "emojis-list": {
               "version": "1.0.1",
-              "from": "emojis-list@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.1.tgz"
             },
             "json5": {
               "version": "0.5.0",
-              "from": "json5@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz"
             },
             "object-assign": {
               "version": "4.0.1",
-              "from": "object-assign@>=4.0.1 <5.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
             }
           }
         },
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.8.0 <4.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "source-map": {
           "version": "0.1.43",
-          "from": "source-map@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "dependencies": {
             "amdefine": {
               "version": "1.0.0",
-              "from": "amdefine@>=0.0.4",
+              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
             }
           }
         },
         "webpack-dev-middleware": {
           "version": "1.6.1",
-          "from": "webpack-dev-middleware@>=1.0.11 <2.0.0",
+          "from": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.6.1.tgz",
           "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.6.1.tgz",
           "dependencies": {
+            "memory-fs": {
+              "version": "0.3.0",
+              "from": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
+              "dependencies": {
+                "errno": {
+                  "version": "0.1.4",
+                  "from": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+                  "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+                  "dependencies": {
+                    "prr": {
+                      "version": "0.0.0",
+                      "from": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "2.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.0.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "inline-process-browser": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inline-process-browser/-/inline-process-browser-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inline-process-browser/-/inline-process-browser-2.0.1.tgz",
+                      "dependencies": {
+                        "falafel": {
+                          "version": "1.2.0",
+                          "from": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
+                          "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
+                          "dependencies": {
+                            "acorn": {
+                              "version": "1.2.2",
+                              "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+                              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+                            },
+                            "foreach": {
+                              "version": "2.0.5",
+                              "from": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+                              "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "object-keys": {
+                              "version": "1.0.9",
+                              "from": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz",
+                              "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz"
+                            }
+                          }
+                        },
+                        "through2": {
+                          "version": "0.6.5",
+                          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                          "dependencies": {
+                            "readable-stream": {
+                              "version": "1.0.34",
+                              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                              "dependencies": {
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                }
+                              }
+                            },
+                            "xtend": {
+                              "version": "4.0.1",
+                              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.6",
+                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "unreachable-branch-transform": {
+                      "version": "0.5.1",
+                      "from": "https://registry.npmjs.org/unreachable-branch-transform/-/unreachable-branch-transform-0.5.1.tgz",
+                      "resolved": "https://registry.npmjs.org/unreachable-branch-transform/-/unreachable-branch-transform-0.5.1.tgz",
+                      "dependencies": {
+                        "esmangle-evaluator": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.0.tgz"
+                        },
+                        "recast": {
+                          "version": "0.11.5",
+                          "from": "https://registry.npmjs.org/recast/-/recast-0.11.5.tgz",
+                          "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.5.tgz",
+                          "dependencies": {
+                            "ast-types": {
+                              "version": "0.8.16",
+                              "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.16.tgz",
+                              "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.16.tgz"
+                            },
+                            "esprima": {
+                              "version": "2.7.2",
+                              "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
+                              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+                            },
+                            "private": {
+                              "version": "0.1.6",
+                              "from": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
+                              "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+                            },
+                            "source-map": {
+                              "version": "0.5.5",
+                              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.5.tgz",
+                              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.5.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "mime": {
+              "version": "1.3.4",
+              "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+            },
+            "range-parser": {
+              "version": "1.0.3",
+              "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
+            }
+          }
+        },
+        "webpack": {
+          "version": "1.13.1",
+          "from": "webpack@>=1.0.0 <2.0.0||>=2.1.0-beta <3.0.0",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.13.1.tgz",
+          "dependencies": {
+            "async": {
+              "version": "1.5.2",
+              "from": "async@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+            },
+            "clone": {
+              "version": "1.0.2",
+              "from": "clone@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+            },
+            "enhanced-resolve": {
+              "version": "0.9.1",
+              "from": "enhanced-resolve@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
+              "dependencies": {
+                "memory-fs": {
+                  "version": "0.2.0",
+                  "from": "memory-fs@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
+                },
+                "graceful-fs": {
+                  "version": "4.1.4",
+                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
+                }
+              }
+            },
+            "acorn": {
+              "version": "3.2.0",
+              "from": "acorn@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.2.0.tgz"
+            },
+            "interpret": {
+              "version": "0.6.6",
+              "from": "interpret@>=0.6.4 <0.7.0",
+              "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz"
+            },
             "memory-fs": {
               "version": "0.3.0",
               "from": "memory-fs@>=0.3.0 <0.4.0",
@@ -12824,10 +13031,15 @@
                   }
                 },
                 "readable-stream": {
-                  "version": "2.1.0",
+                  "version": "2.1.4",
                   "from": "readable-stream@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
                   "dependencies": {
+                    "buffer-shims": {
+                      "version": "1.0.0",
+                      "from": "buffer-shims@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                    },
                     "core-util-is": {
                       "version": "1.0.2",
                       "from": "core-util-is@>=1.0.0 <1.1.0",
@@ -12835,66 +13047,8 @@
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "inherits@>=2.0.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "inline-process-browser": {
-                      "version": "2.0.1",
-                      "from": "inline-process-browser@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inline-process-browser/-/inline-process-browser-2.0.1.tgz",
-                      "dependencies": {
-                        "falafel": {
-                          "version": "1.2.0",
-                          "from": "falafel@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
-                          "dependencies": {
-                            "acorn": {
-                              "version": "1.2.2",
-                              "from": "acorn@>=1.0.3 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
-                            },
-                            "foreach": {
-                              "version": "2.0.5",
-                              "from": "foreach@>=2.0.5 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
-                            },
-                            "isarray": {
-                              "version": "0.0.1",
-                              "from": "isarray@0.0.1",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                            },
-                            "object-keys": {
-                              "version": "1.0.9",
-                              "from": "object-keys@>=1.0.6 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz"
-                            }
-                          }
-                        },
-                        "through2": {
-                          "version": "0.6.5",
-                          "from": "through2@>=0.6.5 <0.7.0",
-                          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                          "dependencies": {
-                            "readable-stream": {
-                              "version": "1.0.34",
-                              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                              "dependencies": {
-                                "isarray": {
-                                  "version": "0.0.1",
-                                  "from": "isarray@0.0.1",
-                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                                }
-                              }
-                            },
-                            "xtend": {
-                              "version": "4.0.1",
-                              "from": "xtend@>=4.0.0 <4.1.0-0",
-                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
                     },
                     "isarray": {
                       "version": "1.0.0",
@@ -12902,53 +13056,14 @@
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                     },
                     "process-nextick-args": {
-                      "version": "1.0.6",
+                      "version": "1.0.7",
                       "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
                       "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "unreachable-branch-transform": {
-                      "version": "0.5.1",
-                      "from": "unreachable-branch-transform@>=0.5.0 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/unreachable-branch-transform/-/unreachable-branch-transform-0.5.1.tgz",
-                      "dependencies": {
-                        "esmangle-evaluator": {
-                          "version": "1.0.0",
-                          "from": "esmangle-evaluator@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.0.tgz"
-                        },
-                        "recast": {
-                          "version": "0.11.5",
-                          "from": "recast@>=0.11.4 <0.12.0",
-                          "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.5.tgz",
-                          "dependencies": {
-                            "ast-types": {
-                              "version": "0.8.16",
-                              "from": "ast-types@0.8.16",
-                              "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.16.tgz"
-                            },
-                            "esprima": {
-                              "version": "2.7.2",
-                              "from": "esprima@>=2.7.1 <2.8.0",
-                              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
-                            },
-                            "private": {
-                              "version": "0.1.6",
-                              "from": "private@>=0.1.5 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
-                            },
-                            "source-map": {
-                              "version": "0.5.5",
-                              "from": "source-map@>=0.5.0 <0.6.0",
-                              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.5.tgz"
-                            }
-                          }
-                        }
-                      }
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
@@ -12959,15 +13074,1172 @@
                 }
               }
             },
-            "mime": {
-              "version": "1.3.4",
-              "from": "mime@>=1.3.4 <2.0.0",
-              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
             },
-            "range-parser": {
-              "version": "1.0.3",
-              "from": "range-parser@>=1.0.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
+            "optimist": {
+              "version": "0.6.1",
+              "from": "optimist@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                },
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "minimist@>=0.0.1 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "3.1.2",
+              "from": "supports-color@>=3.1.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+              "dependencies": {
+                "has-flag": {
+                  "version": "1.0.0",
+                  "from": "has-flag@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+                }
+              }
+            },
+            "tapable": {
+              "version": "0.1.10",
+              "from": "tapable@>=0.1.8 <0.2.0",
+              "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz"
+            },
+            "uglify-js": {
+              "version": "2.6.3",
+              "from": "uglify-js@>=2.6.0 <2.7.0",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.3.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@>=0.2.6 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "source-map": {
+                  "version": "0.5.6",
+                  "from": "source-map@>=0.5.1 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+                },
+                "uglify-to-browserify": {
+                  "version": "1.0.2",
+                  "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+                },
+                "yargs": {
+                  "version": "3.10.0",
+                  "from": "yargs@>=3.10.0 <3.11.0",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.2.1",
+                      "from": "camelcase@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                    },
+                    "cliui": {
+                      "version": "2.1.0",
+                      "from": "cliui@>=2.1.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                      "dependencies": {
+                        "center-align": {
+                          "version": "0.1.3",
+                          "from": "center-align@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                          "dependencies": {
+                            "align-text": {
+                              "version": "0.1.4",
+                              "from": "align-text@>=0.1.3 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                              "dependencies": {
+                                "kind-of": {
+                                  "version": "3.0.3",
+                                  "from": "kind-of@>=3.0.2 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz",
+                                  "dependencies": {
+                                    "is-buffer": {
+                                      "version": "1.1.3",
+                                      "from": "is-buffer@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
+                                    }
+                                  }
+                                },
+                                "longest": {
+                                  "version": "1.0.1",
+                                  "from": "longest@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                },
+                                "repeat-string": {
+                                  "version": "1.5.4",
+                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
+                                }
+                              }
+                            },
+                            "lazy-cache": {
+                              "version": "1.0.4",
+                              "from": "lazy-cache@>=1.0.3 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+                            }
+                          }
+                        },
+                        "right-align": {
+                          "version": "0.1.3",
+                          "from": "right-align@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                          "dependencies": {
+                            "align-text": {
+                              "version": "0.1.4",
+                              "from": "align-text@>=0.1.3 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                              "dependencies": {
+                                "kind-of": {
+                                  "version": "3.0.3",
+                                  "from": "kind-of@>=3.0.2 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz",
+                                  "dependencies": {
+                                    "is-buffer": {
+                                      "version": "1.1.3",
+                                      "from": "is-buffer@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
+                                    }
+                                  }
+                                },
+                                "longest": {
+                                  "version": "1.0.1",
+                                  "from": "longest@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                },
+                                "repeat-string": {
+                                  "version": "1.5.4",
+                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "wordwrap": {
+                          "version": "0.0.2",
+                          "from": "wordwrap@0.0.2",
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                        }
+                      }
+                    },
+                    "decamelize": {
+                      "version": "1.2.0",
+                      "from": "decamelize@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+                    },
+                    "window-size": {
+                      "version": "0.1.0",
+                      "from": "window-size@0.1.0",
+                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "watchpack": {
+              "version": "0.2.9",
+              "from": "watchpack@>=0.2.1 <0.3.0",
+              "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.9.2",
+                  "from": "async@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                },
+                "chokidar": {
+                  "version": "1.5.2",
+                  "from": "chokidar@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.5.2.tgz",
+                  "dependencies": {
+                    "anymatch": {
+                      "version": "1.3.0",
+                      "from": "anymatch@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+                      "dependencies": {
+                        "arrify": {
+                          "version": "1.0.1",
+                          "from": "arrify@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+                        },
+                        "micromatch": {
+                          "version": "2.3.8",
+                          "from": "micromatch@>=2.1.5 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.8.tgz",
+                          "dependencies": {
+                            "arr-diff": {
+                              "version": "2.0.0",
+                              "from": "arr-diff@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                              "dependencies": {
+                                "arr-flatten": {
+                                  "version": "1.0.1",
+                                  "from": "arr-flatten@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "array-unique": {
+                              "version": "0.2.1",
+                              "from": "array-unique@>=0.2.1 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+                            },
+                            "braces": {
+                              "version": "1.8.5",
+                              "from": "braces@>=1.8.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+                              "dependencies": {
+                                "expand-range": {
+                                  "version": "1.8.2",
+                                  "from": "expand-range@>=1.8.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+                                  "dependencies": {
+                                    "fill-range": {
+                                      "version": "2.2.3",
+                                      "from": "fill-range@>=2.1.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+                                      "dependencies": {
+                                        "is-number": {
+                                          "version": "2.1.0",
+                                          "from": "is-number@>=2.1.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
+                                        },
+                                        "isobject": {
+                                          "version": "2.1.0",
+                                          "from": "isobject@>=2.0.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                                          "dependencies": {
+                                            "isarray": {
+                                              "version": "1.0.0",
+                                              "from": "isarray@1.0.0",
+                                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                                            }
+                                          }
+                                        },
+                                        "randomatic": {
+                                          "version": "1.1.5",
+                                          "from": "randomatic@>=1.1.3 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
+                                        },
+                                        "repeat-string": {
+                                          "version": "1.5.4",
+                                          "from": "repeat-string@>=1.5.2 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "preserve": {
+                                  "version": "0.2.0",
+                                  "from": "preserve@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+                                },
+                                "repeat-element": {
+                                  "version": "1.1.2",
+                                  "from": "repeat-element@>=1.1.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+                                }
+                              }
+                            },
+                            "expand-brackets": {
+                              "version": "0.1.5",
+                              "from": "expand-brackets@>=0.1.4 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                              "dependencies": {
+                                "is-posix-bracket": {
+                                  "version": "0.1.1",
+                                  "from": "is-posix-bracket@>=0.1.0 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+                                }
+                              }
+                            },
+                            "extglob": {
+                              "version": "0.3.2",
+                              "from": "extglob@>=0.3.1 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
+                            },
+                            "filename-regex": {
+                              "version": "2.0.0",
+                              "from": "filename-regex@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+                            },
+                            "is-extglob": {
+                              "version": "1.0.0",
+                              "from": "is-extglob@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                            },
+                            "kind-of": {
+                              "version": "3.0.3",
+                              "from": "kind-of@>=3.0.2 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz",
+                              "dependencies": {
+                                "is-buffer": {
+                                  "version": "1.1.3",
+                                  "from": "is-buffer@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
+                                }
+                              }
+                            },
+                            "normalize-path": {
+                              "version": "2.0.1",
+                              "from": "normalize-path@>=2.0.1 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
+                            },
+                            "object.omit": {
+                              "version": "2.0.0",
+                              "from": "object.omit@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
+                              "dependencies": {
+                                "for-own": {
+                                  "version": "0.1.4",
+                                  "from": "for-own@>=0.1.3 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
+                                  "dependencies": {
+                                    "for-in": {
+                                      "version": "0.1.5",
+                                      "from": "for-in@>=0.1.5 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz"
+                                    }
+                                  }
+                                },
+                                "is-extendable": {
+                                  "version": "0.1.1",
+                                  "from": "is-extendable@>=0.1.1 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+                                }
+                              }
+                            },
+                            "parse-glob": {
+                              "version": "3.0.4",
+                              "from": "parse-glob@>=3.0.4 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                              "dependencies": {
+                                "glob-base": {
+                                  "version": "0.3.0",
+                                  "from": "glob-base@>=0.3.0 <0.4.0",
+                                  "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
+                                },
+                                "is-dotfile": {
+                                  "version": "1.0.2",
+                                  "from": "is-dotfile@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
+                                }
+                              }
+                            },
+                            "regex-cache": {
+                              "version": "0.4.3",
+                              "from": "regex-cache@>=0.4.2 <0.5.0",
+                              "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+                              "dependencies": {
+                                "is-equal-shallow": {
+                                  "version": "0.1.3",
+                                  "from": "is-equal-shallow@>=0.1.3 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+                                },
+                                "is-primitive": {
+                                  "version": "2.0.0",
+                                  "from": "is-primitive@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "async-each": {
+                      "version": "1.0.0",
+                      "from": "async-each@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.0.tgz"
+                    },
+                    "glob-parent": {
+                      "version": "2.0.0",
+                      "from": "glob-parent@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "is-binary-path": {
+                      "version": "1.0.1",
+                      "from": "is-binary-path@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+                      "dependencies": {
+                        "binary-extensions": {
+                          "version": "1.4.1",
+                          "from": "binary-extensions@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.1.tgz"
+                        }
+                      }
+                    },
+                    "is-glob": {
+                      "version": "2.0.1",
+                      "from": "is-glob@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                      "dependencies": {
+                        "is-extglob": {
+                          "version": "1.0.0",
+                          "from": "is-extglob@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    },
+                    "readdirp": {
+                      "version": "2.0.0",
+                      "from": "readdirp@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
+                      "dependencies": {
+                        "minimatch": {
+                          "version": "2.0.10",
+                          "from": "minimatch@>=2.0.10 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.5",
+                              "from": "brace-expansion@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.4.1",
+                                  "from": "balanced-match@>=0.4.1 <0.5.0",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "concat-map@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "readable-stream": {
+                          "version": "2.1.4",
+                          "from": "readable-stream@>=2.0.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
+                          "dependencies": {
+                            "buffer-shims": {
+                              "version": "1.0.0",
+                              "from": "buffer-shims@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                            },
+                            "core-util-is": {
+                              "version": "1.0.2",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                            },
+                            "isarray": {
+                              "version": "1.0.0",
+                              "from": "isarray@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                            },
+                            "process-nextick-args": {
+                              "version": "1.0.7",
+                              "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            },
+                            "util-deprecate": {
+                              "version": "1.0.2",
+                              "from": "util-deprecate@>=1.0.1 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "fsevents": {
+                      "version": "1.0.12",
+                      "from": "fsevents@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.12.tgz",
+                      "dependencies": {
+                        "nan": {
+                          "version": "2.3.5",
+                          "from": "nan@>=2.3.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz"
+                        },
+                        "node-pre-gyp": {
+                          "version": "0.6.25",
+                          "from": "node-pre-gyp@0.6.25",
+                          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.25.tgz",
+                          "dependencies": {
+                            "nopt": {
+                              "version": "3.0.6",
+                              "from": "nopt@~3.0.1",
+                              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+                              "dependencies": {
+                                "abbrev": {
+                                  "version": "1.0.7",
+                                  "from": "abbrev@1",
+                                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "ansi": {
+                          "version": "0.3.1",
+                          "from": "ansi@~0.3.1",
+                          "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz"
+                        },
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "from": "ansi-regex@^2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                        },
+                        "are-we-there-yet": {
+                          "version": "1.1.2",
+                          "from": "are-we-there-yet@~1.1.2",
+                          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz"
+                        },
+                        "ansi-styles": {
+                          "version": "2.2.1",
+                          "from": "ansi-styles@^2.2.1",
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                        },
+                        "asn1": {
+                          "version": "0.2.3",
+                          "from": "asn1@>=0.2.3 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                        },
+                        "assert-plus": {
+                          "version": "0.2.0",
+                          "from": "assert-plus@^0.2.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                        },
+                        "async": {
+                          "version": "1.5.2",
+                          "from": "async@^1.5.2",
+                          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+                        },
+                        "bl": {
+                          "version": "1.0.3",
+                          "from": "bl@~1.0.0",
+                          "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz"
+                        },
+                        "aws-sign2": {
+                          "version": "0.6.0",
+                          "from": "aws-sign2@~0.6.0",
+                          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+                        },
+                        "boom": {
+                          "version": "2.10.1",
+                          "from": "boom@2.x.x",
+                          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                        },
+                        "block-stream": {
+                          "version": "0.0.8",
+                          "from": "block-stream@*",
+                          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
+                        },
+                        "caseless": {
+                          "version": "0.11.0",
+                          "from": "caseless@~0.11.0",
+                          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+                        },
+                        "commander": {
+                          "version": "2.9.0",
+                          "from": "commander@^2.9.0",
+                          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+                        },
+                        "chalk": {
+                          "version": "1.1.3",
+                          "from": "chalk@^1.1.1",
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+                        },
+                        "combined-stream": {
+                          "version": "1.0.5",
+                          "from": "combined-stream@~1.0.5",
+                          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+                        },
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                        },
+                        "cryptiles": {
+                          "version": "2.0.5",
+                          "from": "cryptiles@2.x.x",
+                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                        },
+                        "debug": {
+                          "version": "2.2.0",
+                          "from": "debug@~2.2.0",
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+                        },
+                        "deep-extend": {
+                          "version": "0.4.1",
+                          "from": "deep-extend@~0.4.0",
+                          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
+                        },
+                        "delayed-stream": {
+                          "version": "1.0.0",
+                          "from": "delayed-stream@~1.0.0",
+                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.5",
+                          "from": "escape-string-regexp@^1.0.2",
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                        },
+                        "delegates": {
+                          "version": "1.0.0",
+                          "from": "delegates@^1.0.0",
+                          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
+                        },
+                        "ecc-jsbn": {
+                          "version": "0.1.1",
+                          "from": "ecc-jsbn@>=0.0.1 <1.0.0",
+                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                        },
+                        "extsprintf": {
+                          "version": "1.0.2",
+                          "from": "extsprintf@1.0.2",
+                          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                        },
+                        "extend": {
+                          "version": "3.0.0",
+                          "from": "extend@~3.0.0",
+                          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+                        },
+                        "forever-agent": {
+                          "version": "0.6.1",
+                          "from": "forever-agent@~0.6.1",
+                          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                        },
+                        "fstream": {
+                          "version": "1.0.8",
+                          "from": "fstream@^1.0.2",
+                          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
+                        },
+                        "form-data": {
+                          "version": "1.0.0-rc4",
+                          "from": "form-data@~1.0.0-rc3",
+                          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz"
+                        },
+                        "gauge": {
+                          "version": "1.2.7",
+                          "from": "gauge@~1.2.5",
+                          "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz"
+                        },
+                        "generate-object-property": {
+                          "version": "1.2.0",
+                          "from": "generate-object-property@^1.1.0",
+                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+                        },
+                        "generate-function": {
+                          "version": "2.0.0",
+                          "from": "generate-function@^2.0.0",
+                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                        },
+                        "graceful-fs": {
+                          "version": "4.1.3",
+                          "from": "graceful-fs@^4.1.2",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                        },
+                        "har-validator": {
+                          "version": "2.0.6",
+                          "from": "har-validator@~2.0.6",
+                          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
+                        },
+                        "graceful-readlink": {
+                          "version": "1.0.1",
+                          "from": "graceful-readlink@>= 1.0.0",
+                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                        },
+                        "has-ansi": {
+                          "version": "2.0.0",
+                          "from": "has-ansi@^2.0.0",
+                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+                        },
+                        "hawk": {
+                          "version": "3.1.3",
+                          "from": "hawk@~3.1.0",
+                          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
+                        },
+                        "hoek": {
+                          "version": "2.16.3",
+                          "from": "hoek@2.x.x",
+                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                        },
+                        "has-unicode": {
+                          "version": "2.0.0",
+                          "from": "has-unicode@^2.0.0",
+                          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz"
+                        },
+                        "ini": {
+                          "version": "1.3.4",
+                          "from": "ini@~1.3.0",
+                          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                        },
+                        "http-signature": {
+                          "version": "1.1.1",
+                          "from": "http-signature@~1.1.0",
+                          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@*",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "is-my-json-valid": {
+                          "version": "2.13.1",
+                          "from": "is-my-json-valid@^2.12.4",
+                          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz"
+                        },
+                        "jsbn": {
+                          "version": "0.1.0",
+                          "from": "jsbn@>=0.1.0 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                        },
+                        "is-property": {
+                          "version": "1.0.2",
+                          "from": "is-property@^1.0.0",
+                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                        },
+                        "is-typedarray": {
+                          "version": "1.0.0",
+                          "from": "is-typedarray@~1.0.0",
+                          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+                        },
+                        "isstream": {
+                          "version": "0.1.2",
+                          "from": "isstream@~0.1.2",
+                          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                        },
+                        "isarray": {
+                          "version": "1.0.0",
+                          "from": "isarray@~1.0.0",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                        },
+                        "jodid25519": {
+                          "version": "1.0.2",
+                          "from": "jodid25519@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                        },
+                        "json-schema": {
+                          "version": "0.2.2",
+                          "from": "json-schema@0.2.2",
+                          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+                        },
+                        "json-stringify-safe": {
+                          "version": "5.0.1",
+                          "from": "json-stringify-safe@~5.0.1",
+                          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                        },
+                        "jsonpointer": {
+                          "version": "2.0.0",
+                          "from": "jsonpointer@2.0.0",
+                          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                        },
+                        "jsprim": {
+                          "version": "1.2.2",
+                          "from": "jsprim@^1.2.2",
+                          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
+                        },
+                        "lodash.pad": {
+                          "version": "4.1.0",
+                          "from": "lodash.pad@^4.1.0",
+                          "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.1.0.tgz"
+                        },
+                        "lodash.padend": {
+                          "version": "4.2.0",
+                          "from": "lodash.padend@^4.1.0",
+                          "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.2.0.tgz"
+                        },
+                        "lodash.padstart": {
+                          "version": "4.2.0",
+                          "from": "lodash.padstart@^4.1.0",
+                          "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.2.0.tgz"
+                        },
+                        "lodash.repeat": {
+                          "version": "4.0.0",
+                          "from": "lodash.repeat@^4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.0.0.tgz"
+                        },
+                        "mime-db": {
+                          "version": "1.22.0",
+                          "from": "mime-db@~1.22.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
+                        },
+                        "mime-types": {
+                          "version": "2.1.10",
+                          "from": "mime-types@~2.1.7",
+                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz"
+                        },
+                        "lodash.tostring": {
+                          "version": "4.1.2",
+                          "from": "lodash.tostring@^4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.2.tgz"
+                        },
+                        "minimist": {
+                          "version": "0.0.8",
+                          "from": "minimist@0.0.8",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                        },
+                        "mkdirp": {
+                          "version": "0.5.1",
+                          "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
+                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+                        },
+                        "ms": {
+                          "version": "0.7.1",
+                          "from": "ms@0.7.1",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                        },
+                        "npmlog": {
+                          "version": "2.0.3",
+                          "from": "npmlog@~2.0.0",
+                          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.3.tgz"
+                        },
+                        "node-uuid": {
+                          "version": "1.4.7",
+                          "from": "node-uuid@~1.4.7",
+                          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+                        },
+                        "oauth-sign": {
+                          "version": "0.8.1",
+                          "from": "oauth-sign@~0.8.0",
+                          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
+                        },
+                        "once": {
+                          "version": "1.3.3",
+                          "from": "once@~1.3.3",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+                        },
+                        "pinkie": {
+                          "version": "2.0.4",
+                          "from": "pinkie@^2.0.0",
+                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                        },
+                        "pinkie-promise": {
+                          "version": "2.0.0",
+                          "from": "pinkie-promise@^2.0.0",
+                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.6",
+                          "from": "process-nextick-args@~1.0.6",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                        },
+                        "qs": {
+                          "version": "6.0.2",
+                          "from": "qs@~6.0.2",
+                          "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz"
+                        },
+                        "readable-stream": {
+                          "version": "2.0.6",
+                          "from": "readable-stream@^2.0.0 || ^1.1.13",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
+                        },
+                        "request": {
+                          "version": "2.69.0",
+                          "from": "request@2.x",
+                          "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz"
+                        },
+                        "semver": {
+                          "version": "5.1.0",
+                          "from": "semver@~5.1.0",
+                          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+                        },
+                        "sshpk": {
+                          "version": "1.7.4",
+                          "from": "sshpk@^1.7.0",
+                          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz"
+                        },
+                        "sntp": {
+                          "version": "1.0.9",
+                          "from": "sntp@1.x.x",
+                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "from": "strip-ansi@^3.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+                        },
+                        "strip-json-comments": {
+                          "version": "1.0.4",
+                          "from": "strip-json-comments@~1.0.4",
+                          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+                        },
+                        "supports-color": {
+                          "version": "2.0.0",
+                          "from": "supports-color@^2.0.0",
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                        },
+                        "stringstream": {
+                          "version": "0.0.5",
+                          "from": "stringstream@~0.0.4",
+                          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                        },
+                        "tar": {
+                          "version": "2.2.1",
+                          "from": "tar@~2.2.0",
+                          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
+                        },
+                        "tar-pack": {
+                          "version": "3.1.3",
+                          "from": "tar-pack@~3.1.0",
+                          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.3.tgz"
+                        },
+                        "tunnel-agent": {
+                          "version": "0.4.2",
+                          "from": "tunnel-agent@~0.4.1",
+                          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
+                        },
+                        "tough-cookie": {
+                          "version": "2.2.2",
+                          "from": "tough-cookie@~2.2.0",
+                          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
+                        },
+                        "tweetnacl": {
+                          "version": "0.14.3",
+                          "from": "tweetnacl@>=0.13.0 <1.0.0",
+                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
+                        },
+                        "uid-number": {
+                          "version": "0.0.6",
+                          "from": "uid-number@~0.0.6",
+                          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "from": "util-deprecate@~1.0.1",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                        },
+                        "verror": {
+                          "version": "1.3.6",
+                          "from": "verror@1.3.6",
+                          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                        },
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@1",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        },
+                        "xtend": {
+                          "version": "4.0.1",
+                          "from": "xtend@^4.0.0",
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                        },
+                        "dashdash": {
+                          "version": "1.13.0",
+                          "from": "dashdash@>=1.10.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz",
+                          "dependencies": {
+                            "assert-plus": {
+                              "version": "1.0.0",
+                              "from": "assert-plus@^1.0.0",
+                              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "rc": {
+                          "version": "1.1.6",
+                          "from": "rc@~1.1.0",
+                          "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "1.2.0",
+                              "from": "minimist@^1.2.0",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                            }
+                          }
+                        },
+                        "aws4": {
+                          "version": "1.3.2",
+                          "from": "aws4@^1.2.1",
+                          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.3.2.tgz",
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "4.0.1",
+                              "from": "lru-cache@^4.0.0",
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
+                              "dependencies": {
+                                "pseudomap": {
+                                  "version": "1.0.2",
+                                  "from": "pseudomap@^1.0.1",
+                                  "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
+                                },
+                                "yallist": {
+                                  "version": "2.0.0",
+                                  "from": "yallist@^2.0.0",
+                                  "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "fstream-ignore": {
+                          "version": "1.0.3",
+                          "from": "fstream-ignore@~1.0.3",
+                          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.3.tgz",
+                          "dependencies": {
+                            "minimatch": {
+                              "version": "3.0.0",
+                              "from": "minimatch@^3.0.0",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                              "dependencies": {
+                                "brace-expansion": {
+                                  "version": "1.1.3",
+                                  "from": "brace-expansion@^1.0.0",
+                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                                  "dependencies": {
+                                    "balanced-match": {
+                                      "version": "0.3.0",
+                                      "from": "balanced-match@^0.3.0",
+                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                    },
+                                    "concat-map": {
+                                      "version": "0.0.1",
+                                      "from": "concat-map@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "rimraf": {
+                          "version": "2.5.2",
+                          "from": "rimraf@~2.5.0",
+                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                          "dependencies": {
+                            "glob": {
+                              "version": "7.0.3",
+                              "from": "glob@^7.0.0",
+                              "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                              "dependencies": {
+                                "inflight": {
+                                  "version": "1.0.4",
+                                  "from": "inflight@^1.0.4",
+                                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1",
+                                      "from": "wrappy@1",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@2",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                },
+                                "minimatch": {
+                                  "version": "3.0.0",
+                                  "from": "minimatch@2 || 3",
+                                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                                  "dependencies": {
+                                    "brace-expansion": {
+                                      "version": "1.1.3",
+                                      "from": "brace-expansion@^1.0.0",
+                                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                                      "dependencies": {
+                                        "balanced-match": {
+                                          "version": "0.3.0",
+                                          "from": "balanced-match@^0.3.0",
+                                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                        },
+                                        "concat-map": {
+                                          "version": "0.0.1",
+                                          "from": "concat-map@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "once": {
+                                  "version": "1.3.3",
+                                  "from": "once@^1.3.0",
+                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1",
+                                      "from": "wrappy@1",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "path-is-absolute": {
+                                  "version": "1.0.0",
+                                  "from": "path-is-absolute@^1.0.0",
+                                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "4.1.4",
+                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
+                }
+              }
+            },
+            "webpack-core": {
+              "version": "0.6.8",
+              "from": "webpack-core@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.8.tgz",
+              "dependencies": {
+                "source-map": {
+                  "version": "0.4.4",
+                  "from": "source-map@>=0.4.1 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                    }
+                  }
+                },
+                "source-list-map": {
+                  "version": "0.1.6",
+                  "from": "source-list-map@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.6.tgz"
+                }
+              }
             }
           }
         }
@@ -12992,225 +14264,225 @@
     },
     "node-libs-browser": {
       "version": "0.5.3",
-      "from": "node-libs-browser@>=0.5.2 <0.6.0",
+      "from": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.3.tgz",
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.3.tgz",
       "dependencies": {
         "assert": {
           "version": "1.3.0",
-          "from": "assert@>=1.1.1 <2.0.0",
+          "from": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
           "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
         },
         "browserify-zlib": {
           "version": "0.1.4",
-          "from": "browserify-zlib@>=0.1.4 <0.2.0",
+          "from": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
           "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
           "dependencies": {
             "pako": {
               "version": "0.2.8",
-              "from": "pako@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz",
               "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
             }
           }
         },
         "buffer": {
           "version": "3.6.0",
-          "from": "buffer@>=3.0.3 <4.0.0",
+          "from": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
           "dependencies": {
             "base64-js": {
               "version": "0.0.8",
-              "from": "base64-js@0.0.8",
+              "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
               "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
             },
             "ieee754": {
               "version": "1.1.6",
-              "from": "ieee754@>=1.1.4 <2.0.0",
+              "from": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz",
               "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
             },
             "isarray": {
               "version": "1.0.0",
-              "from": "isarray@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
             }
           }
         },
         "console-browserify": {
           "version": "1.1.0",
-          "from": "console-browserify@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "dependencies": {
             "date-now": {
               "version": "0.1.4",
-              "from": "date-now@>=0.1.4 <0.2.0",
+              "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
               "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
             }
           }
         },
         "constants-browserify": {
           "version": "0.0.1",
-          "from": "constants-browserify@0.0.1",
+          "from": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
         },
         "crypto-browserify": {
           "version": "3.2.8",
-          "from": "crypto-browserify@>=3.2.6 <3.3.0",
+          "from": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz",
           "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz",
           "dependencies": {
             "pbkdf2-compat": {
               "version": "2.0.1",
-              "from": "pbkdf2-compat@2.0.1",
+              "from": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz"
             },
             "ripemd160": {
               "version": "0.2.0",
-              "from": "ripemd160@0.2.0",
+              "from": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz"
             },
             "sha.js": {
               "version": "2.2.6",
-              "from": "sha.js@2.2.6",
+              "from": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz",
               "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
             }
           }
         },
         "domain-browser": {
           "version": "1.1.7",
-          "from": "domain-browser@>=1.1.1 <2.0.0",
+          "from": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
           "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
         },
         "http-browserify": {
           "version": "1.7.0",
-          "from": "http-browserify@>=1.3.2 <2.0.0",
+          "from": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
           "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
           "dependencies": {
             "Base64": {
               "version": "0.2.1",
-              "from": "Base64@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
               "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "https-browserify": {
           "version": "0.0.0",
-          "from": "https-browserify@0.0.0",
+          "from": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
         },
         "os-browserify": {
           "version": "0.1.2",
-          "from": "os-browserify@>=0.1.2 <0.2.0",
+          "from": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
         },
         "path-browserify": {
           "version": "0.0.0",
-          "from": "path-browserify@0.0.0",
+          "from": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
         },
         "process": {
           "version": "0.11.2",
-          "from": "process@>=0.11.0 <0.12.0",
+          "from": "https://registry.npmjs.org/process/-/process-0.11.2.tgz",
           "resolved": "https://registry.npmjs.org/process/-/process-0.11.2.tgz"
         },
         "punycode": {
           "version": "1.4.1",
-          "from": "punycode@>=1.2.4 <2.0.0",
+          "from": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
         },
         "querystring-es3": {
           "version": "0.2.1",
-          "from": "querystring-es3@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
           "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
         },
         "readable-stream": {
           "version": "1.1.14",
-          "from": "readable-stream@>=1.1.13 <2.0.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.2",
-              "from": "core-util-is@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
             },
             "isarray": {
               "version": "0.0.1",
-              "from": "isarray@0.0.1",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "stream-browserify": {
           "version": "1.0.0",
-          "from": "stream-browserify@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "string_decoder@>=0.10.25 <0.11.0",
+          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
         },
         "timers-browserify": {
           "version": "1.4.2",
-          "from": "timers-browserify@>=1.0.1 <2.0.0",
+          "from": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
           "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz"
         },
         "tty-browserify": {
           "version": "0.0.0",
-          "from": "tty-browserify@0.0.0",
+          "from": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
         },
         "url": {
           "version": "0.10.3",
-          "from": "url@>=0.10.1 <0.11.0",
+          "from": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
           "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
           "dependencies": {
             "punycode": {
               "version": "1.3.2",
-              "from": "punycode@1.3.2",
+              "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
             },
             "querystring": {
               "version": "0.2.0",
-              "from": "querystring@0.2.0",
+              "from": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
             }
           }
         },
         "util": {
           "version": "0.10.3",
-          "from": "util@>=0.10.3 <0.11.0",
+          "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "vm-browserify": {
           "version": "0.0.4",
-          "from": "vm-browserify@0.0.4",
+          "from": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
           "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
           "dependencies": {
             "indexof": {
               "version": "0.0.1",
-              "from": "indexof@0.0.1",
+              "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
             }
           }
@@ -14964,61 +16236,61 @@
     },
     "postcss-loader": {
       "version": "0.8.2",
-      "from": "postcss-loader@>=0.8.0 <0.9.0",
+      "from": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-0.8.2.tgz",
       "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-0.8.2.tgz",
       "dependencies": {
         "loader-utils": {
           "version": "0.2.14",
-          "from": "loader-utils@>=0.2.7 <0.3.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.14.tgz",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.14.tgz",
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.1.3 <4.0.0",
+              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "emojis-list": {
               "version": "1.0.1",
-              "from": "emojis-list@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.1.tgz"
             },
             "json5": {
               "version": "0.5.0",
-              "from": "json5@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz"
             },
             "object-assign": {
               "version": "4.0.1",
-              "from": "object-assign@>=4.0.1 <5.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
             }
           }
         },
         "postcss": {
           "version": "5.0.19",
-          "from": "postcss@>=5.0.19 <6.0.0",
+          "from": "https://registry.npmjs.org/postcss/-/postcss-5.0.19.tgz",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.19.tgz",
           "dependencies": {
             "supports-color": {
               "version": "3.1.2",
-              "from": "supports-color@>=3.1.2 <4.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
               "dependencies": {
                 "has-flag": {
                   "version": "1.0.0",
-                  "from": "has-flag@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
                 }
               }
             },
             "source-map": {
               "version": "0.5.5",
-              "from": "source-map@>=0.5.1 <0.6.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.5.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.5.tgz"
             },
             "js-base64": {
               "version": "2.1.9",
-              "from": "js-base64@>=2.1.9 <3.0.0",
+              "from": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
               "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
             }
           }
@@ -15126,22 +16398,22 @@
     },
     "react-hot-loader": {
       "version": "1.3.0",
-      "from": "react-hot-loader@>=1.2.7 <2.0.0",
+      "from": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-1.3.0.tgz",
       "dependencies": {
         "react-hot-api": {
           "version": "0.4.7",
-          "from": "react-hot-api@>=0.4.5 <0.5.0",
+          "from": "https://registry.npmjs.org/react-hot-api/-/react-hot-api-0.4.7.tgz",
           "resolved": "https://registry.npmjs.org/react-hot-api/-/react-hot-api-0.4.7.tgz"
         },
         "source-map": {
           "version": "0.4.4",
-          "from": "source-map@>=0.4.4 <0.5.0",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "dependencies": {
             "amdefine": {
               "version": "1.0.0",
-              "from": "amdefine@>=0.0.4",
+              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
             }
           }
@@ -15150,7 +16422,7 @@
     },
     "react-jasmine-matchers": {
       "version": "2.0.0",
-      "from": "react-jasmine-matchers@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/react-jasmine-matchers/-/react-jasmine-matchers-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/react-jasmine-matchers/-/react-jasmine-matchers-2.0.0.tgz"
     },
     "reactable": {
@@ -15160,46 +16432,46 @@
     },
     "sass-loader": {
       "version": "3.2.0",
-      "from": "sass-loader@>=3.2.0 <4.0.0",
+      "from": "https://registry.npmjs.org/sass-loader/-/sass-loader-3.2.0.tgz",
       "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-3.2.0.tgz",
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "from": "async@>=1.2.1 <2.0.0",
+          "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         },
         "loader-utils": {
           "version": "0.2.14",
-          "from": "loader-utils@>=0.2.11 <0.3.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.14.tgz",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.14.tgz",
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.1.3 <4.0.0",
+              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "emojis-list": {
               "version": "1.0.1",
-              "from": "emojis-list@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.1.tgz"
             },
             "json5": {
               "version": "0.5.0",
-              "from": "json5@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz"
             }
           }
         },
         "object-assign": {
           "version": "4.0.1",
-          "from": "object-assign@>=4.0.1 <5.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
         }
       }
     },
     "scss-loader": {
       "version": "0.0.1",
-      "from": "scss-loader@0.0.1",
+      "from": "https://registry.npmjs.org/scss-loader/-/scss-loader-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/scss-loader/-/scss-loader-0.0.1.tgz"
     },
     "sinon": {
@@ -15236,34 +16508,285 @@
         }
       }
     },
+    "smocks": {
+      "version": "4.0.6",
+      "from": "https://registry.npmjs.org/smocks/-/smocks-4.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/smocks/-/smocks-4.0.6.tgz",
+      "dependencies": {
+        "hapi": {
+          "version": "8.8.1",
+          "from": "https://registry.npmjs.org/hapi/-/hapi-8.8.1.tgz",
+          "resolved": "https://registry.npmjs.org/hapi/-/hapi-8.8.1.tgz",
+          "dependencies": {
+            "accept": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/accept/-/accept-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/accept/-/accept-1.0.0.tgz"
+            },
+            "ammo": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/ammo/-/ammo-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/ammo/-/ammo-1.0.0.tgz"
+            },
+            "boom": {
+              "version": "2.7.2",
+              "from": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz"
+            },
+            "call": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/call/-/call-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/call/-/call-2.0.1.tgz"
+            },
+            "catbox": {
+              "version": "4.3.0",
+              "from": "https://registry.npmjs.org/catbox/-/catbox-4.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/catbox/-/catbox-4.3.0.tgz"
+            },
+            "catbox-memory": {
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-1.1.1.tgz"
+            },
+            "cryptiles": {
+              "version": "2.0.4",
+              "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
+            },
+            "h2o2": {
+              "version": "4.0.1",
+              "from": "https://registry.npmjs.org/h2o2/-/h2o2-4.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/h2o2/-/h2o2-4.0.1.tgz",
+              "dependencies": {
+                "wreck": {
+                  "version": "5.6.1",
+                  "from": "https://registry.npmjs.org/wreck/-/wreck-5.6.1.tgz",
+                  "resolved": "https://registry.npmjs.org/wreck/-/wreck-5.6.1.tgz"
+                }
+              }
+            },
+            "heavy": {
+              "version": "3.0.0",
+              "from": "https://registry.npmjs.org/heavy/-/heavy-3.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/heavy/-/heavy-3.0.0.tgz",
+              "dependencies": {
+                "joi": {
+                  "version": "5.1.0",
+                  "from": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
+                  "dependencies": {
+                    "isemail": {
+                      "version": "1.2.0",
+                      "from": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "hoek": {
+              "version": "2.14.0",
+              "from": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
+            },
+            "inert": {
+              "version": "2.1.6",
+              "from": "https://registry.npmjs.org/inert/-/inert-2.1.6.tgz",
+              "resolved": "https://registry.npmjs.org/inert/-/inert-2.1.6.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.6.5",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                }
+              }
+            },
+            "iron": {
+              "version": "2.1.2",
+              "from": "https://registry.npmjs.org/iron/-/iron-2.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/iron/-/iron-2.1.2.tgz"
+            },
+            "items": {
+              "version": "1.1.0",
+              "from": "https://registry.npmjs.org/items/-/items-1.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/items/-/items-1.1.0.tgz"
+            },
+            "joi": {
+              "version": "6.4.1",
+              "from": "https://registry.npmjs.org/joi/-/joi-6.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/joi/-/joi-6.4.1.tgz",
+              "dependencies": {
+                "isemail": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
+                },
+                "moment": {
+                  "version": "2.10.3",
+                  "from": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz",
+                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz"
+                }
+              }
+            },
+            "kilt": {
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/kilt/-/kilt-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/kilt/-/kilt-1.1.1.tgz"
+            },
+            "mimos": {
+              "version": "2.0.2",
+              "from": "https://registry.npmjs.org/mimos/-/mimos-2.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/mimos/-/mimos-2.0.2.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.14.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.14.0.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.14.0.tgz"
+                }
+              }
+            },
+            "peekaboo": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/peekaboo/-/peekaboo-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/peekaboo/-/peekaboo-1.0.0.tgz"
+            },
+            "qs": {
+              "version": "4.0.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
+            },
+            "shot": {
+              "version": "1.5.3",
+              "from": "https://registry.npmjs.org/shot/-/shot-1.5.3.tgz",
+              "resolved": "https://registry.npmjs.org/shot/-/shot-1.5.3.tgz"
+            },
+            "statehood": {
+              "version": "2.1.1",
+              "from": "https://registry.npmjs.org/statehood/-/statehood-2.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/statehood/-/statehood-2.1.1.tgz"
+            },
+            "subtext": {
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/subtext/-/subtext-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/subtext/-/subtext-1.1.1.tgz",
+              "dependencies": {
+                "content": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/content/-/content-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/content/-/content-1.0.1.tgz"
+                },
+                "pez": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/pez/-/pez-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/pez/-/pez-1.0.0.tgz",
+                  "dependencies": {
+                    "b64": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/b64/-/b64-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/b64/-/b64-2.0.0.tgz"
+                    },
+                    "nigel": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/nigel/-/nigel-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/nigel/-/nigel-1.0.1.tgz",
+                      "dependencies": {
+                        "vise": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/vise/-/vise-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/vise/-/vise-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "topo": {
+              "version": "1.0.3",
+              "from": "https://registry.npmjs.org/topo/-/topo-1.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.3.tgz"
+            },
+            "vision": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/vision/-/vision-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/vision/-/vision-2.0.1.tgz"
+            },
+            "wreck": {
+              "version": "6.0.0",
+              "from": "https://registry.npmjs.org/wreck/-/wreck-6.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/wreck/-/wreck-6.0.0.tgz"
+            }
+          }
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+        },
+        "mime-types": {
+          "version": "2.1.11",
+          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+          "dependencies": {
+            "mime-db": {
+              "version": "1.23.0",
+              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+            }
+          }
+        },
+        "moment": {
+          "version": "2.13.0",
+          "from": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz"
+        },
+        "wreck": {
+          "version": "6.3.0",
+          "from": "https://registry.npmjs.org/wreck/-/wreck-6.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/wreck/-/wreck-6.3.0.tgz",
+          "dependencies": {
+            "hoek": {
+              "version": "2.16.3",
+              "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+            },
+            "boom": {
+              "version": "2.10.1",
+              "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+            }
+          }
+        }
+      }
+    },
     "style-loader": {
       "version": "0.13.1",
-      "from": "style-loader@>=0.13.0 <0.14.0",
+      "from": "https://registry.npmjs.org/style-loader/-/style-loader-0.13.1.tgz",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.13.1.tgz",
       "dependencies": {
         "loader-utils": {
           "version": "0.2.14",
-          "from": "loader-utils@>=0.2.7 <0.3.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.14.tgz",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.14.tgz",
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.1.3 <4.0.0",
+              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "emojis-list": {
               "version": "1.0.1",
-              "from": "emojis-list@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.1.tgz"
             },
             "json5": {
               "version": "0.5.0",
-              "from": "json5@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz"
             },
             "object-assign": {
               "version": "4.0.1",
-              "from": "object-assign@>=4.0.1 <5.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
             }
           }
@@ -15311,181 +16834,181 @@
     },
     "watch": {
       "version": "0.16.0",
-      "from": "watch@>=0.16.0 <0.17.0",
+      "from": "https://registry.npmjs.org/watch/-/watch-0.16.0.tgz",
       "resolved": "https://registry.npmjs.org/watch/-/watch-0.16.0.tgz",
       "dependencies": {
         "exec-sh": {
           "version": "0.2.0",
-          "from": "exec-sh@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.0.tgz",
           "dependencies": {
             "merge": {
               "version": "1.2.0",
-              "from": "merge@>=1.1.3 <2.0.0",
+              "from": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
             }
           }
         },
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         }
       }
     },
     "webpack": {
       "version": "1.13.0",
-      "from": "webpack@>=1.12.9 <2.0.0",
+      "from": "https://registry.npmjs.org/webpack/-/webpack-1.13.0.tgz",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.13.0.tgz",
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "from": "async@>=1.3.0 <2.0.0",
+          "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         },
         "clone": {
           "version": "1.0.2",
-          "from": "clone@>=1.0.2 <2.0.0",
+          "from": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
         },
         "enhanced-resolve": {
           "version": "0.9.1",
-          "from": "enhanced-resolve@>=0.9.0 <0.10.0",
+          "from": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
           "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
           "dependencies": {
             "memory-fs": {
               "version": "0.2.0",
-              "from": "memory-fs@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
             },
             "graceful-fs": {
               "version": "4.1.3",
-              "from": "graceful-fs@>=4.1.2 <5.0.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
             }
           }
         },
         "acorn": {
           "version": "3.1.0",
-          "from": "acorn@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/acorn/-/acorn-3.1.0.tgz",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.1.0.tgz"
         },
         "interpret": {
           "version": "0.6.6",
-          "from": "interpret@>=0.6.4 <0.7.0",
+          "from": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz",
           "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz"
         },
         "loader-utils": {
           "version": "0.2.14",
-          "from": "loader-utils@>=0.2.11 <0.3.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.14.tgz",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.14.tgz",
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.1.3 <4.0.0",
+              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "emojis-list": {
               "version": "1.0.1",
-              "from": "emojis-list@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.1.tgz"
             },
             "json5": {
               "version": "0.5.0",
-              "from": "json5@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz"
             },
             "object-assign": {
               "version": "4.0.1",
-              "from": "object-assign@>=4.0.1 <5.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
             }
           }
         },
         "memory-fs": {
           "version": "0.3.0",
-          "from": "memory-fs@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
           "dependencies": {
             "errno": {
               "version": "0.1.4",
-              "from": "errno@>=0.1.3 <0.2.0",
+              "from": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
               "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
               "dependencies": {
                 "prr": {
                   "version": "0.0.0",
-                  "from": "prr@>=0.0.0 <0.1.0",
+                  "from": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
                 }
               }
             },
             "readable-stream": {
               "version": "2.1.0",
-              "from": "readable-stream@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.0.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.0.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "inline-process-browser": {
                   "version": "2.0.1",
-                  "from": "inline-process-browser@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inline-process-browser/-/inline-process-browser-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inline-process-browser/-/inline-process-browser-2.0.1.tgz",
                   "dependencies": {
                     "falafel": {
                       "version": "1.2.0",
-                      "from": "falafel@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
                       "dependencies": {
                         "acorn": {
                           "version": "1.2.2",
-                          "from": "acorn@>=1.0.3 <2.0.0",
+                          "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
                           "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
                         },
                         "foreach": {
                           "version": "2.0.5",
-                          "from": "foreach@>=2.0.5 <3.0.0",
+                          "from": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
                           "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "object-keys": {
                           "version": "1.0.9",
-                          "from": "object-keys@>=1.0.6 <2.0.0",
+                          "from": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz",
                           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz"
                         }
                       }
                     },
                     "through2": {
                       "version": "0.6.5",
-                      "from": "through2@>=0.6.5 <0.7.0",
+                      "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                       "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                       "dependencies": {
                         "readable-stream": {
                           "version": "1.0.34",
-                          "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                           "dependencies": {
                             "isarray": {
                               "version": "0.0.1",
-                              "from": "isarray@0.0.1",
+                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                             }
                           }
                         },
                         "xtend": {
                           "version": "4.0.1",
-                          "from": "xtend@>=4.0.0 <4.1.0-0",
+                          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                         }
                       }
@@ -15494,52 +17017,52 @@
                 },
                 "isarray": {
                   "version": "1.0.0",
-                  "from": "isarray@1.0.0",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "unreachable-branch-transform": {
                   "version": "0.5.1",
-                  "from": "unreachable-branch-transform@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/unreachable-branch-transform/-/unreachable-branch-transform-0.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/unreachable-branch-transform/-/unreachable-branch-transform-0.5.1.tgz",
                   "dependencies": {
                     "esmangle-evaluator": {
                       "version": "1.0.0",
-                      "from": "esmangle-evaluator@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.0.tgz"
                     },
                     "recast": {
                       "version": "0.11.5",
-                      "from": "recast@>=0.11.4 <0.12.0",
+                      "from": "https://registry.npmjs.org/recast/-/recast-0.11.5.tgz",
                       "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.5.tgz",
                       "dependencies": {
                         "ast-types": {
                           "version": "0.8.16",
-                          "from": "ast-types@0.8.16",
+                          "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.16.tgz",
                           "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.16.tgz"
                         },
                         "esprima": {
                           "version": "2.7.2",
-                          "from": "esprima@>=2.7.1 <2.8.0",
+                          "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
                           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
                         },
                         "private": {
                           "version": "0.1.6",
-                          "from": "private@>=0.1.5 <0.2.0",
+                          "from": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
                           "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
                         },
                         "source-map": {
                           "version": "0.5.5",
-                          "from": "source-map@>=0.5.0 <0.6.0",
+                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.5.tgz",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.5.tgz"
                         }
                       }
@@ -15548,7 +17071,7 @@
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
@@ -15557,156 +17080,156 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "minimist@0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "optimist@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.3",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@>=0.0.1 <0.1.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         },
         "supports-color": {
           "version": "3.1.2",
-          "from": "supports-color@>=3.1.0 <4.0.0",
+          "from": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "dependencies": {
             "has-flag": {
               "version": "1.0.0",
-              "from": "has-flag@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
             }
           }
         },
         "tapable": {
           "version": "0.1.10",
-          "from": "tapable@>=0.1.8 <0.2.0",
+          "from": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
           "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz"
         },
         "uglify-js": {
           "version": "2.6.2",
-          "from": "uglify-js@>=2.6.0 <2.7.0",
+          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@>=0.2.6 <0.3.0",
+              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "source-map": {
               "version": "0.5.5",
-              "from": "source-map@>=0.5.1 <0.6.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.5.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.5.tgz"
             },
             "uglify-to-browserify": {
               "version": "1.0.2",
-              "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
             },
             "yargs": {
               "version": "3.10.0",
-              "from": "yargs@>=3.10.0 <3.11.0",
+              "from": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
               "dependencies": {
                 "camelcase": {
                   "version": "1.2.1",
-                  "from": "camelcase@>=1.0.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                 },
                 "cliui": {
                   "version": "2.1.0",
-                  "from": "cliui@>=2.1.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                   "dependencies": {
                     "center-align": {
                       "version": "0.1.3",
-                      "from": "center-align@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.4",
-                          "from": "align-text@>=0.1.3 <0.2.0",
+                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                           "dependencies": {
                             "kind-of": {
                               "version": "3.0.2",
-                              "from": "kind-of@>=3.0.2 <4.0.0",
+                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                               "dependencies": {
                                 "is-buffer": {
                                   "version": "1.1.3",
-                                  "from": "is-buffer@>=1.0.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
                                   "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                 }
                               }
                             },
                             "longest": {
                               "version": "1.0.1",
-                              "from": "longest@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                             },
                             "repeat-string": {
                               "version": "1.5.4",
-                              "from": "repeat-string@>=1.5.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
                               "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                             }
                           }
                         },
                         "lazy-cache": {
                           "version": "1.0.4",
-                          "from": "lazy-cache@>=1.0.3 <2.0.0",
+                          "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
                         }
                       }
                     },
                     "right-align": {
                       "version": "0.1.3",
-                      "from": "right-align@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.4",
-                          "from": "align-text@>=0.1.3 <0.2.0",
+                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                           "dependencies": {
                             "kind-of": {
                               "version": "3.0.2",
-                              "from": "kind-of@>=3.0.2 <4.0.0",
+                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                               "dependencies": {
                                 "is-buffer": {
                                   "version": "1.1.3",
-                                  "from": "is-buffer@>=1.0.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
                                   "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                 }
                               }
                             },
                             "longest": {
                               "version": "1.0.1",
-                              "from": "longest@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                             },
                             "repeat-string": {
                               "version": "1.5.4",
-                              "from": "repeat-string@>=1.5.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
                               "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                             }
                           }
@@ -15715,19 +17238,19 @@
                     },
                     "wordwrap": {
                       "version": "0.0.2",
-                      "from": "wordwrap@0.0.2",
+                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                     }
                   }
                 },
                 "decamelize": {
                   "version": "1.2.0",
-                  "from": "decamelize@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                 },
                 "window-size": {
                   "version": "0.1.0",
-                  "from": "window-size@0.1.0",
+                  "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
                 }
               }
@@ -15736,91 +17259,91 @@
         },
         "watchpack": {
           "version": "0.2.9",
-          "from": "watchpack@>=0.2.1 <0.3.0",
+          "from": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
           "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
           "dependencies": {
             "async": {
               "version": "0.9.2",
-              "from": "async@>=0.9.0 <0.10.0",
+              "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
             },
             "chokidar": {
               "version": "1.4.3",
-              "from": "chokidar@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.3.tgz",
               "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.3.tgz",
               "dependencies": {
                 "anymatch": {
                   "version": "1.3.0",
-                  "from": "anymatch@>=1.3.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
                   "dependencies": {
                     "arrify": {
                       "version": "1.0.1",
-                      "from": "arrify@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
                     },
                     "micromatch": {
                       "version": "2.3.8",
-                      "from": "micromatch@>=2.1.5 <3.0.0",
+                      "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.8.tgz",
                       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.8.tgz",
                       "dependencies": {
                         "arr-diff": {
                           "version": "2.0.0",
-                          "from": "arr-diff@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
                           "dependencies": {
                             "arr-flatten": {
                               "version": "1.0.1",
-                              "from": "arr-flatten@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
                             }
                           }
                         },
                         "array-unique": {
                           "version": "0.2.1",
-                          "from": "array-unique@>=0.2.1 <0.3.0",
+                          "from": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
                           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
                         },
                         "braces": {
                           "version": "1.8.4",
-                          "from": "braces@>=1.8.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/braces/-/braces-1.8.4.tgz",
                           "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.4.tgz",
                           "dependencies": {
                             "expand-range": {
                               "version": "1.8.1",
-                              "from": "expand-range@>=1.8.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                               "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                               "dependencies": {
                                 "fill-range": {
                                   "version": "2.2.3",
-                                  "from": "fill-range@>=2.1.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
                                   "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
                                   "dependencies": {
                                     "is-number": {
                                       "version": "2.1.0",
-                                      "from": "is-number@>=2.1.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
                                       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
                                     },
                                     "isobject": {
                                       "version": "2.1.0",
-                                      "from": "isobject@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                                       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                                       "dependencies": {
                                         "isarray": {
                                           "version": "1.0.0",
-                                          "from": "isarray@1.0.0",
+                                          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                                         }
                                       }
                                     },
                                     "randomatic": {
                                       "version": "1.1.5",
-                                      "from": "randomatic@>=1.1.3 <2.0.0",
+                                      "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
                                       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
                                     },
                                     "repeat-string": {
                                       "version": "1.5.4",
-                                      "from": "repeat-string@>=1.5.2 <2.0.0",
+                                      "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
                                       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                     }
                                   }
@@ -15829,114 +17352,114 @@
                             },
                             "preserve": {
                               "version": "0.2.0",
-                              "from": "preserve@>=0.2.0 <0.3.0",
+                              "from": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
                               "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
                             },
                             "repeat-element": {
                               "version": "1.1.2",
-                              "from": "repeat-element@>=1.1.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
                               "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
                             }
                           }
                         },
                         "expand-brackets": {
                           "version": "0.1.5",
-                          "from": "expand-brackets@>=0.1.4 <0.2.0",
+                          "from": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
                           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
                           "dependencies": {
                             "is-posix-bracket": {
                               "version": "0.1.1",
-                              "from": "is-posix-bracket@>=0.1.0 <0.2.0",
+                              "from": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
                               "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
                             }
                           }
                         },
                         "extglob": {
                           "version": "0.3.2",
-                          "from": "extglob@>=0.3.1 <0.4.0",
+                          "from": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
                           "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
                         },
                         "filename-regex": {
                           "version": "2.0.0",
-                          "from": "filename-regex@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
                         },
                         "is-extglob": {
                           "version": "1.0.0",
-                          "from": "is-extglob@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                         },
                         "kind-of": {
                           "version": "3.0.2",
-                          "from": "kind-of@>=3.0.2 <4.0.0",
+                          "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                           "dependencies": {
                             "is-buffer": {
                               "version": "1.1.3",
-                              "from": "is-buffer@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
                               "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                             }
                           }
                         },
                         "normalize-path": {
                           "version": "2.0.1",
-                          "from": "normalize-path@>=2.0.1 <3.0.0",
+                          "from": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
                         },
                         "object.omit": {
                           "version": "2.0.0",
-                          "from": "object.omit@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
                           "dependencies": {
                             "for-own": {
                               "version": "0.1.4",
-                              "from": "for-own@>=0.1.3 <0.2.0",
+                              "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
                               "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
                               "dependencies": {
                                 "for-in": {
                                   "version": "0.1.5",
-                                  "from": "for-in@>=0.1.5 <0.2.0",
+                                  "from": "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz",
                                   "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz"
                                 }
                               }
                             },
                             "is-extendable": {
                               "version": "0.1.1",
-                              "from": "is-extendable@>=0.1.1 <0.2.0",
+                              "from": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
                               "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
                             }
                           }
                         },
                         "parse-glob": {
                           "version": "3.0.4",
-                          "from": "parse-glob@>=3.0.4 <4.0.0",
+                          "from": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
                           "dependencies": {
                             "glob-base": {
                               "version": "0.3.0",
-                              "from": "glob-base@>=0.3.0 <0.4.0",
+                              "from": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
                               "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
                             },
                             "is-dotfile": {
                               "version": "1.0.2",
-                              "from": "is-dotfile@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
                             }
                           }
                         },
                         "regex-cache": {
                           "version": "0.4.3",
-                          "from": "regex-cache@>=0.4.2 <0.5.0",
+                          "from": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
                           "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
                           "dependencies": {
                             "is-equal-shallow": {
                               "version": "0.1.3",
-                              "from": "is-equal-shallow@>=0.1.3 <0.2.0",
+                              "from": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
                               "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
                             },
                             "is-primitive": {
                               "version": "2.0.0",
-                              "from": "is-primitive@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
                             }
                           }
@@ -15947,71 +17470,71 @@
                 },
                 "async-each": {
                   "version": "1.0.0",
-                  "from": "async-each@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/async-each/-/async-each-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.0.tgz"
                 },
                 "glob-parent": {
                   "version": "2.0.0",
-                  "from": "glob-parent@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "is-binary-path": {
                   "version": "1.0.1",
-                  "from": "is-binary-path@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
                   "dependencies": {
                     "binary-extensions": {
                       "version": "1.4.0",
-                      "from": "binary-extensions@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz",
                       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz"
                     }
                   }
                 },
                 "is-glob": {
                   "version": "2.0.1",
-                  "from": "is-glob@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                   "dependencies": {
                     "is-extglob": {
                       "version": "1.0.0",
-                      "from": "is-extglob@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                 },
                 "readdirp": {
                   "version": "2.0.0",
-                  "from": "readdirp@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
                   "dependencies": {
                     "minimatch": {
                       "version": "2.0.10",
-                      "from": "minimatch@>=2.0.10 <3.0.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.3",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.3.0",
-                              "from": "balanced-match@>=0.3.0 <0.4.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
@@ -16020,66 +17543,66 @@
                     },
                     "readable-stream": {
                       "version": "2.1.0",
-                      "from": "readable-stream@>=2.0.2 <3.0.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.0.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "inline-process-browser": {
                           "version": "2.0.1",
-                          "from": "inline-process-browser@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inline-process-browser/-/inline-process-browser-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inline-process-browser/-/inline-process-browser-2.0.1.tgz",
                           "dependencies": {
                             "falafel": {
                               "version": "1.2.0",
-                              "from": "falafel@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
                               "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
                               "dependencies": {
                                 "acorn": {
                                   "version": "1.2.2",
-                                  "from": "acorn@>=1.0.3 <2.0.0",
+                                  "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
                                   "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
                                 },
                                 "foreach": {
                                   "version": "2.0.5",
-                                  "from": "foreach@>=2.0.5 <3.0.0",
+                                  "from": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
                                   "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
                                 },
                                 "isarray": {
                                   "version": "0.0.1",
-                                  "from": "isarray@0.0.1",
+                                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                                 },
                                 "object-keys": {
                                   "version": "1.0.9",
-                                  "from": "object-keys@>=1.0.6 <2.0.0",
+                                  "from": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz",
                                   "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz"
                                 }
                               }
                             },
                             "through2": {
                               "version": "0.6.5",
-                              "from": "through2@>=0.6.5 <0.7.0",
+                              "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                               "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                               "dependencies": {
                                 "readable-stream": {
                                   "version": "1.0.34",
-                                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                                   "dependencies": {
                                     "isarray": {
                                       "version": "0.0.1",
-                                      "from": "isarray@0.0.1",
+                                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                                     }
                                   }
                                 },
                                 "xtend": {
                                   "version": "4.0.1",
-                                  "from": "xtend@>=4.0.0 <4.1.0-0",
+                                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                                 }
                               }
@@ -16088,52 +17611,52 @@
                         },
                         "isarray": {
                           "version": "1.0.0",
-                          "from": "isarray@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                         },
                         "process-nextick-args": {
                           "version": "1.0.6",
-                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                          "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "unreachable-branch-transform": {
                           "version": "0.5.1",
-                          "from": "unreachable-branch-transform@>=0.5.0 <0.6.0",
+                          "from": "https://registry.npmjs.org/unreachable-branch-transform/-/unreachable-branch-transform-0.5.1.tgz",
                           "resolved": "https://registry.npmjs.org/unreachable-branch-transform/-/unreachable-branch-transform-0.5.1.tgz",
                           "dependencies": {
                             "esmangle-evaluator": {
                               "version": "1.0.0",
-                              "from": "esmangle-evaluator@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.0.tgz"
                             },
                             "recast": {
                               "version": "0.11.5",
-                              "from": "recast@>=0.11.4 <0.12.0",
+                              "from": "https://registry.npmjs.org/recast/-/recast-0.11.5.tgz",
                               "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.5.tgz",
                               "dependencies": {
                                 "ast-types": {
                                   "version": "0.8.16",
-                                  "from": "ast-types@0.8.16",
+                                  "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.16.tgz",
                                   "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.16.tgz"
                                 },
                                 "esprima": {
                                   "version": "2.7.2",
-                                  "from": "esprima@>=2.7.1 <2.8.0",
+                                  "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
                                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
                                 },
                                 "private": {
                                   "version": "0.1.6",
-                                  "from": "private@>=0.1.5 <0.2.0",
+                                  "from": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
                                   "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
                                 },
                                 "source-map": {
                                   "version": "0.5.5",
-                                  "from": "source-map@>=0.5.0 <0.6.0",
+                                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.5.tgz",
                                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.5.tgz"
                                 }
                               }
@@ -16142,7 +17665,7 @@
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                         }
                       }
@@ -16151,12 +17674,12 @@
                 },
                 "fsevents": {
                   "version": "1.0.11",
-                  "from": "fsevents@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.11.tgz",
                   "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.11.tgz",
                   "dependencies": {
                     "nan": {
                       "version": "2.3.2",
-                      "from": "nan@>=2.1.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/nan/-/nan-2.3.2.tgz",
                       "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.2.tgz"
                     },
                     "node-pre-gyp": {
@@ -16178,11 +17701,6 @@
                         }
                       }
                     },
-                    "ansi-styles": {
-                      "version": "2.2.1",
-                      "from": "ansi-styles@^2.2.1",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                    },
                     "ansi-regex": {
                       "version": "2.0.0",
                       "from": "ansi-regex@^2.0.0",
@@ -16192,6 +17710,11 @@
                       "version": "0.3.1",
                       "from": "ansi@~0.3.1",
                       "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz"
+                    },
+                    "ansi-styles": {
+                      "version": "2.2.1",
+                      "from": "ansi-styles@^2.2.1",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                     },
                     "are-we-there-yet": {
                       "version": "1.1.2",
@@ -16203,6 +17726,11 @@
                       "from": "asn1@>=0.2.3 <0.3.0",
                       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                     },
+                    "async": {
+                      "version": "1.5.2",
+                      "from": "async@^1.5.2",
+                      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+                    },
                     "assert-plus": {
                       "version": "0.2.0",
                       "from": "assert-plus@^0.2.0",
@@ -16213,15 +17741,15 @@
                       "from": "aws-sign2@~0.6.0",
                       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
                     },
-                    "async": {
-                      "version": "1.5.2",
-                      "from": "async@^1.5.2",
-                      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
-                    },
                     "bl": {
                       "version": "1.0.3",
                       "from": "bl@~1.0.0",
                       "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz"
+                    },
+                    "boom": {
+                      "version": "2.10.1",
+                      "from": "boom@2.x.x",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                     },
                     "caseless": {
                       "version": "0.11.0",
@@ -16243,20 +17771,15 @@
                       "from": "combined-stream@~1.0.5",
                       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
                     },
-                    "cryptiles": {
-                      "version": "2.0.5",
-                      "from": "cryptiles@2.x.x",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                    },
-                    "boom": {
-                      "version": "2.10.1",
-                      "from": "boom@2.x.x",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                    },
                     "commander": {
                       "version": "2.9.0",
                       "from": "commander@^2.9.0",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "from": "cryptiles@2.x.x",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                     },
                     "core-util-is": {
                       "version": "1.0.2",
@@ -16278,15 +17801,20 @@
                       "from": "delayed-stream@~1.0.0",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                     },
+                    "delegates": {
+                      "version": "1.0.0",
+                      "from": "delegates@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
+                    },
                     "ecc-jsbn": {
                       "version": "0.1.1",
                       "from": "ecc-jsbn@>=0.0.1 <1.0.0",
                       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                     },
-                    "delegates": {
-                      "version": "1.0.0",
-                      "from": "delegates@^1.0.0",
-                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
+                    "escape-string-regexp": {
+                      "version": "1.0.5",
+                      "from": "escape-string-regexp@^1.0.2",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                     },
                     "extend": {
                       "version": "3.0.0",
@@ -16298,20 +17826,15 @@
                       "from": "extsprintf@1.0.2",
                       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                     },
-                    "form-data": {
-                      "version": "1.0.0-rc4",
-                      "from": "form-data@~1.0.0-rc3",
-                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz"
-                    },
                     "forever-agent": {
                       "version": "0.6.1",
                       "from": "forever-agent@~0.6.1",
                       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                     },
-                    "escape-string-regexp": {
-                      "version": "1.0.5",
-                      "from": "escape-string-regexp@^1.0.2",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                    "form-data": {
+                      "version": "1.0.0-rc4",
+                      "from": "form-data@~1.0.0-rc3",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz"
                     },
                     "fstream": {
                       "version": "1.0.8",
@@ -16328,15 +17851,15 @@
                       "from": "generate-function@^2.0.0",
                       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
-                    "graceful-fs": {
-                      "version": "4.1.3",
-                      "from": "graceful-fs@^4.1.2",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
-                    },
                     "generate-object-property": {
                       "version": "1.2.0",
                       "from": "generate-object-property@^1.1.0",
                       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+                    },
+                    "graceful-fs": {
+                      "version": "4.1.3",
+                      "from": "graceful-fs@^4.1.2",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                     },
                     "graceful-readlink": {
                       "version": "1.0.1",
@@ -16353,100 +17876,100 @@
                       "from": "has-ansi@^2.0.0",
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
                     },
-                    "hawk": {
-                      "version": "3.1.3",
-                      "from": "hawk@~3.1.0",
-                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
+                    "has-unicode": {
+                      "version": "2.0.0",
+                      "from": "has-unicode@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz"
                     },
                     "hoek": {
                       "version": "2.16.3",
                       "from": "hoek@2.x.x",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                     },
-                    "has-unicode": {
-                      "version": "2.0.0",
-                      "from": "has-unicode@^2.0.0",
-                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz"
+                    "hawk": {
+                      "version": "3.1.3",
+                      "from": "hawk@~3.1.0",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
                     },
                     "http-signature": {
                       "version": "1.1.1",
                       "from": "http-signature@~1.1.0",
                       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
                     },
-                    "is-my-json-valid": {
-                      "version": "2.13.1",
-                      "from": "is-my-json-valid@^2.12.4",
-                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz"
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@*",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "ini": {
                       "version": "1.3.4",
                       "from": "ini@~1.3.0",
                       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                     },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@*",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "from": "isarray@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                    },
-                    "is-property": {
-                      "version": "1.0.2",
-                      "from": "is-property@^1.0.0",
-                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-                    },
-                    "isstream": {
-                      "version": "0.1.2",
-                      "from": "isstream@~0.1.2",
-                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                    "is-my-json-valid": {
+                      "version": "2.13.1",
+                      "from": "is-my-json-valid@^2.12.4",
+                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz"
                     },
                     "is-typedarray": {
                       "version": "1.0.0",
                       "from": "is-typedarray@~1.0.0",
                       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
                     },
+                    "is-property": {
+                      "version": "1.0.2",
+                      "from": "is-property@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "from": "isarray@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                    },
+                    "isstream": {
+                      "version": "0.1.2",
+                      "from": "isstream@~0.1.2",
+                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                    },
                     "jodid25519": {
                       "version": "1.0.2",
                       "from": "jodid25519@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
-                    },
-                    "jsbn": {
-                      "version": "0.1.0",
-                      "from": "jsbn@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                     },
                     "json-schema": {
                       "version": "0.2.2",
                       "from": "json-schema@0.2.2",
                       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
                     },
+                    "jsbn": {
+                      "version": "0.1.0",
+                      "from": "jsbn@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                    },
                     "jsonpointer": {
                       "version": "2.0.0",
                       "from": "jsonpointer@2.0.0",
                       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
-                    },
-                    "lodash.pad": {
-                      "version": "4.1.0",
-                      "from": "lodash.pad@^4.1.0",
-                      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.1.0.tgz"
                     },
                     "json-stringify-safe": {
                       "version": "5.0.1",
                       "from": "json-stringify-safe@~5.0.1",
                       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                     },
-                    "jsprim": {
-                      "version": "1.2.2",
-                      "from": "jsprim@^1.2.2",
-                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
+                    "lodash.pad": {
+                      "version": "4.1.0",
+                      "from": "lodash.pad@^4.1.0",
+                      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.1.0.tgz"
                     },
                     "lodash.padend": {
                       "version": "4.2.0",
                       "from": "lodash.padend@^4.1.0",
                       "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.2.0.tgz"
+                    },
+                    "jsprim": {
+                      "version": "1.2.2",
+                      "from": "jsprim@^1.2.2",
+                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
                     },
                     "lodash.padstart": {
                       "version": "4.2.0",
@@ -16468,15 +17991,15 @@
                       "from": "mime-db@~1.22.0",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
                     },
-                    "mime-types": {
-                      "version": "2.1.10",
-                      "from": "mime-types@~2.1.7",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz"
-                    },
                     "minimist": {
                       "version": "0.0.8",
                       "from": "minimist@0.0.8",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    },
+                    "mime-types": {
+                      "version": "2.1.10",
+                      "from": "mime-types@~2.1.7",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz"
                     },
                     "mkdirp": {
                       "version": "0.5.1",
@@ -16493,65 +18016,60 @@
                       "from": "npmlog@~2.0.0",
                       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.3.tgz"
                     },
-                    "node-uuid": {
-                      "version": "1.4.7",
-                      "from": "node-uuid@~1.4.7",
-                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+                    "oauth-sign": {
+                      "version": "0.8.1",
+                      "from": "oauth-sign@~0.8.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
                     },
                     "once": {
                       "version": "1.3.3",
                       "from": "once@~1.3.3",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
                     },
+                    "node-uuid": {
+                      "version": "1.4.7",
+                      "from": "node-uuid@~1.4.7",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+                    },
                     "pinkie": {
                       "version": "2.0.4",
                       "from": "pinkie@^2.0.0",
                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                    },
-                    "oauth-sign": {
-                      "version": "0.8.1",
-                      "from": "oauth-sign@~0.8.0",
-                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
-                    },
-                    "qs": {
-                      "version": "6.0.2",
-                      "from": "qs@~6.0.2",
-                      "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz"
                     },
                     "pinkie-promise": {
                       "version": "2.0.0",
                       "from": "pinkie-promise@^2.0.0",
                       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
                     },
-                    "request": {
-                      "version": "2.69.0",
-                      "from": "request@2.x",
-                      "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz"
-                    },
                     "process-nextick-args": {
                       "version": "1.0.6",
                       "from": "process-nextick-args@~1.0.6",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                     },
-                    "semver": {
-                      "version": "5.1.0",
-                      "from": "semver@~5.1.0",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+                    "qs": {
+                      "version": "6.0.2",
+                      "from": "qs@~6.0.2",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz"
                     },
                     "readable-stream": {
                       "version": "2.0.6",
                       "from": "readable-stream@^2.0.0 || ^1.1.13",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
                     },
+                    "request": {
+                      "version": "2.69.0",
+                      "from": "request@2.x",
+                      "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz"
+                    },
+                    "semver": {
+                      "version": "5.1.0",
+                      "from": "semver@~5.1.0",
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+                    },
                     "sntp": {
                       "version": "1.0.9",
                       "from": "sntp@1.x.x",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "sshpk": {
                       "version": "1.7.4",
@@ -16563,10 +18081,20 @@
                       "from": "stringstream@~0.0.4",
                       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                     },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
                     "strip-ansi": {
                       "version": "3.0.1",
                       "from": "strip-ansi@^3.0.0",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+                    },
+                    "strip-json-comments": {
+                      "version": "1.0.4",
+                      "from": "strip-json-comments@~1.0.4",
+                      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
                     },
                     "supports-color": {
                       "version": "2.0.0",
@@ -16578,20 +18106,15 @@
                       "from": "tar@~2.2.0",
                       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
                     },
-                    "tough-cookie": {
-                      "version": "2.2.2",
-                      "from": "tough-cookie@~2.2.0",
-                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
-                    },
-                    "strip-json-comments": {
-                      "version": "1.0.4",
-                      "from": "strip-json-comments@~1.0.4",
-                      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
-                    },
                     "tar-pack": {
                       "version": "3.1.3",
                       "from": "tar-pack@~3.1.0",
                       "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.3.tgz"
+                    },
+                    "tough-cookie": {
+                      "version": "2.2.2",
+                      "from": "tough-cookie@~2.2.0",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
                     },
                     "tunnel-agent": {
                       "version": "0.4.2",
@@ -16603,25 +18126,25 @@
                       "from": "tweetnacl@>=0.13.0 <1.0.0",
                       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
                     },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "util-deprecate@~1.0.1",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    },
                     "uid-number": {
                       "version": "0.0.6",
                       "from": "uid-number@~0.0.6",
                       "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
-                    },
-                    "verror": {
-                      "version": "1.3.6",
-                      "from": "verror@1.3.6",
-                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                     },
                     "wrappy": {
                       "version": "1.0.1",
                       "from": "wrappy@1",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "util-deprecate@~1.0.1",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    "verror": {
+                      "version": "1.3.6",
+                      "from": "verror@1.3.6",
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                     },
                     "xtend": {
                       "version": "4.0.1",
@@ -16785,31 +18308,31 @@
             },
             "graceful-fs": {
               "version": "4.1.3",
-              "from": "graceful-fs@>=4.1.2 <5.0.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
             }
           }
         },
         "webpack-core": {
           "version": "0.6.8",
-          "from": "webpack-core@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.8.tgz",
           "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.8.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.4.4",
-              "from": "source-map@>=0.4.1 <0.5.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "1.0.0",
-                  "from": "amdefine@>=0.0.4",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                 }
               }
             },
             "source-list-map": {
               "version": "0.1.6",
-              "from": "source-list-map@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.6.tgz",
               "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.6.tgz"
             }
           }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint": "eslint -c .eslintrc ./static_src",
     "postinstall": "npm run cloudgov-style",
     "test": "npm run lint && karma start --single-run --browsers PhantomJS2",
+    "testing-server": "node test/server.js",
     "watch-test": "karma start --browsers Chrome",
     "watch": "watch 'npm run build' ./static_src",
     "shrinkwrap": "npm shrinkwrap --dev"
@@ -75,6 +76,7 @@
     "reactable": "^0.11.5",
     "sass-loader": "^3.2.0",
     "scss-loader": "0.0.1",
+    "smocks": "^4.0.6",
     "style-loader": "^0.13.0",
     "url-loader": "^0.5.7",
     "watch": "^0.16.0",

--- a/test/api.js
+++ b/test/api.js
@@ -1,0 +1,38 @@
+var data = require('./fixtures');
+
+var organizations = data.organizations;
+var spaces = data.spaces;
+
+var BASE_URL = '/v2';
+
+module.exports = function api(smocks) {
+  smocks.route({
+    id: 'organizations',
+    label: 'Organizations', // label is optional
+    path: `${BASE_URL}/organizations`,
+    handler: function (req, reply) {
+      reply({
+        "total_results": organizations.length,
+        "total_pages": 1,
+        "prev_url": null,
+        "next_url": null,
+        "resources": organizations
+      })
+    }
+  });
+
+  smocks.route({
+    id: 'organization-summary',
+    label: 'Organization summary',
+    path: `${BASE_URL}/organizations/{guid}/summary`,
+    handler: function (req, reply) {
+      var guid = req.params.guid;
+      reply({
+        guid: guid,
+        name: 'org-name',
+        status: 'active',
+        spaces: spaces
+      });
+    }
+  })
+};

--- a/test/api.js
+++ b/test/api.js
@@ -1,5 +1,6 @@
 var data = require('./fixtures');
 
+var apps = data.apps;
 var organizations = data.organizations;
 var spaces = data.spaces;
 
@@ -34,5 +35,19 @@ module.exports = function api(smocks) {
         spaces: spaces
       });
     }
-  })
+  });
+
+  smocks.route({
+    id: 'space-summary',
+    label: 'Space summary',
+    path: `${BASE_URL}/spaces/{guid}/summary`,
+    handler: function (req, reply) {
+      var guid = req.params.guid;
+      reply({
+        guid: guid,
+        name: `space-${guid}`,
+        apps: apps
+      });
+    }
+  });
 };

--- a/test/api.js
+++ b/test/api.js
@@ -2,14 +2,52 @@ var data = require('./fixtures');
 
 var apps = data.apps;
 var organizations = data.organizations;
+var routes = data.routes;
+var serviceInstances = data.serviceInstances;
 var spaces = data.spaces;
+var users = data.users;
 
 var BASE_URL = '/v2';
 
 module.exports = function api(smocks) {
+
+  smocks.route({
+    id: 'app-routes',
+    label: 'App routes',
+    path: `${BASE_URL}/apps/{guid}/routes`,
+    handler: function (req, reply) {
+      var guid = req.params.guid;
+      var route = routes.pop();
+      console.log('guid', guid);
+      reply(route);
+    }
+  });
+
+  smocks.route({
+    id: 'app-stats',
+    label: 'App stats',
+    path: `${BASE_URL}/apps/{guid}/stats`,
+    handler: function (req, reply) {
+      reply({
+        "yo": "fool"
+      });
+    }
+  });
+
+  smocks.route({
+    id: 'app-summary',
+    label: 'App summary',
+    path: `${BASE_URL}/apps/{guid}/summary`,
+    handler: function (req, reply) {
+      var guid = req.params.guid;
+      var app = apps.filter((app) => app.guid === guid).pop();
+      reply(app);
+    }
+  });
+
   smocks.route({
     id: 'organizations',
-    label: 'Organizations', // label is optional
+    label: 'Organizations',
     path: `${BASE_URL}/organizations`,
     handler: function (req, reply) {
       reply({
@@ -19,6 +57,17 @@ module.exports = function api(smocks) {
         "next_url": null,
         "resources": organizations
       })
+    }
+  });
+
+  smocks.route({
+    id: 'organization',
+    label: 'Organization',
+    path: `${BASE_URL}/organizations/{guid}`,
+    handler: function (req, reply) {
+      var guid = req.params.guid;
+      var organization = organizations.filter((org) => org.metadata.guid === guid).pop();
+      reply(organization);
     }
   });
 
@@ -38,6 +87,34 @@ module.exports = function api(smocks) {
   });
 
   smocks.route({
+    id: 'organization-memory-usage',
+    label: 'Organization memory usage',
+    path: `${BASE_URL}/organizations/{guid}/memory_usage`,
+    handler: function (req, reply) {
+      var guid = req.params.guid;
+      reply({
+        memory_usage_in_mb: 17616
+      });
+    }
+  });
+
+  smocks.route({
+    id: 'organization-user-roles',
+    label: 'Organization user roles',
+    path: `${BASE_URL}/organizations/{guid}/user_roles`,
+    handler: function (req, reply) {
+      var guid = req.params.guid;
+      reply({
+        total_results: users.length,
+        total_pages: 1,
+        prev_url: null,
+        next_url: null,
+        resources: users
+      });
+    }
+  });
+
+  smocks.route({
     id: 'space-summary',
     label: 'Space summary',
     path: `${BASE_URL}/spaces/{guid}/summary`,
@@ -47,6 +124,38 @@ module.exports = function api(smocks) {
         guid: guid,
         name: `space-${guid}`,
         apps: apps
+      });
+    }
+  });
+
+  smocks.route({
+    id: 'space-service-instances',
+    label: 'Space service instances',
+    path: `${BASE_URL}/spaces/{guid}/service_instances`,
+    handler: function (req, reply) {
+      var guid = req.params.guid;
+      reply({
+        total_results: serviceInstances.length,
+        total_pages: 1,
+        prev_url: null,
+        next_url: null,
+        resources: serviceInstances
+     });
+   }
+  });
+
+  smocks.route({
+    id: 'space-user-roles',
+    label: 'Space user roles',
+    path: `${BASE_URL}/spaces/{guid}/user_roles`,
+    handler: function (req, reply) {
+      var guid = req.params.guid;
+      reply({
+        total_results: users.length,
+        total_pages: 1,
+        prev_url: null,
+        next_url: null,
+        resources: users
       });
     }
   });

--- a/test/authstatus.js
+++ b/test/authstatus.js
@@ -1,0 +1,13 @@
+module.exports = function authstatus(smocks) {
+  smocks.route({
+    id: 'authstatus',
+    label: 'Auth status', // label is optional
+    path: '/v2/authstatus',
+
+    handler: function (req, reply) {
+      reply({
+        "status": "authorized"
+      })
+    }
+  })
+};

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1,5 +1,52 @@
 var URL_BASE = '/v2'
 
+var appGuids = [
+  'app-guid-one',
+  'app-guid-two',
+  'app-guid-three'
+]
+
+module.exports.appGuids = appGuids;
+
+var apps = appGuids.map(function(guid) {
+  return {
+    guid: guid,
+    name: `app-${guid}`,
+    production: false,
+    buildpack: 'https://github.com/cloudfoundry/staticfile-buildpack.git',
+    command: null,
+    console: false,
+    debug: null,
+    detected_buildpack: 'node.js 1.5.10',
+    disk_quota: 1024,
+    memory: 64,
+    package_state: 'STAGED',
+    ports: null,
+    instances: 2,
+    running_instances: 2,
+    service_count: 0,
+    service_names: [],
+    state: 'STARTED',
+    version: 'version',
+    urls: [
+      `${guid}.apps.cloud.gov`
+    ],
+    routes: [
+      {
+        guid: "d32ee365-637b-493d-874e-8fe93c7212e2",
+        host: "18f-site",
+        path: "",
+        domain: {
+          guid: "3750eb89-86c6-4882-96bf-66b8c6363290",
+          name: "18f.gov"
+        }
+      }
+    ]
+  }
+});
+
+module.exports.apps = apps;
+
 var organizationGuids = [
   'org-guid-one',
   'org-guid-two',

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1,0 +1,59 @@
+var URL_BASE = '/v2'
+
+var organizationGuids = [
+  'org-guid-one',
+  'org-guid-two',
+  'org-guid-three'
+];
+
+module.exports.organizationGuids = organizationGuids;
+
+var organizations = organizationGuids.map(function(guid) {
+  return {
+    metadata: {
+      guid: guid,
+      url: `${URL_BASE}/organizations/${guid}`,
+      created_at: "2015-03-02T19:58:26Z",
+      updated_at: "2015-03-02T19:58:26Z",
+    },
+    entity: {
+      name: `org-${guid}`,
+      billing_enabled: false,
+      status: 'active',
+      quota_definition_guid: '',
+      quota_definition_url: '',
+      spaces_url: `${URL_BASE}/organizations/${guid}/spaces`,
+      domains_url: `${URL_BASE}/organizations/${guid}/domains`,
+      private_domains_url: `${URL_BASE}/organizations/${guid}/private_domains`,
+      users_url: `${URL_BASE}/organizations/${guid}/users`,
+      managers_url: `${URL_BASE}/organizations/${guid}/managers`,
+      billing_managers_url: `${URL_BASE}/organizations/${guid}/billing_managers`,
+      auditors_url: `${URL_BASE}/organizations/${guid}/auditors`,
+      app_events_url: `${URL_BASE}/organizations/${guid}/app_events`,
+      space_quota_definitions_url: `${URL_BASE}/organizations/${guid}/space_quota_definitions`
+    }
+  }
+});
+
+module.exports.organizations  = organizations;
+
+var spaceGuids = [
+  'space-guid-one',
+  'space-guid-two',
+  'space-guid-three'
+];
+
+module.exports.spaceGuids = spaceGuids;
+
+var spaces = spaceGuids.map(function(guid){
+  return {
+    guid: guid,
+    name: `space-${guid}`,
+    service_count: 0,
+    app_count: 2,
+    mem_dev_total: 2560,
+    mem_prod_total: 0
+  };
+});
+
+module.exports.spaces = spaces;

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -4,9 +4,49 @@ var appGuids = [
   'app-guid-one',
   'app-guid-two',
   'app-guid-three'
-]
+];
 
 module.exports.appGuids = appGuids;
+
+var organizationGuids = [
+  'org-guid-one',
+  'org-guid-two',
+  'org-guid-three'
+];
+
+module.exports.organizationGuids = organizationGuids;
+
+var routeGuids = [
+  'route-guid-one',
+  'route-guid-two',
+  'route-guid-three'
+];
+
+module.exports.routeGuids = routeGuids;
+
+var serviceInstanceGuids = [
+  'service-instance-guid-one',
+  'service-instance-guid-two',
+  'service-instance-guid-three'
+];
+
+module.exports.serviceInstanceGuids = serviceInstanceGuids;
+
+var spaceGuids = [
+  'space-guid-one',
+  'space-guid-two',
+  'space-guid-three'
+];
+
+module.exports.spaceGuids = spaceGuids;
+
+var userGuids = [
+  'user-guid-one',
+  'user-guid-two',
+  'user-guid-three'
+];
+
+module.exports.userGuids = userGuids;
 
 var apps = appGuids.map(function(guid) {
   return {
@@ -47,14 +87,6 @@ var apps = appGuids.map(function(guid) {
 
 module.exports.apps = apps;
 
-var organizationGuids = [
-  'org-guid-one',
-  'org-guid-two',
-  'org-guid-three'
-];
-
-module.exports.organizationGuids = organizationGuids;
-
 var organizations = organizationGuids.map(function(guid) {
   return {
     metadata: {
@@ -84,13 +116,75 @@ var organizations = organizationGuids.map(function(guid) {
 
 module.exports.organizations  = organizations;
 
-var spaceGuids = [
-  'space-guid-one',
-  'space-guid-two',
-  'space-guid-three'
-];
+var routes = routeGuids.map(function(guid, i){
+  var domainGuid = 'yo';
+  var spaceGuid = spaceGuids[i];
+  return {
+    total_results: 1,
+    total_pages: 1,
+    prev_url: null,
+    next_url: null,
+    resources: [
+      {
+        metadata: {
+          guid: guid,
+          url: `${URL_BASE}/routes/${guid}`,
+          created_at: '2015-10-13T18:30:37Z',
+          updated_at: null
+        },
+        entity: {
+          host: 'console',
+          path: '',
+          domain_guid: '',
+          space_guid: spaceGuids[i],
+          service_instance_guid: null,
+          port: 0,
+          domain_url: `${URL_BASE}/domains/${domainGuid}`,
+          space_url: `${URL_BASE}/spaces/${spaceGuid}`,
+          apps_url: `${URL_BASE}/routes/${guid}/apps`,
+          route_mappings_url: `${URL_BASE}/routes/${guid}/route_mappings`
+        }
+      }
+    ]
+  }
+});
 
-module.exports.spaceGuids = spaceGuids;
+module.exports.routes = routes;
+
+var serviceInstances = serviceInstanceGuids.map(function(guid, i) {
+  return {
+    metadata: {
+      guid: guid,
+      url: `${URL_BASE}/service_instances/${guid}`,
+      created_at: '2015-07-14T04:02:30Z',
+      updated_at: null
+    },
+    entity: {
+      name: `service-instance-${guid}`,
+      credentials: {},
+      service_plan_guid: 'fake-service-plan-guid',
+      space_guid: spaceGuids[i],
+      gateway_data: null,
+      dashboard_url: null,
+      type: 'managed_service_instance',
+      last_operation: {
+        type: 'create',
+        state: 'succeeded',
+        description: 'The instance was created',
+        created_at: '2015-07-14T04:02:30Z',
+        updated_at: '2015-07-14T04:02:30Z',
+        tags: [],
+        space_url: `${URL_BASE}/spaces/${spaceGuids[i]}`,
+        service_plan_url: '',
+        service_bindings_url: `${URL_BASE}/service_instances/${guid}/service_bindings`,
+        service_keys_url: `${URL_BASE}/service_instances/${guid}/service_keys`,
+        routes_url: `${URL_BASE}/service_instances/${guid}/routes`
+      }
+    }
+  }
+});
+
+module.exports.serviceInstances = serviceInstances;
 
 var spaces = spaceGuids.map(function(guid){
   return {
@@ -104,3 +198,30 @@ var spaces = spaceGuids.map(function(guid){
 });
 
 module.exports.spaces = spaces;
+
+var users = userGuids.map(function(guid, i) {
+  return {
+    metadata: {
+      guid: guid,
+      url: `${URL_BASE}/users/${guid}`,
+      created_at: "2015-02-19T08:46:28Z",
+      updated_at: null
+    },
+    entity: {
+      admin: (i === 0) ? true : false,
+      active: true,
+      default_space_guid: null,
+      username: `user-${guid}`,
+      organization_roles: [ 'org_user' ],
+      spaces_url: `${URL_BASE}/users/${guid}/spaces`,
+      organizations_url: `${URL_BASE}/users/${guid}/organizations`,
+      managed_organizations_url: `${URL_BASE}/users/${guid}/managed_organizations_url`,
+      billing_managed_organizations_url: `${URL_BASE}/users/${guid}/billing_managed_organizations`,
+      audited_organizations_url: `${URL_BASE}/users/${guid}/audited_organizations`,
+      managed_spaces_url: `${URL_BASE}/users/${guid}/managed_spaces`,
+      audited_spaces_url: `${URL_BASE}/users/${guid}/audited_spaces`
+    }
+  }
+});
+
+module.exports.users = users;

--- a/test/server.js
+++ b/test/server.js
@@ -1,0 +1,30 @@
+var path = require('path');
+
+var smocks = require('smocks');
+
+var authstatus = require('./authstatus');
+var api = require('./api');
+
+smocks.id('cg-deck-testing');
+
+// add auth status route
+authstatus(smocks);
+// add all api routes
+api(smocks);
+
+// serve static assets from /static
+smocks.route({
+  id: 'app',
+  label: 'Front end assets',
+  path: '/{p*}',
+  handler: function (req, reply) {
+    var url = (req.params.p) ? req.params.p : 'index.html';
+    reply.file(path.resolve(__dirname, '../static', url));
+  }
+});
+
+// now start the server
+require('smocks/hapi').start({
+  port: 8000,
+  host: 'localhost'
+});


### PR DESCRIPTION
Adds the `smocks` library to serve mocked data through the API with the goal of making functional tests run with a predictable state (refs #262), but another benefit of this approach is that it enables folks to get the repo set up locally without needing to follow any of the instructions for Go (which can be pretty confusing such as #386).

There are still some endpoints to be mocked out (such as the "Marketplace" view endpoints), but we want to merge it now because it really simplifies getting the application set up locally for front end development.