### PR TITLE
Fix accessibility errors for the service instance creation form 

### DIFF
--- a/static_src/components/button.jsx
+++ b/static_src/components/button.jsx
@@ -21,8 +21,9 @@ export default class Button extends React.Component {
 
   render() {
     var classes = classNames(...this.props.classes);
+    let type = this.props.type || 'button';
     return (
-      <button type="button" className={ classes }
+      <button type={ type } className={ classes }
           aria-label={ this.props.label } onClick={ this._handleClick }
           disabled={this.props.disabled}>
         { this.props.children }
@@ -35,6 +36,7 @@ Button.propTypes = {
   classes: React.PropTypes.array,
   label: React.PropTypes.string,
   onClickHandler: React.PropTypes.func,
+  type: React.PropTypes.string,
   disabled: React.PropTypes.bool
 };
 

--- a/static_src/components/button.jsx
+++ b/static_src/components/button.jsx
@@ -20,8 +20,8 @@ export default class Button extends React.Component {
   }
 
   render() {
-    var classes = classNames(...this.props.classes);
-    let type = this.props.type || 'button';
+    const classes = classNames(...this.props.classes);
+    const type = this.props.type;
     return (
       <button type={ type } className={ classes }
           aria-label={ this.props.label } onClick={ this._handleClick }
@@ -42,7 +42,8 @@ Button.propTypes = {
 
 Button.defaultProps = {
   classes: [],
+  disabled: false,
   label: '',
-  onClickHandler: function() { return true; },
-  disabled: false
+  onClickHandler: () => true,
+  type: 'button'
 };

--- a/static_src/components/create_service_instance.jsx
+++ b/static_src/components/create_service_instance.jsx
@@ -93,27 +93,29 @@ export default class CreateServiceInstance extends React.Component {
 
     return (
       <div className = { this.styler('actions-large') }>
-        <h4>Create service instance for <strong
-          className={this.styler('actions-callout-inline-block') }>
-          { this.serviceName }</strong> using <strong
-          className={this.styler('actions-callout-inline-block')}>
-          { this.servicePlanName }</strong> plan.
-        </h4>
         { createError }
         <Form action="/service_instances"
-            classes={ ["test-create_service_instance_form"] }
-            method="post"
-            ref="form"
-            onValidate={ this._onValidateForm }
-            onValid={ this._onValidForm }>
+          classes={ ['test-create_service_instance_form'] }
+          method="post"
+          ref="form"
+          onValidate={ this._onValidateForm }
+          onValid={ this._onValidForm }
+        >
+          <legend>
+            Create a service instance for <strong
+              className={this.styler('actions-callout-inline-block') }>
+            { this.serviceName }</strong> using <strong
+              className={this.styler('actions-callout-inline-block')}>
+            { this.servicePlanName }</strong> plan.
+          </legend>
           <FormText
-            classes={ ["test-create_service_instance_name"] }
+            classes={ ['test-create_service_instance_name'] }
             label="Choose a name for the service"
             name="name"
             validator={ FormElement.validatorString }
           />
           <FormSelect
-            classes={ ["test-create_service_instance_space"] }
+            classes={ ['test-create_service_instance_space'] }
             label="Choose a name for the service"
             label="Select the space for the service instance"
             name="space"
@@ -122,9 +124,9 @@ export default class CreateServiceInstance extends React.Component {
             })}
             validator={ FormElement.validatorString }
           />
-          <Button name="submit">Create service instance</Button>
-          <Button name="cancel" classes={ [this.styler("button-cancel")] }
-            onClickHandler={this._onCancelForm.bind(this)}>
+          <Button name="submit" type="submit">Create service instance</Button>
+          <Button name="cancel" classes={ [this.styler('button-cancel')] }
+            onClickHandler={ this._onCancelForm.bind(this) }>
             Cancel
           </Button>
         </Form>

--- a/static_src/components/create_service_instance.jsx
+++ b/static_src/components/create_service_instance.jsx
@@ -8,13 +8,13 @@ import ReactDOM from 'react-dom';
 import Box from './box.jsx';
 import Button from './button.jsx';
 import { Form, FormText, FormSelect, FormElement, FormError } from './form.jsx';
+import OrgStore from '../stores/org_store.js';
 import SpaceStore from '../stores/space_store.js';
 import ServiceInstanceStore from '../stores/service_instance_store.js';
 import serviceActions from '../actions/service_actions.js';
 import actionStyle from 'cloudgov-style/css/components/actions.css';
 import baseStyle from 'cloudgov-style/css/base.css';
 import createStyler from '../util/create_styler';
-
 
 function stateSetter() {
   return {
@@ -85,6 +85,7 @@ export default class CreateServiceInstance extends React.Component {
   }
 
   render() {
+    const currentOrgGuid = OrgStore.currentOrgGuid;
     let createError;
 
     if (this.state.createError) {
@@ -119,7 +120,9 @@ export default class CreateServiceInstance extends React.Component {
             label="Choose a name for the service"
             label="Select the space for the service instance"
             name="space"
-            options={ this.state.spaces.map((space) => {
+            options={ this.state.spaces.filter((space) => {
+              return space.org === currentOrgGuid;
+            }).map((space) => {
               return { value: space.guid, label: space.name };
             })}
             validator={ FormElement.validatorString }

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -76,6 +76,7 @@ function app(orgGuid, spaceGuid, appGuid) {
 function marketplace(orgGuid, serviceGuid, servicePlanGuid) {
   cfApi.fetchOrg(orgGuid);
   cfApi.fetchAllServices(orgGuid);
+  orgActions.changeCurrentOrg(orgGuid);
   if (serviceGuid && servicePlanGuid) {
     serviceActions.createInstanceForm(serviceGuid, servicePlanGuid);
   }

--- a/static_src/stores/space_store.js
+++ b/static_src/stores/space_store.js
@@ -19,9 +19,13 @@ class SpaceStore extends BaseStore {
   _registerToActions(action) {
     switch (action.type) {
       case orgActionTypes.ORG_RECEIVED: {
-        const spaces = action.org.spaces;
-        if (spaces) {
-          this.mergeMany('guid', spaces, (changed) => {
+        const spaces = action.org.spaces || [];
+        const spacesWithOrgGuid = spaces.map((space) => {
+          const org = { org: action.org.guid };
+          return Object.assign({}, space, org);
+        });
+        if (spacesWithOrgGuid.length > 0) {
+          this.mergeMany('guid', spacesWithOrgGuid, (changed) => {
             if (changed) this.emitChange();
           });
         }

--- a/static_src/test/unit/stores/space_store.spec.js
+++ b/static_src/test/unit/stores/space_store.spec.js
@@ -28,11 +28,31 @@ describe('SpaceStore', function() {
   });
 
   describe('on org actions org received', function() {
+    it('should include the org guid in the space', function () {
+      var spaceGuid = 'spaceGuid';
+      var orgGuid = 'orgGuid';
+      var org = {
+        guid: orgGuid,
+        spaces: [
+          { guid: spaceGuid }
+        ]
+      };
+      var expected = {
+        guid: spaceGuid,
+        org: orgGuid
+      };
+
+      orgActions.receivedOrg(org);
+
+      expect(SpaceStore.getAll().pop()).toEqual(expected);
+    });
+
     it('should merge the org spaces data in with any current spaces', function() {
+      var orgGuid = 'adsfadzcxvzdfaew';
       var expectedSpace = { guid: 'adfadsbcvbqwrsdfadsf32' };
       var existingSpace = { guid: 'xczczxczczxcv2' };
       var org = {
-        guid: 'adsfadzcxvzdfaew',
+        guid: orgGuid,
         spaces: [expectedSpace]
       };
 
@@ -40,7 +60,7 @@ describe('SpaceStore', function() {
       orgActions.receivedOrg(org);
 
       expect(SpaceStore.getAll().length).toEqual(2);
-      expect(SpaceStore.get(expectedSpace.guid)).toEqual(expectedSpace);
+      expect(SpaceStore.get(expectedSpace.guid).org).toEqual(orgGuid);
     });
 
     it('should emit a change event if there are spaces', function() {


### PR DESCRIPTION
The criteria in #373 are:

0. Dropdown options should be grouped with optgroup.
0. Fieldset should contain a legend element.
0. Field set element must have an accessible name.
0. Form should have some sort of submit element.

**Dropdown options should be grouped with optgroup.**
I didn't implement this requirement. Instead, I altered the space store to keep a reference of the parent org on each store and the service instance creation form in the marketplace only shows spaces for the current organization. This was preferable because the "Marketplace" view (on which the service instance creation form resides) is a child view of an organization. Therefore, it didn't make sense to show spaces that are in other organizations in this view.

**Fieldset should contain a legend element.**
I converted the former `<h4>` into a legend element (f1ddc039b2ebf0ea6a3cc9d1cd5f9983c91e29a8)

**Field set element must have an accessible name.**
I never saw this error using `HTML_CodeSniffer`. Maybe adding a `<legend>` fixed it.

**Form should have some sort of submit element.**
The `<Button />` component was modified to accept a `type` property (d0e9f580dd1ea0f7b63606c13687384a50e80d83) and the form button was given a "submit" type (f9092092426065a834512d7055421041727a9c65).