### PR TITLE
Use description in service plan lists in the marketplace

### DIFF
--- a/static_src/components/service_plan_list.jsx
+++ b/static_src/components/service_plan_list.jsx
@@ -13,18 +13,10 @@ import ServicePlanStore from '../stores/service_plan_store.js';
 import createStyler from '../util/create_styler';
 import tableStyles from 'cloudgov-style/css/base.css';
 
-var Table = Reactable.Table,
-    Thead = Reactable.Thead,
-    Th = Reactable.Th,
-    Tr = Reactable.Tr,
-    Td = Reactable.Td;
-
 function stateSetter(serviceGuid) {
-  var s = {
+  return {
     servicePlans: ServicePlanStore.getAllFromService(serviceGuid)
   };
-
-  return s;
 }
 
 export default class ServicePlanList extends React.Component {
@@ -41,7 +33,7 @@ export default class ServicePlanList extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    this.setState({serviceGuid: nextProps.initialServiceGuid});
+    this.setState({ serviceGuid: nextProps.initialServiceGuid });
     this.setState(stateSetter(this.state.serviceGuid));
   }
 
@@ -67,49 +59,53 @@ export default class ServicePlanList extends React.Component {
   }
 
   get rows() {
-    var rows = this.state.servicePlans;
-    return rows;
+    return this.state.servicePlans;
   }
 
   render() {
     var content = <h4 className="test-none_message">No service plans</h4>;
-    if (this.state.servicePlans.length) {
+
+    if (this.rows.length) {
       content = (
-      <Table sortable={ true }>
-        <Thead>
+      <table>
+        <thead>
           { this.columns.map((column) => {
             return (
-              <Th column={ column.label } className={ column.key }
-                  key={ column.key }>
-                { column.label }</Th>
+              <th column={ column.label } className={ column.key }
+                key={ column.key }
+              >
+                { column.label }</th>
+            );
+          })}
+        </thead>
+        <tbody>
+          { this.rows.map((plan) => {
+            return (
+              <tr key={ plan.guid }>
+                <td label="Name">
+                  <span>{ plan.name }</span>
+                </td>
+                <td label="Free">{ (plan.free) ? 'Yes': 'No' }</td>
+                <td label="Description">{ plan.description }</td>
+                <td label="Cost">
+                  <span>
+                    ${ (plan.extra && plan.extra.costs &&
+                        plan.extra.costs[0].amount.usd || 0).toFixed(2) } monthly
+                  </span>
+                </td>
+                <td label="Actions">
+                  <Button
+                    classes={ ["test-create_service_instance"] }
+                    onClickHandler={ this._handleAdd.bind(this, plan.guid) }
+                    label="create">
+                      <span>Create service instance</span>
+                  </Button>
+                </td>
+              </tr>
             )
           })}
-        </Thead>
-        { this.state.servicePlans.map((plan) => {
-          return (
-            <Tr key={ plan.guid }>
-              <Td column={ this.columns[0].label }>
-                <span>{ plan.name }</span></Td>
-              <Td column={ this.columns[1].label }>{ plan.free }</Td>
-              <Td column={ this.columns[2].label }>{ plan.updated_at }</Td>
-              <Td column={ this.columns[3].label }>
-                <span>
-                  ${ (plan.extra && plan.extra.costs &&
-                      plan.extra.costs[0].amount.usd || 0).toFixed(2) } monthly
-                </span>
-              </Td>
-              <Td column={ this.columns[4].label }>
-                <Button
-                  classes={ ["test-create_service_instance"] }
-                  onClickHandler={ this._handleAdd.bind(this, plan.guid) }
-                  label="create">
-                    <span>Create service instance</span>
-                </Button>
-              </Td>
-            </Tr>
-          )
-        })}
-      </Table>
+        </tbody>
+      </table>
       );
     }
 


### PR DESCRIPTION
We want to show service plan descriptions in the marketplace listing. Previously, a datetime was in the "Description" column.

Removes Reactable and refactors table code

Before screenshot:
![screen shot 2016-07-12 at 3 57 50 pm](https://cloud.githubusercontent.com/assets/780941/16781462/71f7dde4-4849-11e6-9225-1c7b228386b3.png)

After screenshot:
![screen shot 2016-07-12 at 3 52 22 pm](https://cloud.githubusercontent.com/assets/780941/16781461/71f7a9dc-4849-11e6-87e3-31b08d753ffb.png)

Refs #456