### PR TITLE
Remove on branches from travis deploy config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,15 +48,6 @@ deploy:
   skip_cleanup: true
   script: deploy/travis_deploy.sh
   on:
-    branch:
-    - master
-    - staging
-    - deprecated
-deploy:
-- provider: script
-  skip_cleanup: true
-  script: deploy/travis_deploy.sh
-  on:
     tags: true
 env:
   global:

--- a/deploy/travis_deploy.sh
+++ b/deploy/travis_deploy.sh
@@ -26,6 +26,9 @@ elif [ "$TRAVIS_BRANCH" == "deprecated" ]
 then
 	CF_MANIFEST="manifests/manifest-deprecated.yml"
 	CF_SPACE="deck-prod"
+else
+then
+  exit
 fi
 
 echo $CF_MANIFEST


### PR DESCRIPTION
In an attempt to get deploy working, remove on branches from travis
deploy config, and keep on tags. Hopefully this means travis will
deploy on tags and any branch, and then will not deploy on the branches
not listed in the travis deploy script.