### PR TITLE
Updating notice to reflect new switchover plan

### DIFF
--- a/static/app/views/dashboard.html
+++ b/static/app/views/dashboard.html
@@ -2,6 +2,6 @@
   <div class="jumbotron text-center">
       <h3>Welcome to CG-Deck</h3>
       <p>Pick an organization to get started</p>
-      <p>We’re updating the Deck (soon to be the Dashboard) next week, so here’s what to expect! We’re switching to a new codebase that is more flexible and has better tests, so we can change it much faster than we could with the current Deck. It’ll match cloud.gov’s style and navigation! Initially it’ll be missing some of the Deck’s current options for managing apps, and the user experience will need more work; we’ll improve it based on research and use. You can see <a href="https://console-staging.cloud.gov/">an in-progress preview</a> (and <href="https://github.com/18F/cg-deck/issues">our issue list</a>). Let us know at cloud-gov-support@gsa.gov or <a href="https://18f.slack.com/messages/cloud-gov-liberator/">#cloud-gov-liberator</a> if you have questions.</p>
+      <p>We've released a new version of the Deck! Switch over to the new <a href="https://dashboard.cloud.gov/">Dashboard</a> and read the <a href="https://cloud.gov/updates/">update about what's new and different</a>. We'll redirect this Deck to that new Dashboard on approximately July 11, so please let us know at cloud-gov-support@gsa.gov or <a href="https://18f.slack.com/messages/cloud-gov-liberator/">#cloud-gov-liberator</a> if you have questions or if that would cause problems for you.</p>
   </div>
 </div>


### PR DESCRIPTION
Since we changed our plan for switching to the new version of the Deck/Dashboard, here's a new notice, to be posted on the day that we switch these things. The old text is no longer accurate.