### PR TITLE
Fix authorities and add autoapprove

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ git clone git@github.com:18F/cg-deck.git cg-deck-ws/src/github.com/18F/cg-deck
 - Create client account:
 ```
 uaac client add <your-client-id> \
- --authorities cloud_controller.admin,cloud_controller.read,cloud_controller.write,openid,scim.read \
+ --authorities uaa.none \
  --authorized_grant_types authorization_code,client_credentials,refresh_token \
  --scope cloud_controller.admin,cloud_controller.read,cloud_controller.write,openid,scim.read \
+ --autoapprove true \
 -s <your-client-secret>
 ```
 - Unable to create an account still? Troubleshoot [here](https://docs.cloudfoundry.org/adminguide/uaa-user-management.html#creating-admin-users)


### PR DESCRIPTION
Partly addresses https://github.com/18F/cg-deck/issues/340

Prior to this patch, an admin would setup the cg-deck client with authorities which means the deck would have it's own permissions. We don't want that. Instead, we want the client to only use the perms the user logged in has.

Additionally, the current set of scope is a subset of the scopes used for the cf CLI.

@afeld