### PR TITLE
Create service bug

### DIFF
--- a/static_src/actions/service_actions.js
+++ b/static_src/actions/service_actions.js
@@ -82,6 +82,13 @@ export default {
     });
   },
 
+  receivedInstance(serviceInstance) {
+    AppDispatcher.handleServerAction({
+      type: serviceActionTypes.SERVICE_INSTANCE_RECEIVED,
+      serviceInstance: serviceInstance
+    });
+  },
+
   receivedInstances(serviceInstances) {
     AppDispatcher.handleServerAction({
       type: serviceActionTypes.SERVICE_INSTANCES_RECEIVED,

--- a/static_src/constants.js
+++ b/static_src/constants.js
@@ -57,6 +57,8 @@ const serviceActionTypes = keymirror({
   SERVICE_INSTANCE_DELETED: null,
   // Action to fetch a all service instances from the server.
   SERVICE_INSTANCES_FETCH: null,
+  // Action when service instance was received from the server.
+  SERVICE_INSTANCE_RECEIVED: null,
   // Action when all service instances were received from the server.
   SERVICE_INSTANCES_RECEIVED: null,
   // Action to open UI to create a service instance.

--- a/static_src/stores/service_instance_store.js
+++ b/static_src/stores/service_instance_store.js
@@ -69,6 +69,7 @@ class ServiceInstanceStore extends BaseStore {
       }
 
       case serviceActionTypes.SERVICE_INSTANCE_CREATED: {
+        cfApi.fetchServiceInstance(action.serviceInstance.guid);
         this._createInstanceForm = null;
         this.emitChange();
         break;

--- a/static_src/stores/service_instance_store.js
+++ b/static_src/stores/service_instance_store.js
@@ -37,6 +37,15 @@ class ServiceInstanceStore extends BaseStore {
         break;
       }
 
+      case serviceActionTypes.SERVICE_INSTANCE_RECEIVED: {
+        const instance = this.formatSplitResponse(
+          [action.serviceInstance])[0];
+        this.merge('guid', instance, (changed) => {
+          if (changed) this.emitChange();
+        });
+        break;
+      }
+
       case serviceActionTypes.SERVICE_INSTANCES_RECEIVED: {
         const services = this.formatSplitResponse(action.serviceInstances);
         this._data = Immutable.fromJS(services);

--- a/static_src/stores/service_instance_store.js
+++ b/static_src/stores/service_instance_store.js
@@ -78,7 +78,7 @@ class ServiceInstanceStore extends BaseStore {
       }
 
       case serviceActionTypes.SERVICE_INSTANCE_CREATED: {
-        cfApi.fetchServiceInstance(action.serviceInstance.guid);
+        cfApi.fetchServiceInstance(action.serviceInstance.metadata.guid);
         this._createInstanceForm = null;
         this.emitChange();
         break;

--- a/static_src/stores/service_instance_store.js
+++ b/static_src/stores/service_instance_store.js
@@ -69,12 +69,8 @@ class ServiceInstanceStore extends BaseStore {
       }
 
       case serviceActionTypes.SERVICE_INSTANCE_CREATED: {
-        this.merge('guid', action.serviceInstance, (changed) => {
-          if (!changed) return;
-
-          this._createInstanceForm = null;
-          this.emitChange();
-        });
+        this._createInstanceForm = null;
+        this.emitChange();
         break;
       }
 

--- a/static_src/test/unit/actions/service_actions.spec.js
+++ b/static_src/test/unit/actions/service_actions.spec.js
@@ -188,6 +188,31 @@ describe('serviceActions', function() {
 
   describe('receivedInstance()', function() {
     it('should dispatch a server event of type service instance resv with ' +
+       'the service instance', function() {
+      const expected = {
+        metadata: {
+          guid: 'afds'
+        },
+        entity: {
+          type: 'someasdf'
+        }
+      };
+
+      let expectedParams = {
+        serviceInstance: expected
+      }
+
+      let spy = setupServerSpy(sandbox)
+
+      serviceActions.receivedInstance(expected);
+
+      assertAction(spy, serviceActionTypes.SERVICE_INSTANCE_RECEIVED,
+                   expectedParams);
+    });
+  });
+
+  describe('receivedInstances()', function() {
+    it('should dispatch a server event of type service instance resv with ' +
        'the service instances', function() {
       var expected = [
         { metadata: {

--- a/static_src/test/unit/stores/service_instance_store.spec.js
+++ b/static_src/test/unit/stores/service_instance_store.spec.js
@@ -174,6 +174,17 @@ describe('ServiceInstanceStore', function() {
   });
 
   describe('on sevice instance created', function() {
+    it('should fetch the created instance with guid', function() {
+      const spy = sandbox.spy(cfApi, 'fetchServiceInstance');
+      const expectedGuid = 'akdfjzxcv32dfmnv23';
+
+      serviceActions.createdInstance({ guid: expectedGuid });
+
+      expect(spy).toHaveBeenCalledOnce();
+      let arg = spy.getCall(0).args[0];
+      expect(arg).toEqual(expectedGuid);
+    });
+
     it('emits a change event', function() {
       var spy = sandbox.spy(ServiceInstanceStore, 'emitChange');
 

--- a/static_src/test/unit/stores/service_instance_store.spec.js
+++ b/static_src/test/unit/stores/service_instance_store.spec.js
@@ -60,6 +60,33 @@ describe('ServiceInstanceStore', function() {
   });
 
   describe('on service instances received', function() {
+    it('should merge in the service instance', function() {
+      const spy = sandbox.spy(ServiceInstanceStore, 'merge');
+      const instance = {
+        metadata: {
+          guid: 'zxmcvn23vlkxmcvn'
+        },
+        entity: {
+          name: 'testa'
+        }
+      };
+      const expected = unwrapOfRes([instance])[0];
+
+      serviceActions.receivedInstance(instance);
+
+      expect(spy).toHaveBeenCalledOnce();
+      let arg1 = spy.getCall(0).args[0];
+      let arg2 = spy.getCall(0).args[1];
+      expect(arg1).toEqual('guid');
+      expect(arg2).toEqual(expected);
+    });
+
+    it('should emit a change event', function() {
+
+    });
+  });
+
+  describe('on service instances received', function() {
     it('should set data to unwrapped, passed in instances', function() {
       var expected = [
         {

--- a/static_src/test/unit/stores/service_instance_store.spec.js
+++ b/static_src/test/unit/stores/service_instance_store.spec.js
@@ -174,33 +174,6 @@ describe('ServiceInstanceStore', function() {
   });
 
   describe('on sevice instance created', function() {
-    it('should add received instance to the data', function() {
-      var expectedInstance = { guid: 'asdf9a8fasss' };
-
-      ServiceInstanceStore.push({ guid: 'zzxcvz' });
-
-      serviceActions.createdInstance(expectedInstance);
-
-      expect(ServiceInstanceStore.get(expectedInstance.guid)).toEqual(
-        expectedInstance);
-    });
-
-    it('theres a store with the same guid, it should update that store',
-        function() {
-      var expectedInstance = { guid: 'asdf9a8fasss', name: 'nameA' };
-
-      ServiceInstanceStore._data.push(expectedInstance);
-
-      let newInstance = Object.assign({}, expectedInstance);
-      newInstance.name = 'nameB';
-
-      serviceActions.createdInstance(newInstance);
-
-      expect(ServiceInstanceStore.getAll().length).toEqual(1);
-      let actual = ServiceInstanceStore.get(expectedInstance.guid);
-      expect(actual.name).toEqual(newInstance.name);
-    });
-
     it('emits a change event', function() {
       var spy = sandbox.spy(ServiceInstanceStore, 'emitChange');
 

--- a/static_src/test/unit/stores/service_instance_store.spec.js
+++ b/static_src/test/unit/stores/service_instance_store.spec.js
@@ -205,7 +205,7 @@ describe('ServiceInstanceStore', function() {
       const spy = sandbox.spy(cfApi, 'fetchServiceInstance');
       const expectedGuid = 'akdfjzxcv32dfmnv23';
 
-      serviceActions.createdInstance({ guid: expectedGuid });
+      serviceActions.createdInstance({ metadata: {guid: expectedGuid }});
 
       expect(spy).toHaveBeenCalledOnce();
       let arg = spy.getCall(0).args[0];
@@ -215,7 +215,7 @@ describe('ServiceInstanceStore', function() {
     it('emits a change event', function() {
       var spy = sandbox.spy(ServiceInstanceStore, 'emitChange');
 
-      serviceActions.createdInstance({ guid: 'adsfavzxc' });
+      serviceActions.createdInstance({ metadata: {guid: 'adsfavzxc' }});
 
       expect(spy).toHaveBeenCalledOnce();
     });
@@ -223,7 +223,8 @@ describe('ServiceInstanceStore', function() {
     it('should set form to nothing', function() {
       ServiceInstanceStore._createInstanceForm = { service: {} };
       expect(ServiceInstanceStore.createInstanceForm).toBeTruthy();
-      serviceActions.createdInstance({ guid: 'asdf9a8fasss', name: 'nameA' });
+      serviceActions.createdInstance(
+        { metadata: { guid: 'asdf9a8fasss', name: 'nameA' }});
 
       expect(ServiceInstanceStore.createInstanceForm).toBeFalsy();
     });

--- a/static_src/test/unit/util/cf_api.spec.js
+++ b/static_src/test/unit/util/cf_api.spec.js
@@ -304,6 +304,23 @@ describe('cfApi', function() {
     });
   });
 
+  describe('fetchServiceInstance()', function() {
+    it('should call fetch with spaces service instances url and recevied space',
+        function() {
+      var expected = '2qpofhskjdf',
+          spy = sandbox.stub(cfApi, 'fetchOne');
+
+      cfApi.fetchServiceInstance(expected);
+
+      expect(spy).toHaveBeenCalledOnce();
+      let actual = spy.getCall(0).args[0];
+      expect(actual).toMatch(new RegExp(expected));
+      expect(actual).toMatch(new RegExp('service_instances'));
+      actual = spy.getCall(0).args[1];
+      expect(actual).toEqual(serviceActions.receivedInstance);
+    });
+  });
+
   describe('fetchServiceInstances()', function() {
     it('should call fetch with spaces service instances url and recevied space',
         function() {

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -110,6 +110,11 @@ export default {
                          spaceActions.receivedSpace);
   },
 
+  fetchServiceInstance(instanceGuid) {
+    return this.fetchOne(`/service_instances/${instanceGuid}`,
+                          serviceActions.receivedInstance);
+  },
+
   fetchServiceInstances(spaceGuid) {
     return this.fetchMany(`/spaces/${spaceGuid}/service_instances`,
                           serviceActions.receivedInstances);


### PR DESCRIPTION
There was a bug where if you create a service instance and then go to the service instances page, it would fail because of missing data for `updated_at` and `created_at`. This is because in the CF API, when you create a service instance, it delivers back an incomplete representation of it.

I solved this by just fetching the service instance from the server rather then trying to deal with the incomplete one. I did this because it's easier to reason about a complete object that has the same format rather then trying to deal with a differently formatted object, which would split the logic of the codebase.

ref #403