### PR TITLE
Updated info about closing old Deck

### DIFF
--- a/static_src/components/home.jsx
+++ b/static_src/components/home.jsx
@@ -17,8 +17,7 @@ export default class Home extends React.Component {
           <p className={ this.styler('usa-alert-body') }><em>
             We updated the Deck and renamed it the Dashboard!
             <a href="https://cloud.gov/2016/07/07/deck-update.html"> Here’s what
-            changed and how to give feedback</a> on this alpha version. The <a href="https://console.cloud.gov/">old Deck</a> will
-            be available until July 11.
+            changed and how to give feedback</a> on this alpha version. We’ll close the <a href="https://console.cloud.gov/">old Deck</a> soon.
           </em></p>
         </aside>
         <div className={ this.styler('usa-grid') }>


### PR DESCRIPTION
We didn't close it on July 11, so let's just make this more accurate.