### PR TITLE
Track Google Analytics only on production

### DIFF
--- a/manifests/eastwest/manifest-prod.yml
+++ b/manifests/eastwest/manifest-prod.yml
@@ -5,3 +5,4 @@ applications:
   host: dashboard
   env:
     CONSOLE_HOSTNAME: https://dashboard.cloud.gov
+    NODE_ENV: production

--- a/static_src/dispatcher.js
+++ b/static_src/dispatcher.js
@@ -3,6 +3,8 @@ import { Dispatcher } from 'flux';
 
 import { trackAction } from './util/analytics';
 
+const PRODUCTION = ('production' === process.env.NODE_ENV);
+
 function logAction(action) {
   console.log('::action::', action);
 }
@@ -20,7 +22,7 @@ class AppDispatcher extends Dispatcher {
     const action = addSourceType(srcAction, 'VIEW_ACTION');
     this.dispatch(action);
     logAction(action);
-    trackAction(action);
+    if (PRODUCTION) trackAction(action);
   }
 
   // UI actions are things like clicking to expand a menu
@@ -29,7 +31,7 @@ class AppDispatcher extends Dispatcher {
     const action = addSourceType(srcAction, 'UI_ACTION');
     this.dispatch(action);
     logAction(action);
-    trackAction(action);
+    if (PRODUCTION) trackAction(action);
   }
 
   // Server actions come from the network/API
@@ -37,7 +39,7 @@ class AppDispatcher extends Dispatcher {
     const action = addSourceType(srcAction, 'SERVER_ACTION');
     this.dispatch(action);
     logAction(action);
-    trackAction(action);
+    if (PRODUCTION) trackAction(action);
   }
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 
 const path = require('path');
+const webpack = require('webpack');
 
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
@@ -69,7 +70,12 @@ module.exports = {
   },
 
   plugins: [
-    new ExtractTextPlugin('style.css', { allChunks: true })
+    new ExtractTextPlugin('style.css', { allChunks: true }),
+    new webpack.DefinePlugin({
+      'process.env': {
+        'NODE_ENV': JSON.stringify(process.env.NODE_ENV)
+      }
+    })
   ],
 
   publicPath: './static'


### PR DESCRIPTION
We don't want to pollute our user data with development data, so Google Analytics should only be used in production.

Check for the environment variable `NODE_ENV`, and if it is present, then track events in Google Analytics. Otherwise, we do not.

Idea from a [Dan Abramov tweet](https://twitter.com/dan_abramov/status/592692202335301636)