### PR TITLE
Change "Deck" to "Dashboard" 

### DIFF
--- a/static_src/components/login.jsx
+++ b/static_src/components/login.jsx
@@ -9,7 +9,7 @@ export default class Login extends React.Component {
   render() {
     return (
     <div>
-      <h1>Welcome to Cf-Deck</h1>
+      <h1>Welcome to Cloud.gov Dashboard</h1>
       <a href="/handshake" className="test-login">
         Login</a>
       <div className="text-right">

--- a/static_src/components/login.jsx
+++ b/static_src/components/login.jsx
@@ -9,7 +9,7 @@ export default class Login extends React.Component {
   render() {
     return (
     <div>
-      <h1>Welcome to Cloud.gov Dashboard</h1>
+      <h1>Welcome to the Dashboard</h1>
       <a href="/handshake" className="test-login">
         Login</a>
       <div className="text-right">


### PR DESCRIPTION
Per content guidelines outlined here, "Deck" should be changed to "Dashboard" throughout various applications under cloud.gov

Refs https://github.com/18F/cg-deck/issues/333#issuecomment-229223814