### PR TITLE
Change console to dashboard in package.json description

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "node": "4.2.3",
     "npm": "2.14.x"
   },
-  "description": "A web console for managing Cloud Foundry apps",
+  "description": "A web dashboard for managing Cloud Foundry apps",
   "main": "null",
   "scripts": {
     "build": "npm run clean && node_modules/webpack/bin/webpack.js",


### PR DESCRIPTION
The description in the `package.json` was out of date, as it used the word "console". This changes the description to use "dashboard" instead.