### PR TITLE
Loading bug fixes for flash of "No apps", etc content

### DIFF
--- a/static_src/main.js
+++ b/static_src/main.js
@@ -39,7 +39,7 @@ function dashboard() {
 function org(orgGuid) {
   orgActions.changeCurrentOrg(orgGuid);
   orgActions.toggleSpaceMenu(orgGuid);
-  cfApi.fetchOrg(orgGuid);
+  orgActions.fetch(orgGuid);
   ReactDOM.render(
     <App>
       <SpaceList initialOrgGuid={ orgGuid } />

--- a/static_src/stores/app_store.js
+++ b/static_src/stores/app_store.js
@@ -29,8 +29,9 @@ class AppStore extends BaseStore {
         break;
 
       case appActionTypes.APP_RECEIVED:
-        this.merge('guid', action.app, () => {});
-        this.fetching = false;
+        this.merge('guid', action.app, () => {
+          this.fetching = false;
+        });
         break;
 
       case appActionTypes.APP_STATS_RECEIVED: {

--- a/static_src/stores/org_store.js
+++ b/static_src/stores/org_store.js
@@ -36,15 +36,15 @@ class OrgStore extends BaseStore {
       }
 
       case orgActionTypes.ORG_RECEIVED: {
-        this.fetching = false;
         if (action.org) {
-          this.merge('guid', action.org, () => {});
+          this.merge('guid', action.org, () => {
+            this.fetching = false;
+          });
         }
         break;
       }
 
       case orgActionTypes.ORGS_RECEIVED: {
-        this.fetching = false;
         const updates = this.formatSplitResponse(action.orgs).map((d) => {
           if (d.spaces) {
             return d;
@@ -56,14 +56,15 @@ class OrgStore extends BaseStore {
           return Object.assign(d, { spaces: [] });
         });
         cfApi.fetchOrgsSummaries(updates.map((u) => u.guid));
-
+        // we don't set .fetching here because we triggered subsequent requests
+        // and will just set .fetching to false when they come back
         this.mergeMany('guid', updates, () => {});
         break;
       }
 
       case orgActionTypes.ORGS_SUMMARIES_RECEIVED: {
-        this.fetching = false;
         this.mergeMany('guid', action.orgs, (changed) => {
+          this.fetching = false;
           if (changed) {
             const orgUpdates = this.updateOpenOrgs(this._currentOrgGuid);
             this.mergeMany('guid', orgUpdates, () => {});

--- a/static_src/stores/space_store.js
+++ b/static_src/stores/space_store.js
@@ -39,8 +39,9 @@ class SpaceStore extends BaseStore {
       }
 
       case spaceActionTypes.SPACE_RECEIVED: {
-        this.fetching = false;
-        this.merge('guid', action.space, () => {});
+        this.merge('guid', action.space, () => {
+          this.fetching = false;
+        });
         break;
       }
 

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -165,6 +165,8 @@ class UserStore extends BaseStore {
               this.emitChange();
             }
           });
+        } else {
+          this.fetching = false;
         }
         break;
       }

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -157,9 +157,9 @@ class UserStore extends BaseStore {
           }
           return updateCopy;
         });
-        this.fetching = false;
         if (updates.length) {
           this.mergeMany('guid', updates, (changed) => {
+            this.fetching = false;
             if (changed) {
               this._error = null;
               this.emitChange();


### PR DESCRIPTION
I think the real bug is fixed with 9fdfa1a94b0689fcb976d938b9fa8d51cda6f034. There was a weird space between the time when fetching would be set to false and when all of the data had been merged in. Since both emit a change event, the components would re-render and could result in flashes of the null state (no apps, no services, etc).

By setting false after the data update is complete within the stores, and only emitting one change event (which is triggered by the change in the value of .fetching), we eliminate a potential reason for flash of content bugs.

Refs #448 