### PR TITLE
Use single css file for all components

### DIFF
--- a/static_src/components/app_list.jsx
+++ b/static_src/components/app_list.jsx
@@ -1,4 +1,5 @@
 
+import style from 'cloudgov-style/css/cloudgov-style.css';
 import dedent from 'dedent';
 import React from 'react';
 import Reactable from 'reactable';
@@ -6,7 +7,6 @@ import Reactable from 'reactable';
 import createStyler from '../util/create_styler';
 import Loading from './loading.jsx';
 import SpaceStore from '../stores/space_store.js';
-import tableStyles from 'cloudgov-style/css/base.css';
 
 const unsafe = Reactable.unsafe;
 
@@ -27,7 +27,7 @@ export default class AppList extends React.Component {
     this.props = props;
     this.state = stateSetter(props);
     this._onChange = this._onChange.bind(this);
-    this.styler = createStyler(tableStyles);
+    this.styler = createStyler(style);
   }
 
   componentDidMount() {

--- a/static_src/components/app_page.jsx
+++ b/static_src/components/app_page.jsx
@@ -1,11 +1,11 @@
 
+import style from 'cloudgov-style/css/cloudgov-style.css';
 import React from 'react';
 
 import AppStore from '../stores/app_store.js';
 import Loading from './loading.jsx';
 import RouteList from './route_list.jsx';
 
-import sectionStyle from 'cloudgov-style/css/components/section.css';
 import createStyler from '../util/create_styler';
 
 export default class AppPage extends React.Component {
@@ -18,7 +18,7 @@ export default class AppPage extends React.Component {
       loading: AppStore.fetching
     };
     this._onChange = this._onChange.bind(this);
-    this.styler = createStyler(sectionStyle);
+    this.styler = createStyler(style);
   }
 
   componentDidMount() {

--- a/static_src/components/confirmation_box.jsx
+++ b/static_src/components/confirmation_box.jsx
@@ -3,11 +3,10 @@
  * A component that renders a box with a different style and background
  */
 
+import style from 'cloudgov-style/css/cloudgov-style.css';
 import React from 'react';
 
 import createStyler from '../util/create_styler';
-import actionStyles from 'cloudgov-style/css/components/actions.css';
-import baseStyles from 'cloudgov-style/css/base.css';
 
 import Button from './button.jsx';
 
@@ -16,7 +15,7 @@ export default class ConfirmationBox extends React.Component {
     super(props);
     this.props = props;
     this.state = {};
-    this.styler = createStyler(actionStyles, baseStyles);
+    this.styler = createStyler(style);
     this._confirmHandler = this._confirmHandler.bind(this);
     this._cancelHandler = this._cancelHandler.bind(this);
   }
@@ -54,4 +53,3 @@ ConfirmationBox.defaultProps = {
   confirmHandler: (ev) => { console.log('confirm ev', ev); },
   cancelHandler: (ev) => { console.log('cancel ev', ev); }
 };
-

--- a/static_src/components/create_service_instance.jsx
+++ b/static_src/components/create_service_instance.jsx
@@ -2,6 +2,7 @@
  * Renders the form to create a service instance
  */
 
+import style from 'cloudgov-style/css/cloudgov-style.css';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
@@ -12,8 +13,6 @@ import OrgStore from '../stores/org_store.js';
 import SpaceStore from '../stores/space_store.js';
 import ServiceInstanceStore from '../stores/service_instance_store.js';
 import serviceActions from '../actions/service_actions.js';
-import actionStyle from 'cloudgov-style/css/components/actions.css';
-import baseStyle from 'cloudgov-style/css/base.css';
 import createStyler from '../util/create_styler';
 
 function stateSetter() {
@@ -35,7 +34,7 @@ export default class CreateServiceInstance extends React.Component {
     this._onValidateForm = this._onValidateForm.bind(this);
     this._onValidForm = this._onValidForm.bind(this);
     this._onCancelForm = this._onCancelForm.bind(this);
-    this.styler = createStyler(actionStyle, baseStyle);
+    this.styler = createStyler(style);
   }
 
   componentDidMount() {

--- a/static_src/components/disclaimer.jsx
+++ b/static_src/components/disclaimer.jsx
@@ -1,15 +1,15 @@
 
 import classNames from 'classnames';
+import style from 'cloudgov-style/css/cloudgov-style.css';
 import React from 'react';
 
-import baseStyle from 'cloudgov-style/css/base.css';
 import createStyler from '../util/create_styler';
 
 export default class Disclaimer extends React.Component {
 
   constructor(props) {
     super(props);
-    this.styler = createStyler(baseStyle);
+    this.styler = createStyler(style);
   }
 
   render() {

--- a/static_src/components/dropdown.jsx
+++ b/static_src/components/dropdown.jsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 
-import styles from '../css/main.css';
+import style from 'cloudgov-style/css/cloudgov-style.css';
 
 import classNames from 'classnames';
 
@@ -19,7 +19,7 @@ export default class Dropdown extends React.Component {
 
   render() {
     var id = 'dropdown-' + this.props.title,
-        classes = classNames(styles.dropdown, this.props.classes, {
+        classes = classNames(style.dropdown, this.props.classes, {
           'open': !!this.state.open
         });
 

--- a/static_src/components/header.jsx
+++ b/static_src/components/header.jsx
@@ -1,19 +1,16 @@
 
+import style from 'cloudgov-style/css/cloudgov-style.css';
 import React from 'react';
 
 import LoginStore from '../stores/login_store.js';
 
 import createStyler from '../util/create_styler';
 
-import headerStyle from 'cloudgov-style/css/components/header.css';
-import navStyle from 'cloudgov-style/css/components/nav.css';
-import logoStyle from 'cloudgov-style/css/components/logo.css';
-
 export default class Header extends React.Component {
 
   constructor(props) {
     super(props);
-    this.styler = createStyler(headerStyle, navStyle, logoStyle);
+    this.styler = createStyler(style);
   }
 
   getImagePath(iconName) {

--- a/static_src/components/home.jsx
+++ b/static_src/components/home.jsx
@@ -1,13 +1,13 @@
 
+import style from 'cloudgov-style/css/cloudgov-style.css';
 import React from 'react';
 
-import baseStyle from 'cloudgov-style/css/base.css';
 import createStyler from '../util/create_styler';
 
 export default class Home extends React.Component {
   constructor(props) {
     super(props);
-    this.styler = createStyler(baseStyle);
+    this.styler = createStyler(style);
   }
 
   render() {

--- a/static_src/components/icon.jsx
+++ b/static_src/components/icon.jsx
@@ -1,8 +1,7 @@
 
 import classNames from 'classnames';
+import style from 'cloudgov-style/css/cloudgov-style.css';
 import React from 'react';
-
-import styles from 'cloudgov-style/css/components/icon.css';
 
 export default class Icon extends React.Component {
   constructor(props) {
@@ -16,11 +15,11 @@ export default class Icon extends React.Component {
   }
 
   render() {
-    var iconClasses = classNames(styles.icon,
-        styles[`icon-${ this.props.styleType }`]);
+    var iconClasses = classNames(style.icon,
+        style[`icon-${ this.props.styleType }`]);
 
     return (
-      <div className={ styles['icon-container'] }>
+      <div className={ style['icon-container'] }>
         <svg className={ iconClasses }>
           <use
             xlinkHref={ this.getImagePath(this.props.name) }>

--- a/static_src/components/navbar.jsx
+++ b/static_src/components/navbar.jsx
@@ -1,10 +1,8 @@
 
-import classNames from 'classnames';
+import style from 'cloudgov-style/css/cloudgov-style.css';
 import React from 'react';
 
-import cgBaseStyles from 'cloudgov-style/css/base.css';
-import cgSidenavStyles from 'cloudgov-style/css/components/sidenav.css';
-
+import createStyler from '../util/create_styler';
 import spaceActions from '../actions/space_actions.js';
 import orgActions from '../actions/org_actions.js';
 import OrgStore from '../stores/org_store.js';
@@ -30,6 +28,7 @@ export class Nav extends React.Component {
       currentSpace: SpaceStore.get(this.props.initialSpaceGuid),
       orgs: OrgStore.getAll() || []
     };
+    this.styler = createStyler(style);
     this._onChange = this._onChange.bind(this);
     this._handleOverviewClick = this._handleOverviewClick.bind(this);
   }
@@ -86,34 +85,12 @@ export class Nav extends React.Component {
   }
 
   render() {
-    const mainList = classNames(
-      cgBaseStyles['usa-sidenav-list'],
-      cgSidenavStyles['sidenav-list'], cgSidenavStyles['sidenav-level-one']
-    );
-    const secondList = classNames(
-      cgBaseStyles['usa-sidenav-list'],
-      cgSidenavStyles['sidenav-list'],
-      cgSidenavStyles['sidenav-level-two']
-    );
-    const thirdList = classNames(
-      cgSidenavStyles['sidenav-list'],
-      cgBaseStyles['usa-sidenav-sub_list'],
-      cgSidenavStyles['sidenav-level-three']
-    );
-    const downArrow = classNames(
-      cgSidenavStyles['menu-arrow'],
-      cgSidenavStyles['sidenav-arrow'],
-      cgSidenavStyles['sidenav-arrow-down']
-    );
-    const rightArrow = classNames(
-      cgSidenavStyles['menu-arrow'],
-      cgSidenavStyles['sidenav-arrow'],
-      cgSidenavStyles['sidenav-arrow-right']
-    );
-    const subMenu = classNames('sub-menu');
-    const header = classNames(
-      cgSidenavStyles['sidenav-header']
-    );
+    const mainList = this.styler('usa-sidenav-list', 'sidenav-list', 'sidenav-level-one');
+    const secondList = this.styler('usa-sidenav-list', 'sidenav-list', 'sidenav-level-two');
+    const thirdList = this.styler('sidenav-list', 'usa-sidenav-sub_list', 'sidenav-level-three');
+    const downArrow = this.styler('menu-arrow', 'sidenav-arrow', 'sidenav-arrow-down');
+    const rightArrow = this.styler('menu-arrow', 'sidenav-arrow', 'sidenav-arrow-right');
+    const header = this.styler('sidenav-header');
 
     if (this.state.orgs) {
       const openOrg = this.state.orgs.find((org) => {
@@ -126,21 +103,19 @@ export class Nav extends React.Component {
     }
 
     return (
-      <div className={ classNames('test-nav-primary') }>
+      <div className={ this.styler('test-nav-primary') }>
         <ul className={ mainList }>
-          <li key="overview" className={cgSidenavStyles['sidenav-entity']}>
+          <li key="overview" className={ this.styler('sidenav-entity') }>
             <a href="/#" onClick={this._handleOverviewClick}>Overview</a>
           </li>
-          <li key="organizations" className={classNames(
-              cgSidenavStyles['sidenav-header'])}>
-            <span className={cgSidenavStyles['sidenav-header-text']}>
+          <li key="organizations" className={ this.styler('sidenav-header') }>
+            <span className={ this.styler('sidenav-header-text') }>
               Organizations</span>
           </li>
         { this.state.orgs.map((org) => {
           let toggleSpaceHandler = this._toggleSpacesMenu.bind(this, org.guid);
           let arrowClasses = (org.space_menu_open) ? downArrow : rightArrow;
-          let activeOrgClasses = (org.space_menu_open) ?
-            cgSidenavStyles['sidenav-active'] : '';
+          let activeOrgClasses = (org.space_menu_open) ? this.styler('sidenav-active') : '';
           let subList = <div></div>;
 
           if (org.space_menu_open) {
@@ -148,13 +123,13 @@ export class Nav extends React.Component {
               <ul className={ secondList }>
                 <li className={ header }>
                   <a href={ this.orgHref(org) }>
-                    <span className={cgSidenavStyles['sidenav-header-text']}>
+                    <span className={ this.styler('sidenav-header-text') }>
                       Spaces</span>
                   </a>
                   <ul className={ thirdList }>
                     { org.spaces.map((space) => {
                       let activeSpaceClasses = (this.isCurrentSpace(space.guid)) ?
-                          cgSidenavStyles['sidenav-active'] : '';
+                          this.styler('sidenav-active') : '';
                       return (
                         <li key={ space.guid } className={activeSpaceClasses}>
                           <a href={ this.spaceHref(org, space.guid) }>
@@ -165,7 +140,7 @@ export class Nav extends React.Component {
                     })}
                   </ul>
                 </li>
-                <li className={cgSidenavStyles.marketplace}>
+                <li className={ this.styler('marketplace') }>
                   <a href={ this.marketplaceHref(org) }>Marketplace</a>
                 </li>
               </ul>

--- a/static_src/components/route_list.jsx
+++ b/static_src/components/route_list.jsx
@@ -1,10 +1,10 @@
 
+import style from 'cloudgov-style/css/cloudgov-style.css';
 import React from 'react';
 
 import RouteStore from '../stores/route_store.js';
 
 import createStyler from '../util/create_styler';
-import tableStyles from 'cloudgov-style/css/base.css';
 
 function stateSetter(appGuid) {
   const routes = RouteStore.getAll();
@@ -21,7 +21,7 @@ export default class RouteList extends React.Component {
     this.props = props;
     this.state = stateSetter(props.initialAppGuid);
     this._onChange = this._onChange.bind(this);
-    this.styler = createStyler(tableStyles);
+    this.styler = createStyler(style);
   }
 
   componentDidMount() {

--- a/static_src/components/service_instance_list.jsx
+++ b/static_src/components/service_instance_list.jsx
@@ -1,10 +1,10 @@
 
+import style from 'cloudgov-style/css/cloudgov-style.css';
 import React from 'react';
 
 import formatDateTime from '../util/format_date';
 
 import createStyler from '../util/create_styler';
-import baseStyle from 'cloudgov-style/css/base.css';
 
 import Button from './button.jsx';
 import ConfirmationBox from './confirmation_box.jsx';
@@ -30,7 +30,7 @@ export default class ServiceInstanceList extends React.Component {
     this._handleDeleteConfirmation = this._handleDeleteConfirmation.bind(this);
     this._handleDeleteCancel = this._handleDeleteCancel.bind(this);
     this.renderConfirmationBox = this.renderConfirmationBox.bind(this);
-    this.styler = createStyler(baseStyle);
+    this.styler = createStyler(style);
   }
 
   componentDidMount() {

--- a/static_src/components/service_list.jsx
+++ b/static_src/components/service_list.jsx
@@ -3,12 +3,11 @@
  * Renders a list of services
  */
 
+import style from 'cloudgov-style/css/cloudgov-style.css';
 import React from 'react';
 
 import ServicePlanList from './service_plan_list.jsx';
-
 import createStyler from '../util/create_styler';
-import tableStyles from 'cloudgov-style/css/base.css';
 
 
 export default class ServiceList extends React.Component {
@@ -18,7 +17,7 @@ export default class ServiceList extends React.Component {
     this.state = {
       services: props.initialServices
     };
-    this.styler = createStyler(tableStyles);
+    this.styler = createStyler(style);
   }
 
   componentWillReceiveProps(nextProps) {

--- a/static_src/components/service_plan_list.jsx
+++ b/static_src/components/service_plan_list.jsx
@@ -3,15 +3,14 @@
  * Renders a list of service plans
  */
 
+import style from 'cloudgov-style/css/cloudgov-style.css';
 import React from 'react';
 import Reactable from 'reactable';
 
 import Button from './button.jsx';
 import serviceActions from '../actions/service_actions.js';
 import ServicePlanStore from '../stores/service_plan_store.js';
-
 import createStyler from '../util/create_styler';
-import tableStyles from 'cloudgov-style/css/base.css';
 
 function stateSetter(serviceGuid) {
   return {
@@ -29,7 +28,7 @@ export default class ServicePlanList extends React.Component {
     };
     this._onChange = this._onChange.bind(this);
     this._handleAdd = this._handleAdd.bind(this);
-    this.styler = createStyler(tableStyles);
+    this.styler = createStyler(style);
   }
 
   componentWillReceiveProps(nextProps) {

--- a/static_src/components/space_list.jsx
+++ b/static_src/components/space_list.jsx
@@ -1,10 +1,10 @@
 
+import style from 'cloudgov-style/css/cloudgov-style.css';
 import React from 'react';
 
 import OrgStore from '../stores/org_store';
 
 import createStyler from '../util/create_styler';
-import tableStyles from 'cloudgov-style/css/base.css';
 
 function stateSetter() {
   const currentOrgGuid = OrgStore.currentOrgGuid;
@@ -24,7 +24,7 @@ export default class SpaceList extends React.Component {
     this.state = { rows: [], currentOrgGuid: this.props.initialOrgGuid };
     this._onChange = this._onChange.bind(this);
     this.spaceLink = this.spaceLink.bind(this);
-    this.styler = createStyler(tableStyles);
+    this.styler = createStyler(style);
   }
 
   componentDidMount() {

--- a/static_src/components/tabnav.jsx
+++ b/static_src/components/tabnav.jsx
@@ -1,8 +1,8 @@
 
+import classNames from 'classnames';
+import style from 'cloudgov-style/css/cloudgov-style.css';
 import React from 'react';
 
-import classNames from 'classnames';
-import navStyles from 'cloudgov-style/css/components/nav.css';
 import createStyler from '../util/create_styler';
 
 
@@ -11,23 +11,30 @@ export default class Tabnav extends React.Component {
     super(props);
     this.props = props;
     this.state = { current: this.props.initialItem };
-    this.styler = createStyler(navStyles);
+    this.styler = createStyler(style);
   }
 
   componentWillReceiveProps(nextProps) {
     this.setState({current: nextProps.initialItem});
   }
 
+  get defaultClasses() {
+    return [
+      this.styler('nav'),
+      this.styler('nav-tabs'),
+      this.styler('nav-justified')
+    ];
+  }
+
   render() {
-    var defaultClasses = [this.styler('nav'), this.styler('nav-tabs'), this.styler('nav-justified')];
-    var classes = classNames(defaultClasses, this.props.classes);
+    let classes = classNames(this.defaultClasses, this.props.classes);
 
     return (
     <ul className={ classes } role="tablist">
       { this.props.items.map((item, i) => {
         if (item.name === this.state.current) {
           let newProps = Object.assign({}, item.element.props, {
-            selected: true});
+            selected: true });
           const nav = React.cloneElement(item.element, newProps);
           return <li role="presentation"
               className={ this.styler('active') } key={ i }>{ nav }</li>;
@@ -38,7 +45,7 @@ export default class Tabnav extends React.Component {
     </ul>
     );
   }
-};
+}
 
 Tabnav.propTypes = {
   initialItem: React.PropTypes.string.isRequired,

--- a/static_src/components/user_list.jsx
+++ b/static_src/components/user_list.jsx
@@ -3,16 +3,14 @@
  * Renders a list of users.
  */
 
+import style from 'cloudgov-style/css/cloudgov-style.css';
 import React from 'react';
 
 import formatDateTime from '../util/format_date';
 
 import Button from './button.jsx';
 import UserRoleListControl from './user_role_list_control.jsx';
-
 import createStyler from '../util/create_styler';
-import baseStyles from 'cloudgov-style/css/base.css';
-import navStyles from 'cloudgov-style/css/components/nav.css';
 
 
 export default class UserList extends React.Component {
@@ -24,7 +22,7 @@ export default class UserList extends React.Component {
       userType: props.initialUserType,
       currentUserAccess: props.initialCurrentUserAccess
     };
-    this.styler = createStyler(baseStyles, navStyles);
+    this.styler = createStyler(style);
     this._handleDelete = this._handleDelete.bind(this);
   }
 


### PR DESCRIPTION
CSS modules is a cool idea, but our implementation got a bit complex. We were importing the individual component files from the style library, meaning that anybody working on a component had to know not only that a class was in `cloudgov-style` but also which file it was in. This was a lot of work for something as simple as adding a class.

Now, all components just use the final, generated output css from `cloudgov-style` so that any class in the library should work pretty well in any component. I kept the `.styler()` convention mostly in place to minimize changes.

The best illustration of how this changes improves code legibility is in `navbar.jsx` right after `render()` begins. Where we used to have to know which component file a class was in, now we can simply use any class from the style library.

Refs #350