### PR TITLE
Fix false positive for tests

### DIFF
--- a/helpers/testhelpers/testhelpers.go
+++ b/helpers/testhelpers/testhelpers.go
@@ -120,6 +120,7 @@ type BasicSecureTest struct {
 	BasicConsoleUnitTest
 	ExpectedCode     int
 	ExpectedResponse string
+	ExpectedLocation string
 }
 
 // BasicProxyTest contains information for what our test 'external' server should do when the proxy methods contact it.


### PR DESCRIPTION
Addresses #404 

There are now two functions
testCmd will just check for the error code of the command.
testCmdOutput will wrap a command in `fgt`. This is useful for commands
that may not return non-zero themselves but will just output something
an error. fgt will take any output and say its non zero.

Also fix the tests from regression from #365