### PR TITLE
Limit current user actions

### DIFF
--- a/static_src/actions/user_actions.js
+++ b/static_src/actions/user_actions.js
@@ -120,5 +120,13 @@ export default {
       type: userActionTypes.USER_CHANGE_VIEWED_TYPE,
       userType
     });
+  },
+
+  receivedCurrentUserInfo(user) {
+    AppDispatcher.handleServerAction({
+      type: userActionTypes.CURRENT_USER_INFO_RECEIVED,
+      currentUser: user
+    });
   }
+
 };

--- a/static_src/components/user_list.jsx
+++ b/static_src/components/user_list.jsx
@@ -117,6 +117,7 @@ export default class UserList extends React.Component {
                 <td column="Permissions" key={ `${user.guid}-role` }>
                   <UserRoleListControl
                     initialUserType={ this.state.userType }
+                    initialCurrentUserAccess={ this.state.currentUserAccess }
                     onAddPermissions={ this.props.onAddPermissions }
                     onRemovePermissions={ this.props.onRemovePermissions }
                     user={ user }

--- a/static_src/components/user_list.jsx
+++ b/static_src/components/user_list.jsx
@@ -21,15 +21,19 @@ export default class UserList extends React.Component {
     this.props = props;
     this.state = {
       users: props.initialUsers,
-      userType: props.initialUserType
+      userType: props.initialUserType,
+      currentUserAccess: props.initialCurrentUserAccess
     };
     this.styler = createStyler(baseStyles, navStyles);
     this._handleDelete = this._handleDelete.bind(this);
   }
 
   componentWillReceiveProps(nextProps) {
-    this.setState({ users: nextProps.initialUsers,
-      userType: nextProps.initialUserType });
+    this.setState({
+      users: nextProps.initialUsers,
+      userType: nextProps.initialUserType,
+      currentUserAccess: nextProps.initialCurrentUserAccess
+    });
   }
 
   _handleDelete(userGuid, ev) {
@@ -90,15 +94,21 @@ export default class UserList extends React.Component {
           { this.state.users.map((user) => {
             let actions;
             if (this.props.onRemove) {
-              actions = (
-                <td column="Actions">
+              let button = <span></span>;
+              if (this.state.currentUserAccess) {
+                button = (
                   <Button
                     classes={[this.styler('usa-button-secondary')]}
                     onClickHandler={ this._handleDelete.bind(this, user.guid) }
                     label="delete">
                     <span>Remove User From Org</span>
                   </Button>
-                  </td>
+                );
+              }
+              actions = (
+                <td column="Actions" style={{ width: '14rem' }}>
+                  { button }
+                </td>
               );
             }
             return ([
@@ -115,8 +125,8 @@ export default class UserList extends React.Component {
                 <td column="Date Created">{ formatDateTime(user.created_at) }</td>
                 { actions }
               </tr>
-            ]);
-          })}
+              ]);
+            })}
           </tbody>
         </table>
       </div>
@@ -135,6 +145,7 @@ export default class UserList extends React.Component {
 UserList.propTypes = {
   initialUsers: React.PropTypes.array,
   initialUserType: React.PropTypes.string,
+  initialCurrentUserAccess: React.PropTypes.bool,
   // Set to a function when there should be a remove button.
   onRemove: React.PropTypes.func,
   onRemovePermissions: React.PropTypes.func,
@@ -143,5 +154,6 @@ UserList.propTypes = {
 
 UserList.defaultProps = {
   initialUsers: [],
-  initialUserType: 'space_users'
+  initialUserType: 'space_users',
+  initialCurrentUserAccess: false
 };

--- a/static_src/components/user_role_control.jsx
+++ b/static_src/components/user_role_control.jsx
@@ -6,13 +6,17 @@ export default class UserRoleControl extends React.Component {
     super(props);
     this.props = props;
     this.state = {
-      checked: props.initialValue
+      checked: props.initialValue,
+      enableControl: props.initialEnableControl
     };
     this._handleChange = this._handleChange.bind(this);
   }
 
   componentWillReceiveProps(nextProps) {
-    this.setState({checked: nextProps.initialValue});
+    this.setState({
+      checked: nextProps.initialValue,
+      enableControl: nextProps.initialEnableControl
+    });
   }
 
   _handleChange(ev) {
@@ -27,6 +31,7 @@ export default class UserRoleControl extends React.Component {
             onChange={ this._handleChange }
             name={ this.props.roleKey }
             checked={ this.state.checked }
+            disabled={ !this.state.enableControl }
             id={ this.props.roleKey + this.props.userId }
           />
           { this.props.roleName }
@@ -39,9 +44,11 @@ UserRoleControl.propTypes = {
   roleName: React.PropTypes.string.isRequired,
   roleKey: React.PropTypes.string.isRequired,
   initialValue: React.PropTypes.bool,
+  initialEnableControl: React.PropTypes.bool,
   onChange: React.PropTypes.func
 };
 UserRoleControl.defaultProps = {
   initialValue: false,
+  initialEnableControl: false,
   onChange: function() { }
 }

--- a/static_src/components/user_role_list_control.jsx
+++ b/static_src/components/user_role_list_control.jsx
@@ -35,7 +35,8 @@ export default class UserRoleListControl extends React.Component {
     this.props = props;
     this.state = {
       user: props.user,
-      userType: props.initialUserType
+      userType: props.initialUserType,
+      currentUserAccess: props.initialCurrentUserAccess
     };
     this._onChange = this._onChange.bind(this);
     this.checkRole = this.checkRole.bind(this);
@@ -44,7 +45,8 @@ export default class UserRoleListControl extends React.Component {
   componentWillReceiveProps(nextProps) {
     this.setState({
       user: nextProps.user,
-      userType: nextProps.initialUserType
+      userType: nextProps.initialUserType,
+      currentUserAccess: nextProps.initialCurrentUserAccess
     });
   }
 
@@ -81,6 +83,7 @@ export default class UserRoleListControl extends React.Component {
             roleName={ role.label }
             roleKey={ role.key }
             initialValue={ this.checkRole(role.key) }
+            initialEnableControl={ this.state.currentUserAccess }
             onChange={ this._onChange.bind(this, role.key) }
             userId={ this.props.user.guid }
           />
@@ -93,11 +96,13 @@ export default class UserRoleListControl extends React.Component {
 UserRoleListControl.propTypes = {
   user: React.PropTypes.object.isRequired,
   initialUserType: React.PropTypes.string,
+  initialCurrentUserAccess: React.PropTypes.bool,
   onRemovePermissions: React.PropTypes.func,
-  onAddPermissions: React.PropTypes.func
+  onAddPermissions: React.PropTypes.func,
 };
 UserRoleListControl.defaultProps = {
   initialUserType: 'space_users',
+  initialCurrentUserAccess: false,
   onRemovePermissions: function defaultRemove() { },
   onAddPermissions: function defaultAdd() { }
 };

--- a/static_src/components/users.jsx
+++ b/static_src/components/users.jsx
@@ -18,15 +18,19 @@ const TAB_ORG_NAME = 'org_users';
 function stateSetter(currentState) {
   let users = [];
   const currentTab = UserStore.currentlyViewedType;
+  let currentUserAccess: false;
+
   if (currentTab === TAB_SPACE_NAME) {
     users = UserStore.getAllInSpace(currentState.currentSpaceGuid);
+    currentUserAccess = UserStore.currentUserHasSpaceRole('space_manager');
   } else {
     users = UserStore.getAllInOrg(currentState.currentOrgGuid);
+    currentUserAccess = UserStore.currentUserHasOrgRole('org_manager');
   }
 
   return {
     error: UserStore.getError(),
-    currentUserAccess: UserStore.currentUserHasOrgRole('org_manager'),
+    currentUserAccess: currentUserAccess,
     currentTab,
     loading: UserStore.fetching,
     users
@@ -131,6 +135,11 @@ export default class Users extends React.Component {
   render() {
     let removeHandler;
     let errorMessage;
+
+    if (this.state.currentTab === TAB_ORG_NAME) {
+      removeHandler = this.handleRemove;
+    }
+
     let content = (<UserList
       initialUsers={ this.state.users }
       initialUserType= { this.state.currentTab }
@@ -139,10 +148,6 @@ export default class Users extends React.Component {
       onAddPermissions={ this.handleAddPermissions }
       onRemovePermissions={ this.handleRemovePermissions }
     />);
-
-    if (this.state.currentTab === TAB_ORG_NAME) {
-      removeHandler = this.handleRemove;
-    }
 
     if (this.state.loading) {
       content = <Loading text="Loading users" />;

--- a/static_src/components/users.jsx
+++ b/static_src/components/users.jsx
@@ -26,6 +26,7 @@ function stateSetter(currentState) {
 
   return {
     error: UserStore.getError(),
+    currentUserAccess: UserStore.currentUserHasOrgRole('org_manager'),
     currentTab,
     loading: UserStore.fetching,
     users
@@ -41,6 +42,7 @@ export default class Users extends React.Component {
       currentSpaceGuid: props.initialSpaceGuid,
       currentTab: props.initialCurrentTab,
       loading: UserStore.fetching,
+      currentUserAccess: UserStore.currentUserHasOrgRole('org_manager'),
       users: (props.initialCurrentTab === TAB_ORG_NAME) ?
         UserStore.getAllInOrg(props.initialOrgGuid) :
         UserStore.getAllInSpace(props.initialSpaceGuid)
@@ -132,6 +134,7 @@ export default class Users extends React.Component {
     let content = (<UserList
       initialUsers={ this.state.users }
       initialUserType= { this.state.currentTab }
+      initialCurrentUserAccess={ this.state.currentUserAccess }
       onRemove={ removeHandler }
       onAddPermissions={ this.handleAddPermissions }
       onRemovePermissions={ this.handleRemovePermissions }

--- a/static_src/constants.js
+++ b/static_src/constants.js
@@ -120,7 +120,9 @@ const userActionTypes = keymirror({
   // Action when there's an error when trying to remove a user.
   ERROR_REMOVE_USER: null,
   // Action when the type of users being looked at changes
-  USER_CHANGE_VIEWED_TYPE: null
+  USER_CHANGE_VIEWED_TYPE: null,
+  // Action when current user info received from server.
+  CURRENT_USER_INFO_RECEIVED: null
 });
 
 const routeActionTypes = keymirror({

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -20,6 +20,7 @@ import serviceActions from './actions/service_actions.js';
 import Space from './components/space.jsx';
 import SpaceList from './components/space_list.jsx';
 import { trackPageView } from './util/analytics.js';
+import uaaApi from './util/uaa_api.js';
 import userActions from './actions/user_actions.js';
 
 const mainEl = document.querySelector('.js-app');
@@ -98,7 +99,9 @@ function marketplace(orgGuid, serviceGuid, servicePlanGuid) {
 }
 
 function checkAuth() {
-  cfApi.getAuthStatus();
+  cfApi.getAuthStatus().then(() => {
+    uaaApi.fetchUserInfo();
+  });
   orgActions.fetchAll();
 }
 

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -250,10 +250,18 @@ class UserStore extends BaseStore {
     return this._currentViewedType;
   }
 
-  currentUserHasOrgRole(role) {
+  _hasRole(roleToCheck, userType) {
     const user = this.currentUser;
     if (!user) return false;
-    return !!(user.organization_roles.find((orgRole) => orgRole === role));
+    return !!(user[userType].find((role) => role === roleToCheck));
+  }
+
+  currentUserHasSpaceRole(role) {
+    return this._hasRole(role, 'space_roles');
+  }
+
+  currentUserHasOrgRole(role) {
+    return this._hasRole(role, 'organization_roles');
   }
 
   get currentUser() {

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -250,6 +250,12 @@ class UserStore extends BaseStore {
     return this._currentViewedType;
   }
 
+  currentUserHasOrgRole(role) {
+    const user = this.currentUser;
+    if (!user) return false;
+    return !!(user.organization_roles.find((orgRole) => orgRole === role));
+  }
+
   get currentUser() {
     return this.get(this._currentUserGuid);
   }

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -31,6 +31,7 @@ class UserStore extends BaseStore {
     this.subscribe(() => this._registerToActions.bind(this));
     this._data = new Immutable.List();
     this._currentViewedType = 'space_users';
+    this._currentUserGuid = null;
     this._error = null;
   }
 
@@ -194,6 +195,15 @@ class UserStore extends BaseStore {
         break;
       }
 
+      case userActionTypes.CURRENT_USER_INFO_RECEIVED: {
+        const user = this.get(action.currentUser.user_id);
+        if (user) {
+          this._currentUserGuid = user.guid;
+          this.emitChange();
+        }
+        break;
+      }
+
       case userActionTypes.USER_CHANGE_VIEWED_TYPE: {
         if (this._currentViewedType !== action.userType) {
           this._currentViewedType = action.userType;
@@ -238,6 +248,10 @@ class UserStore extends BaseStore {
 
   get currentlyViewedType() {
     return this._currentViewedType;
+  }
+
+  get currentUser() {
+    return this.get(this._currentUserGuid);
   }
 
 }

--- a/static_src/test/unit/actions/user_actions.spec.js
+++ b/static_src/test/unit/actions/user_actions.spec.js
@@ -283,4 +283,19 @@ describe('userActions', function() {
         expectedParams);
     });
   });
+
+  describe('receivedCurrentUserInfo()', function() {
+    it('should call a server action with user object passed in', function() {
+      const user = { user_id: 'zcxvkjadsuf', user_name: 'john' };
+      const expectedParams = {
+        currentUser: user
+      };
+      let spy = setupServerSpy(sandbox);
+
+      userActions.receivedCurrentUserInfo(user);
+
+      assertAction(spy, userActionTypes.CURRENT_USER_INFO_RECEIVED,
+        expectedParams);
+    });
+  });
 });

--- a/static_src/test/unit/stores/app_store.spec.js
+++ b/static_src/test/unit/stores/app_store.spec.js
@@ -14,7 +14,7 @@ describe('AppStore', function() {
 
   beforeEach(() => {
     AppStore._data = Immutable.List();
-    AppStore.fetching = false;
+    AppStore._fetching = false;
     sandbox = sinon.sandbox.create();
   });
 

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -15,6 +15,7 @@ describe('UserStore', function() {
 
   beforeEach(() => {
     UserStore._data = Immutable.List();
+    UserStore._currentUserGuid = null;
     sandbox = sinon.sandbox.create();
   });
 
@@ -429,6 +430,36 @@ describe('UserStore', function() {
 
     it('should change currentlyViewedType to whatever is passed in', function() {
 
+    });
+  });
+
+  describe('on current user info received', function() {
+    it('should emit a change event if user found', function() {
+      const userGuid = 'zxsdkfjasdfladsf';
+      const user = { user_id: userGuid, user_name: 'mr' };
+      const existingUser = { guid: userGuid };
+      const spy = sandbox.spy(UserStore, 'emitChange');
+      userActions.receivedCurrentUserInfo(user);
+
+      expect(spy).not.toHaveBeenCalled();
+
+      UserStore._data = Immutable.fromJS([existingUser]);
+      userActions.receivedCurrentUserInfo(user);
+
+      expect(spy).toHaveBeenCalledOnce();
+    });
+
+    it('should set the currentUser to user object if exists', function() {
+      const userGuid = 'zxsdkfjasdfladsf';
+      const currentUserInfo = { user_id: userGuid, user_name: 'mr' };
+      const existingUser = { guid: userGuid };
+      UserStore._data = Immutable.fromJS([existingUser]);
+
+      userActions.receivedCurrentUserInfo(currentUserInfo);
+
+      const actual = UserStore.currentUser;
+
+      expect(actual).toEqual(existingUser);
     });
   });
 

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -477,11 +477,35 @@ describe('UserStore', function() {
     });
   });
 
+  describe('currentUserHasSpaceRole()', function() {
+    it('should call _hasRole() with role and userType of space', function() {
+      const spy = sandbox.spy(UserStore, '_hasRole');
+      const testRole = 'space';
+
+      UserStore.currentUserHasSpaceRole(testRole);
+
+      expect(spy).toHaveBeenCalledOnce();
+      expect(spy).toHaveBeenCalledWith(testRole, 'space_roles');
+    });
+  });
+
   describe('currentUserHasOrgRole()', function() {
+    it('should call _hasRole() with role and userType of org', function() {
+      const spy = sandbox.spy(UserStore, '_hasRole');
+      const testRole = 'person';
+
+      UserStore.currentUserHasOrgRole(testRole);
+
+      expect(spy).toHaveBeenCalledOnce();
+      expect(spy).toHaveBeenCalledWith(testRole, 'organization_roles');
+    });
+  });
+
+  describe('_hasRole()', function() {
     it('should return false if user not found', function() {
       const role = 'test';
       UserStore._currentUserGuid = 'alkdsjf';
-      const actual = UserStore.currentUserHasOrgRole(role);
+      const actual = UserStore._hasRole(role, 'organization_roles');
 
       expect(actual).toBeFalsy();
     });
@@ -495,7 +519,7 @@ describe('UserStore', function() {
       UserStore._currentUserGuid = userGuid;
       UserStore.push(user);
 
-      const actual = UserStore.currentUserHasOrgRole(role);
+      const actual = UserStore._hasRole(role, 'organization_roles');
 
       expect(actual).toBeFalsy();
     });
@@ -509,7 +533,7 @@ describe('UserStore', function() {
       UserStore._currentUserGuid = userGuid;
       UserStore.push(user);
 
-      const actual = UserStore.currentUserHasOrgRole(role);
+      const actual = UserStore._hasRole(role, 'organization_roles');
 
       expect(actual).toBeTruthy();
 

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -477,6 +477,45 @@ describe('UserStore', function() {
     });
   });
 
+  describe('currentUserHasOrgRole()', function() {
+    it('should return false if user not found', function() {
+      const role = 'test';
+      UserStore._currentUserGuid = 'alkdsjf';
+      const actual = UserStore.currentUserHasOrgRole(role);
+
+      expect(actual).toBeFalsy();
+    });
+
+    it('should return false if user doesn\'t have role', function() {
+      const userGuid = 'adfadsfa';
+      const user = { guid: userGuid, user_name: 'poop', organization_roles: [
+        'iron_throne_manager']};
+      const role = 'vale_manager';
+
+      UserStore._currentUserGuid = userGuid;
+      UserStore.push(user);
+
+      const actual = UserStore.currentUserHasOrgRole(role);
+
+      expect(actual).toBeFalsy();
+    });
+
+    it('should true if it finds the role on the user', function() {
+      const role = 'highgarden_manager';
+      const userGuid = 'adfadsfa';
+      const user = { guid: userGuid, user_name: 'poop', organization_roles: [
+        'iron_throne_manager', role]};
+
+      UserStore._currentUserGuid = userGuid;
+      UserStore.push(user);
+
+      const actual = UserStore.currentUserHasOrgRole(role);
+
+      expect(actual).toBeTruthy();
+
+    });
+  });
+
   describe('getAllInOrg()', function() {
     it('should find all users that have the org guid passed in', function() {
       var orgGuid = 'asdfa';

--- a/static_src/test/unit/util/uaa_api.spec.js
+++ b/static_src/test/unit/util/uaa_api.spec.js
@@ -1,0 +1,81 @@
+
+import '../../global_setup.js';
+
+import http from 'axios';
+
+import errorActions from '../../../actions/error_actions.js';
+import uaaApi from '../../../util/uaa_api.js';
+import userActions from '../../../actions/user_actions.js';
+import { wrapInRes, unwrapOfRes } from '../helpers.js';
+
+function createPromise(res, err) {
+  // TODO figure out how to do this with actual Promise object.
+  if (!err) {
+    return Promise.resolve(res);
+  } else {
+    return Promise.reject(err);
+  }
+};
+
+describe('uaaApi', function() {
+  let sandbox;
+  const errorFetchRes = { message: 'error' };
+
+  function fetchErrorSetup() {
+    var stub = sandbox.stub(http, 'get'),
+        spy = sandbox.spy(errorActions, 'errorFetch'),
+        expected = errorFetchRes;
+
+    let testPromise = createPromise(true, expected);
+    stub.returns(testPromise);
+
+    return spy;
+  };
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('fetchUserInfo()', function() {
+    it('should call an http get request for uaa user info', function(done) {
+      var spy = sandbox.spy(http, 'get');
+
+      uaaApi.fetchUserInfo().then(() => {
+        expect(spy).toHaveBeenCalledOnce();
+        let actual = spy.getCall(0).args[0];
+        expect(actual).toMatch('userinfo');
+        done();
+      });
+    });
+
+    it('should call a user action current user info received on success',
+        function(done) {
+      const expected = { user_id: 'zcxcvbxcvb', user_name: 'brain' };
+      let stub = sandbox.stub(http, 'get');
+      let spy = sandbox.spy(userActions, 'receivedCurrentUserInfo');
+
+      let testPromise = createPromise({data: expected});
+      stub.returns(testPromise);
+
+      uaaApi.fetchUserInfo().then(() => {
+        expect(spy).toHaveBeenCalledOnce();
+        expect(spy).toHaveBeenCalledWith(expected);
+        done();
+      });
+    });
+
+    it('should call a fetch error on failure', function() {
+      var spy = fetchErrorSetup();
+
+      uaaApi.fetchUserInfo().then(() => {
+        expect(spy).toHaveBeenCalledOnce();
+        expect(spy).toHaveBeenCalledWith(errorFetchRes);
+        done();
+      });
+    });
+  });
+});

--- a/static_src/util/uaa_api.js
+++ b/static_src/util/uaa_api.js
@@ -1,0 +1,16 @@
+
+import http from 'axios';
+import errorActions from '../actions/error_actions.js';
+import userActions from '../actions/user_actions.js';
+
+const URL = '/uaa';
+
+export default {
+  fetchUserInfo() {
+    return http.get(`${URL}/userinfo`).then((res) => {
+      userActions.receivedCurrentUserInfo(res.data);
+    }).catch((err) => {
+      errorActions.errorFetch(err);
+    });
+  }
+};


### PR DESCRIPTION
Added code that:
- Get's the current user with guid.
- Adds the current user to the UserStore.
- Allow to check if current user has a certain role
- Has the user UI check the current user for the "org_manager" role before showing the user delete button

This role checking functionality will only work on this users page, because otherwise, the role information for a user may have not been fetched yet and may not be there. I think this is fine for now, as its the only place we need it, and can come up with a more robust solution after.

I'm not 100% certain what user role allows you to delete a user, I'm pretty sure it's org_manager.

An additional thing to fix here would be to also check for this role for the role checkboxes, and allow for role checking in the space for those checkboxes.

Ref #396 